### PR TITLE
fix: Send actual dashboard product (rather than hardcoded mode) to ES

### DIFF
--- a/databuilder/extractor/neo4j_search_data_extractor.py
+++ b/databuilder/extractor/neo4j_search_data_extractor.py
@@ -79,7 +79,6 @@ class Neo4jSearchDataExtractor(Extractor):
         """
     )
 
-    # todo: 1. change mode to generic once add more support for dashboard
     DEFAULT_NEO4J_DASHBOARD_CYPHER_QUERY = textwrap.dedent(
         """
         MATCH (db:Dashboard)
@@ -96,7 +95,7 @@ class Neo4jSearchDataExtractor(Extractor):
         coalesce(db_descr.description, '') as description,
         coalesce(dbg.description, '') as group_description, dbg.dashboard_group_url as group_url,
         db.dashboard_url as url, db.key as uri,
-        'mode' as product, toInt(last_exec.timestamp) as last_successful_run_timestamp,
+        split(db.key, '_')[0] as product, toInt(last_exec.timestamp) as last_successful_run_timestamp,
         COLLECT(DISTINCT query.name) as query_names,
         total_usage
         order by dbg.name


### PR DESCRIPTION
### Summary of Changes

`Neo4jSearchDataExtractor` currently hardcodes the `product` field for dashboards to `mode`. As a result, all dashboards show up as Mode dashboards in search results. This change un-hardcodes that and parses out the correct product instead.

### Tests

Simple query change, no relevant unit tests. Manual loading of non-Mode dashboards works as expected after this change.

### Documentation

_What documentation did you add or modify and why? Add any relevant links then remove this line_

### CheckList
Make sure you have checked **all** steps below to ensure a timely review.
- [X] PR title addresses the issue accurately and concisely. Example: "Updates the version of Flask to v1.0.2"
    - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
- [X] PR includes a summary of changes. 
- [X] PR adds unit tests, updates existing unit tests, __OR__ documents why no test additions or modifications are needed.
- [X] In case of new functionality, my PR adds documentation that describes how to use it.
    - All the public functions and the classes in the PR contain docstrings that explain what it does
- [X] PR passes `make test`
