### PR TITLE
Fix/tag description dependency

### DIFF
--- a/tests/unit/models/test_table_metadata.py
+++ b/tests/unit/models/test_table_metadata.py
@@ -134,6 +134,7 @@ class TestTableMetadata(unittest.TestCase):
 
         self.assertEqual(self.expected_rels_deduped, actual)
 
+    
     def test_table_attributes(self):
         # type: () -> None
         self.table_metadata3 = TableMetadata('hive', 'gold', 'test_schema3', 'test_table3', 'test_table3', [
@@ -252,6 +253,25 @@ class TestTableMetadata(unittest.TestCase):
             self.assertNotEqual(node_row.get('LABEL'), 'Tag')
             node_row = self.table_metadata7.next_node()
 
+
+    def test_column_tags_arent_dependant_on_column_description(self):
+        # type: () -> None
+        self.table_metadata8 = TableMetadata('hive', 'gold', 'test_schema8', 'test_table8', 'test_table8', [
+            ColumnMetadata('test_id1', None, 'bigint', 0, ['column_tag1', 'column_tag2'])], tags=[])
+
+        tag_nodes = []
+        expected_tag_nodes = [{'LABEL': 'Tag', 'KEY': 'column_tag1', 'tag_type': 
+                               'default'},
+                              {'LABEL': 'Tag', 'KEY': 'column_tag2', 'tag_type':
+                               'default'}]
+
+        node_row = self.table_metadata8.next_node()
+        while node_row:
+            if node_row['LABEL'] == 'Tag':
+                tag_nodes.append(node_row)
+            node_row = self.table_metadata8.next_node()
+            
+        self.assertEqual(tag_nodes, expected_tag_nodes)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
### Summary of Changes

Fixed a dependency between the column description and the column tags. The only changes were made on the `table_metadata.py` module on the `models` folder. Instead of breaking the whole method if description is not present, the code would proceed to check if the columns are present.

### Tests

Only added a single test on the `test_table_metadata.py` file. It tests if a table metadata object generates tags if it is initialized without description. The test is double checked to work on the modified code and to not work on the non-modified. 

However, the presence of this test breaks the `test_serialize` test. **Not the feature, only the test**. And it seems not to be specific to the test. I checked with any tests that iterates over the `node_rows`, the test breaks. If anyone can explain to me why is this happening, I'll be happy to change the code properly.

