### PR TITLE
chore: Convert typings to mypy

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,10 @@ test_unit:
 lint:
 	flake8 .
 
+.PHONY: mypy
+mypy:
+	mypy .
+
 .PHONY: test
-test: test_unit lint
+test: test_unit lint mypy
 

--- a/README.md
+++ b/README.md
@@ -646,8 +646,7 @@ job.launch()
 The `RedashDashboardExtractor` extracts raw queries from each dashboard. You may optionally use these queries to parse out relations to tables in Amundsen. A table parser can be provided in the configuration for the `RedashDashboardExtractor`, as seen above. This function should have type signature `(RedashVisualizationWidget) -> Iterator[TableRelationData]`. For example:
 
 ```python
-def parse_tables(viz_widget):
-	# type: (RedashVisualiationWidget) -> Iterator[TableRelationData]
+def parse_tables(viz_widget: RedashVisualiationWidget) -> Iterator[TableRelationData]:
 	# Each viz_widget corresponds to one query.
 	# viz_widget.data_source_id is the ID of the target DB in Redash.
 	# viz_widget.raw_query is the raw query (e.g., SQL).

--- a/databuilder/__init__.py
+++ b/databuilder/__init__.py
@@ -29,8 +29,7 @@ class Scoped(object, metaclass=abc.ABCMeta):
     """
 
     @abc.abstractmethod
-    def init(self, conf):
-        # type: (ConfigTree) -> None
+    def init(self, conf: ConfigTree) -> None:
         """
         All scoped instance is expected to be lazily initialized. Means that
         __init__ should not have any heavy operation such as service call.
@@ -46,8 +45,7 @@ class Scoped(object, metaclass=abc.ABCMeta):
         pass
 
     @abc.abstractmethod
-    def get_scope(self):
-        # type: () -> str
+    def get_scope(self) -> str:
         """
         A scope for the config. Typesafe config supports nested config.
         Scope, string, is used to basically peel off nested config
@@ -55,8 +53,7 @@ class Scoped(object, metaclass=abc.ABCMeta):
         """
         return ''
 
-    def close(self):
-        # type: () -> None
+    def close(self) -> None:
         """
         Anything that needs to be cleaned up after the use of the instance.
         :return: None
@@ -64,8 +61,7 @@ class Scoped(object, metaclass=abc.ABCMeta):
         pass
 
     @classmethod
-    def get_scoped_conf(cls, conf, scope):
-        # type: (ConfigTree, str) -> ConfigTree
+    def get_scoped_conf(cls, conf: ConfigTree, scope: str) -> ConfigTree:
         """
         Convenient method to provide scoped method.
 

--- a/databuilder/callback/call_back.py
+++ b/databuilder/callback/call_back.py
@@ -16,8 +16,7 @@ class Callback(object, metaclass=abc.ABCMeta):
     """
 
     @abc.abstractmethod
-    def on_success(self):
-        # type: () -> None
+    def on_success(self) -> None:
         """
         A call back method that will be called when operation is successful
         :return: None
@@ -25,8 +24,7 @@ class Callback(object, metaclass=abc.ABCMeta):
         pass
 
     @abc.abstractmethod
-    def on_failure(self):
-        # type: () -> None
+    def on_failure(self) -> None:
         """
         A call back method that will be called when operation failed
         :return: None
@@ -34,7 +32,7 @@ class Callback(object, metaclass=abc.ABCMeta):
         pass
 
 
-def notify_callbacks(callbacks, is_success):
+def notify_callbacks(callbacks: List[Callback], is_success: bool) -> None:
     """
     A Utility method that notifies callback. If any callback fails it will still go through all the callbacks,
     and raise the last exception it experienced.
@@ -43,7 +41,6 @@ def notify_callbacks(callbacks, is_success):
     :param is_success:
     :return:
     """
-    # type: (List[Callback], bool) -> None
 
     if not callbacks:
         LOGGER.info('No callbacks to notify')

--- a/databuilder/extractor/athena_metadata_extractor.py
+++ b/databuilder/extractor/athena_metadata_extractor.py
@@ -43,8 +43,7 @@ class AthenaMetadataExtractor(Extractor):
         {WHERE_CLAUSE_SUFFIX_KEY: ' ', CATALOG_KEY: DEFAULT_CLUSTER_NAME}
     )
 
-    def init(self, conf):
-        # type: (ConfigTree) -> None
+    def init(self, conf: ConfigTree) -> None:
         conf = conf.with_fallback(AthenaMetadataExtractor.DEFAULT_CONFIG)
         self._cluster = '{}'.format(conf.get_string(AthenaMetadataExtractor.CATALOG_KEY))
 
@@ -60,10 +59,9 @@ class AthenaMetadataExtractor(Extractor):
             .with_fallback(ConfigFactory.from_dict({SQLAlchemyExtractor.EXTRACT_SQL: self.sql_stmt}))
 
         self._alchemy_extractor.init(sql_alch_conf)
-        self._extract_iter = None  # type: Union[None, Iterator]
+        self._extract_iter: Union[None, Iterator] = None
 
-    def extract(self):
-        # type: () -> Union[TableMetadata, None]
+    def extract(self) -> Union[TableMetadata, None]:
         if not self._extract_iter:
             self._extract_iter = self._get_extract_iter()
         try:
@@ -71,12 +69,10 @@ class AthenaMetadataExtractor(Extractor):
         except StopIteration:
             return None
 
-    def get_scope(self):
-        # type: () -> str
+    def get_scope(self) -> str:
         return 'extractor.athena_metadata'
 
-    def _get_extract_iter(self):
-        # type: () -> Iterator[TableMetadata]
+    def _get_extract_iter(self) -> Iterator[TableMetadata]:
         """
         Using itertools.groupby and raw level iterator, it groups to table and yields TableMetadata
         :return:
@@ -97,8 +93,7 @@ class AthenaMetadataExtractor(Extractor):
                                 '',
                                 columns)
 
-    def _get_raw_extract_iter(self):
-        # type: () -> Iterator[Dict[str, Any]]
+    def _get_raw_extract_iter(self) -> Iterator[Dict[str, Any]]:
         """
         Provides iterator of result row from SQLAlchemy extractor
         :return:
@@ -108,8 +103,7 @@ class AthenaMetadataExtractor(Extractor):
             yield row
             row = self._alchemy_extractor.extract()
 
-    def _get_table_key(self, row):
-        # type: (Dict[str, Any]) -> Union[TableKey, None]
+    def _get_table_key(self, row: Dict[str, Any]) -> Union[TableKey, None]:
         """
         Table key consists of schema and table name
         :param row:

--- a/databuilder/extractor/base_bigquery_extractor.py
+++ b/databuilder/extractor/base_bigquery_extractor.py
@@ -33,8 +33,7 @@ class BaseBigQueryExtractor(Extractor):
     NUM_RETRIES = 3
     DATE_LENGTH = 8
 
-    def init(self, conf):
-        # type: (ConfigTree) -> None
+    def init(self, conf: ConfigTree) -> None:
         # should use key_path, or cred_key if the former doesn't exist
         self.key_path = conf.get_string(BaseBigQueryExtractor.KEY_PATH_KEY, None)
         self.cred_key = conf.get_string(BaseBigQueryExtractor.CRED_KEY, None)
@@ -63,8 +62,7 @@ class BaseBigQueryExtractor(Extractor):
         self.logging_service = build('logging', 'v2', http=authed_http, cache_discovery=False)
         self.iter = iter(self._iterate_over_tables())
 
-    def extract(self):
-        # type: () -> Any
+    def extract(self) -> Any:
         try:
             return next(self.iter)
         except StopIteration:
@@ -74,14 +72,12 @@ class BaseBigQueryExtractor(Extractor):
         suffix = table_id[-BaseBigQueryExtractor.DATE_LENGTH:]
         return suffix.isdigit()
 
-    def _iterate_over_tables(self):
-        # type: () -> Any
+    def _iterate_over_tables(self) -> Any:
         for dataset in self._retrieve_datasets():
             for entry in self._retrieve_tables(dataset):
                 yield(entry)
 
-    def _retrieve_datasets(self):
-        # type: () -> List[DatasetRef]
+    def _retrieve_datasets(self) -> List[DatasetRef]:
         datasets = []
         for page in self._page_dataset_list_results():
             if 'datasets' not in page:
@@ -94,8 +90,7 @@ class BaseBigQueryExtractor(Extractor):
 
         return datasets
 
-    def _page_dataset_list_results(self):
-        # type: () -> Any
+    def _page_dataset_list_results(self) -> Any:
         response = self.bigquery_service.datasets().list(
             projectId=self.project_id,
             all=False,  # Do not return hidden datasets
@@ -116,8 +111,7 @@ class BaseBigQueryExtractor(Extractor):
             else:
                 response = None
 
-    def _page_table_list_results(self, dataset):
-        # type: (DatasetRef) -> Any
+    def _page_table_list_results(self, dataset: DatasetRef) -> Any:
         response = self.bigquery_service.tables().list(
             projectId=dataset.projectId,
             datasetId=dataset.datasetId,
@@ -137,6 +131,5 @@ class BaseBigQueryExtractor(Extractor):
             else:
                 response = None
 
-    def get_scope(self):
-        # type: () -> str
+    def get_scope(self) -> str:
         return 'extractor.bigquery_table_metadata'

--- a/databuilder/extractor/base_bigquery_extractor.py
+++ b/databuilder/extractor/base_bigquery_extractor.py
@@ -28,7 +28,7 @@ class BaseBigQueryExtractor(Extractor):
     CRED_KEY = 'project_cred'
     PAGE_SIZE_KEY = 'page_size'
     FILTER_KEY = 'filter'
-    _DEFAULT_SCOPES = ['https://www.googleapis.com/auth/bigquery.readonly', ]
+    _DEFAULT_SCOPES = ['https://www.googleapis.com/auth/bigquery.readonly']
     DEFAULT_PAGE_SIZE = 300
     NUM_RETRIES = 3
     DATE_LENGTH = 8

--- a/databuilder/extractor/base_bigquery_extractor.py
+++ b/databuilder/extractor/base_bigquery_extractor.py
@@ -68,7 +68,7 @@ class BaseBigQueryExtractor(Extractor):
         except StopIteration:
             return None
 
-    def _is_sharded_table(self, table_id):
+    def _is_sharded_table(self, table_id: str) -> bool:
         suffix = table_id[-BaseBigQueryExtractor.DATE_LENGTH:]
         return suffix.isdigit()
 

--- a/databuilder/extractor/base_bigquery_extractor.py
+++ b/databuilder/extractor/base_bigquery_extractor.py
@@ -74,6 +74,16 @@ class BaseBigQueryExtractor(Extractor):
         suffix = table_id[-BaseBigQueryExtractor.DATE_LENGTH:]
         return suffix.isdigit()
 
+    def _iterate_over_tables(self) -> Any:
+        for dataset in self._retrieve_datasets():
+            for entry in self._retrieve_tables(dataset):
+                yield entry
+
+    # TRICKY: this function has different return types between different subclasses,
+    # so type as Any. Should probably refactor to remove this unclear sharing.
+    def _retrieve_tables(self, dataset: DatasetRef) -> Any:
+        pass
+
     def _retrieve_datasets(self) -> List[DatasetRef]:
         datasets = []
         for page in self._page_dataset_list_results():

--- a/databuilder/extractor/base_extractor.py
+++ b/databuilder/extractor/base_extractor.py
@@ -15,18 +15,15 @@ class Extractor(Scoped):
     """
 
     @abc.abstractmethod
-    def init(self, conf):
-        # type: (ConfigTree) -> None
+    def init(self, conf: ConfigTree) -> None:
         pass
 
     @abc.abstractmethod
-    def extract(self):
-        # type: () -> Any
+    def extract(self) -> Any:
         """
         :return: Provides a record or None if no more to extract
         """
         return None
 
-    def get_scope(self):
-        # type: () -> str
+    def get_scope(self) -> str:
         return 'extractor'

--- a/databuilder/extractor/bigquery_metadata_extractor.py
+++ b/databuilder/extractor/bigquery_metadata_extractor.py
@@ -5,14 +5,12 @@ import logging
 from collections import namedtuple
 
 from pyhocon import ConfigTree  # noqa: F401
-from typing import List, Any  # noqa: F401
+from typing import cast, Any, Dict, List, Set  # noqa: F401
 
-from databuilder.extractor.base_bigquery_extractor import BaseBigQueryExtractor
+from databuilder.extractor.base_bigquery_extractor import BaseBigQueryExtractor, \
+    DatasetRef, TableKey
 from databuilder.models.table_metadata import TableMetadata, ColumnMetadata
 
-
-DatasetRef = namedtuple('DatasetRef', ['datasetId', 'projectId'])
-TableKey = namedtuple('TableKey', ['schema', 'table_name'])
 
 LOGGER = logging.getLogger(__name__)
 
@@ -31,9 +29,9 @@ class BigQueryMetadataExtractor(BaseBigQueryExtractor):
 
     def init(self, conf: ConfigTree) -> None:
         BaseBigQueryExtractor.init(self, conf)
-        self.grouped_tables = set([])
+        self.grouped_tables: Set[str] = set([])
 
-    def _retrieve_tables(self, dataset) -> Any:
+    def _retrieve_tables(self, dataset: DatasetRef) -> Any:
         for page in self._page_table_list_results(dataset):
             if 'tables' not in page:
                 continue
@@ -64,13 +62,14 @@ class BigQueryMetadataExtractor(BaseBigQueryExtractor):
 
                 # BigQuery tables also have interesting metadata about partitioning
                 # data location (EU/US), mod/create time, etc... Extract that some other time?
-                cols = []
+                cols: List[ColumnMetadata] = []
                 # Not all tables have schemas
                 if 'schema' in table:
                     schema = table['schema']
                     if 'fields' in schema:
                         total_cols = 0
                         for column in schema['fields']:
+                            # TRICKY: this mutates :cols:
                             total_cols = self._iterate_over_cols('', column, cols, total_cols + 1)
 
                 table_meta = TableMetadata(
@@ -86,7 +85,7 @@ class BigQueryMetadataExtractor(BaseBigQueryExtractor):
 
     def _iterate_over_cols(self,
                            parent: str,
-                           column: str,
+                           column: Dict[str, str],
                            cols: List[ColumnMetadata],
                            total_cols: int) -> int:
         if len(parent) > 0:
@@ -103,7 +102,11 @@ class BigQueryMetadataExtractor(BaseBigQueryExtractor):
             cols.append(col)
             total_cols += 1
             for field in column['fields']:
-                total_cols = self._iterate_over_cols(col_name, field, cols, total_cols)
+                # TODO field is actually a TableFieldSchema, per
+                # https://cloud.google.com/bigquery/docs/reference/rest/v2/tables#TableFieldSchema
+                # however it's typed as str, which is incorrect. Work-around by casting.
+                field_casted = cast(Dict[str, str], field)
+                total_cols = self._iterate_over_cols(col_name, field_casted, cols, total_cols)
             return total_cols
         else:
             col = ColumnMetadata(

--- a/databuilder/extractor/bigquery_metadata_extractor.py
+++ b/databuilder/extractor/bigquery_metadata_extractor.py
@@ -30,6 +30,7 @@ class BigQueryMetadataExtractor(BaseBigQueryExtractor):
     def init(self, conf: ConfigTree) -> None:
         BaseBigQueryExtractor.init(self, conf)
         self.grouped_tables: Set[str] = set([])
+        self.iter = iter(self._iterate_over_tables())
 
     def _retrieve_tables(self, dataset: DatasetRef) -> Any:
         for page in self._page_table_list_results(dataset):

--- a/databuilder/extractor/bigquery_metadata_extractor.py
+++ b/databuilder/extractor/bigquery_metadata_extractor.py
@@ -2,13 +2,11 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import logging
-from collections import namedtuple
 
 from pyhocon import ConfigTree  # noqa: F401
 from typing import cast, Any, Dict, List, Set  # noqa: F401
 
-from databuilder.extractor.base_bigquery_extractor import BaseBigQueryExtractor, \
-    DatasetRef, TableKey
+from databuilder.extractor.base_bigquery_extractor import BaseBigQueryExtractor, DatasetRef
 from databuilder.models.table_metadata import TableMetadata, ColumnMetadata
 
 

--- a/databuilder/extractor/bigquery_metadata_extractor.py
+++ b/databuilder/extractor/bigquery_metadata_extractor.py
@@ -87,7 +87,7 @@ class BigQueryMetadataExtractor(BaseBigQueryExtractor):
     def _iterate_over_cols(self,
                            parent: str,
                            column: str,
-                           cols: List[ColumnMetadata()],
+                           cols: List[ColumnMetadata],
                            total_cols: int) -> int:
         if len(parent) > 0:
             col_name = '{parent}.{field}'.format(parent=parent, field=column['name'])

--- a/databuilder/extractor/bigquery_metadata_extractor.py
+++ b/databuilder/extractor/bigquery_metadata_extractor.py
@@ -29,13 +29,11 @@ class BigQueryMetadataExtractor(BaseBigQueryExtractor):
     column name.
     """
 
-    def init(self, conf):
-        # type: (ConfigTree) -> None
+    def init(self, conf: ConfigTree) -> None:
         BaseBigQueryExtractor.init(self, conf)
         self.grouped_tables = set([])
 
-    def _retrieve_tables(self, dataset):
-        # type: () -> Any
+    def _retrieve_tables(self, dataset) -> Any:
         for page in self._page_table_list_results(dataset):
             if 'tables' not in page:
                 continue
@@ -86,8 +84,11 @@ class BigQueryMetadataExtractor(BaseBigQueryExtractor):
 
                 yield(table_meta)
 
-    def _iterate_over_cols(self, parent, column, cols, total_cols):
-        # type: (str, str, List[ColumnMetadata()], int) -> int
+    def _iterate_over_cols(self,
+                           parent: str,
+                           column: str,
+                           cols: List[ColumnMetadata()],
+                           total_cols: int) -> int:
         if len(parent) > 0:
             col_name = '{parent}.{field}'.format(parent=parent, field=column['name'])
         else:
@@ -113,6 +114,5 @@ class BigQueryMetadataExtractor(BaseBigQueryExtractor):
             cols.append(col)
             return total_cols + 1
 
-    def get_scope(self):
-        # type: () -> str
+    def get_scope(self) -> str:
         return 'extractor.bigquery_table_metadata'

--- a/databuilder/extractor/bigquery_usage_extractor.py
+++ b/databuilder/extractor/bigquery_usage_extractor.py
@@ -29,8 +29,7 @@ class BigQueryTableUsageExtractor(BaseBigQueryExtractor):
     EMAIL_PATTERN = 'email_pattern'
     DELAY_TIME = 'delay_time'
 
-    def init(self, conf):
-        # type: (ConfigTree) -> None
+    def init(self, conf: ConfigTree) -> None:
         BaseBigQueryExtractor.init(self, conf)
         self.timestamp = conf.get_string(
             BigQueryTableUsageExtractor.TIMESTAMP_KEY,
@@ -43,8 +42,7 @@ class BigQueryTableUsageExtractor(BaseBigQueryExtractor):
         self._count_usage()
         self.iter = iter(self.table_usage_counts)
 
-    def _count_usage(self):  # noqa: C901
-        # type: () -> None
+    def _count_usage(self) -> None:  # noqa: C901
         count = 0
         for entry in self._retrieve_records():
             count += 1
@@ -95,8 +93,7 @@ class BigQueryTableUsageExtractor(BaseBigQueryExtractor):
                 new_count = self.table_usage_counts.get(key, 0) + 1
                 self.table_usage_counts[key] = new_count
 
-    def _retrieve_records(self):
-        # type: () -> Optional[Dict]
+    def _retrieve_records(self) -> Optional[Dict]:
         """
         Extracts bigquery log data by looking at the principalEmail in the
         authenticationInfo block and referencedTables in the jobStatistics.
@@ -116,16 +113,14 @@ class BigQueryTableUsageExtractor(BaseBigQueryExtractor):
             for entry in page['entries']:
                 yield(entry)
 
-    def extract(self):
-        # type: () -> Optional[tuple]
+    def extract(self) -> Optional[tuple]:
         try:
             key = next(self.iter)
             return key, self.table_usage_counts[key]
         except StopIteration:
             return None
 
-    def _page_over_results(self, body):
-        # type: (Dict) -> Optional[Dict]
+    def _page_over_results(self, body: Dict) -> Optional[Dict]:
         response = self.logging_service.entries().list(body=body).execute(
             num_retries=BigQueryTableUsageExtractor.NUM_RETRIES)
         while response:
@@ -143,6 +138,5 @@ class BigQueryTableUsageExtractor(BaseBigQueryExtractor):
                 # Add a delay when BQ quota exceeds limitation
                 sleep(self.delay_time)
 
-    def get_scope(self):
-        # type: () -> str
+    def get_scope(self) -> str:
         return 'extractor.bigquery_table_usage'

--- a/databuilder/extractor/bigquery_watermark_extractor.py
+++ b/databuilder/extractor/bigquery_watermark_extractor.py
@@ -22,17 +22,14 @@ LOGGER = logging.getLogger(__name__)
 
 class BigQueryWatermarkExtractor(BaseBigQueryExtractor):
 
-    def init(self, conf):
-        # type: (ConfigTree) -> None
+    def init(self, conf: ConfigTree) -> None:
         BaseBigQueryExtractor.init(self, conf)
         self.iter = iter(self._iterate_over_tables())
 
-    def get_scope(self):
-        # type: () -> str
+    def get_scope(self) -> str:
         return 'extractor.bigquery_watermarks'
 
-    def _retrieve_tables(self, dataset):
-        # type: () -> Any
+    def _retrieve_tables(self, dataset) -> Any:
         sharded_table_watermarks = {}
 
         for page in self._page_table_list_results(dataset):

--- a/databuilder/extractor/bigquery_watermark_extractor.py
+++ b/databuilder/extractor/bigquery_watermark_extractor.py
@@ -28,11 +28,6 @@ class BigQueryWatermarkExtractor(BaseBigQueryExtractor):
     def get_scope(self) -> str:
         return 'extractor.bigquery_watermarks'
 
-    def _iterate_over_tables(self) -> Iterator[Watermark]:
-        for dataset in self._retrieve_datasets():
-            for entry in self._retrieve_tables(dataset):
-                yield(entry)
-
     def _retrieve_tables(self,
                          dataset: DatasetRef
                          ) -> Iterator[Watermark]:

--- a/databuilder/extractor/bigquery_watermark_extractor.py
+++ b/databuilder/extractor/bigquery_watermark_extractor.py
@@ -8,13 +8,12 @@ import datetime
 import textwrap
 
 from pyhocon import ConfigTree  # noqa: F401
-from typing import List, Any  # noqa: F401
+from typing import Any, Dict, Iterator, List, Tuple, Union  # noqa: F401
 
-from databuilder.extractor.base_bigquery_extractor import BaseBigQueryExtractor
+from databuilder.extractor.base_bigquery_extractor import BaseBigQueryExtractor, \
+    DatasetRef, TableKey
 from databuilder.models.watermark import Watermark
 
-DatasetRef = namedtuple('DatasetRef', ['datasetId', 'projectId'])
-TableKey = namedtuple('TableKey', ['schema', 'table_name'])
 PartitionInfo = namedtuple('PartitionInfo', ['partition_id', 'epoch_created'])
 
 LOGGER = logging.getLogger(__name__)
@@ -24,13 +23,20 @@ class BigQueryWatermarkExtractor(BaseBigQueryExtractor):
 
     def init(self, conf: ConfigTree) -> None:
         BaseBigQueryExtractor.init(self, conf)
-        self.iter = iter(self._iterate_over_tables())
+        self.iter: Iterator[Watermark] = iter(self._iterate_over_tables())
 
     def get_scope(self) -> str:
         return 'extractor.bigquery_watermarks'
 
-    def _retrieve_tables(self, dataset) -> Any:
-        sharded_table_watermarks = {}
+    def _iterate_over_tables(self) -> Iterator[Watermark]:
+        for dataset in self._retrieve_datasets():
+            for entry in self._retrieve_tables(dataset):
+                yield(entry)
+
+    def _retrieve_tables(self,
+                         dataset: DatasetRef
+                         ) -> Iterator[Watermark]:
+        sharded_table_watermarks: Dict[str, Dict[str, Union[str, Dict[str, Any]]]] = {}
 
         for page in self._page_table_list_results(dataset):
             if 'tables' not in page:
@@ -85,9 +91,12 @@ class BigQueryWatermarkExtractor(BaseBigQueryExtractor):
                     cluster=tableRef['projectId']
                 )
 
-    def _get_partitions(self, table, tableRef):
+    def _get_partitions(self,
+                        table: str,
+                        tableRef: Dict[str, str]
+                        ) -> List[PartitionInfo]:
         if 'timePartitioning' not in table:
-            return
+            return []
 
         query = textwrap.dedent("""
         SELECT partition_id,
@@ -106,11 +115,15 @@ class BigQueryWatermarkExtractor(BaseBigQueryExtractor):
         result = self.bigquery_service.jobs().query(projectId=self.project_id, body=body).execute()
 
         if 'rows' not in result:
-            return
+            return []
 
         return [PartitionInfo(row['f'][0]['v'], row['f'][1]['v']) for row in result['rows']]
 
-    def _get_partition_watermarks(self, table, tableRef, partitions):
+    def _get_partition_watermarks(self,
+                                  table: Dict[str, Any],
+                                  tableRef: Dict[str, str],
+                                  partitions: List[PartitionInfo]
+                                  ) -> Tuple[Watermark, Watermark]:
         if 'field' in table['timePartitioning']:
             field = table['timePartitioning']['field']
         else:

--- a/databuilder/extractor/bigquery_watermark_extractor.py
+++ b/databuilder/extractor/bigquery_watermark_extractor.py
@@ -10,8 +10,7 @@ import textwrap
 from pyhocon import ConfigTree  # noqa: F401
 from typing import Any, Dict, Iterator, List, Tuple, Union  # noqa: F401
 
-from databuilder.extractor.base_bigquery_extractor import BaseBigQueryExtractor, \
-    DatasetRef, TableKey
+from databuilder.extractor.base_bigquery_extractor import BaseBigQueryExtractor, DatasetRef
 from databuilder.models.watermark import Watermark
 
 PartitionInfo = namedtuple('PartitionInfo', ['partition_id', 'epoch_created'])

--- a/databuilder/extractor/cassandra_extractor.py
+++ b/databuilder/extractor/cassandra_extractor.py
@@ -23,7 +23,7 @@ class CassandraExtractor(Extractor):
     KWARGS_KEY = 'kwargs'
     # Key to define custom filter function based on keyspace and table
     # since the cluster metadata doesn't support native filters,
-    # it should be like def filter(keyspace, table) and return False if
+    # it should be like def filter(keyspace: str, table: str) -> bool and return False if
     # going to skip that table and True if not
     FILTER_FUNCTION_KEY = 'filter'
 

--- a/databuilder/extractor/cassandra_extractor.py
+++ b/databuilder/extractor/cassandra_extractor.py
@@ -43,10 +43,9 @@ class CassandraExtractor(Extractor):
         kwargs = conf.get(CassandraExtractor.KWARGS_KEY)
         self._client = Cluster(ips, **kwargs)
         self._client.connect()
-        self._extract_iter = None  # type: Union[None, Iterator]
+        self._extract_iter: Union[None, Iterator] = None
 
-    def extract(self):
-        # type: () -> Union[TableMetadata, None]
+    def extract(self) -> Union[TableMetadata, None]:
         if not self._extract_iter:
             self._extract_iter = self._get_extract_iter()
         try:
@@ -54,12 +53,10 @@ class CassandraExtractor(Extractor):
         except StopIteration:
             return None
 
-    def get_scope(self):
-        # type: () -> str
+    def get_scope(self) -> str:
         return 'extractor.cassandra'
 
-    def _get_extract_iter(self):
-        # type: () -> Iterator[TableMetadata]
+    def _get_extract_iter(self) -> Iterator[TableMetadata]:
         """
         It gets all tables and yields TableMetadata
         :return:

--- a/databuilder/extractor/cassandra_extractor.py
+++ b/databuilder/extractor/cassandra_extractor.py
@@ -2,9 +2,10 @@
 # SPDX-License-Identifier: Apache-2.0
 
 from cassandra.cluster import Cluster
+import cassandra.metadata
 
 from pyhocon import ConfigFactory, ConfigTree  # noqa: F401
-from typing import Iterator, Union, Dict, Any  # noqa: F401
+from typing import Iterator, Union, Dict, Any, List  # noqa: F401
 
 from databuilder.extractor.base_extractor import Extractor
 from databuilder.models.table_metadata import TableMetadata, ColumnMetadata
@@ -35,7 +36,7 @@ class CassandraExtractor(Extractor):
         FILTER_FUNCTION_KEY: None
     })
 
-    def init(self, conf):
+    def init(self, conf: ConfigTree) -> None:
         conf = conf.with_fallback(CassandraExtractor.DEFAULT_CONFIG)
         self._cluster = '{}'.format(conf.get_string(CassandraExtractor.CLUSTER_KEY))
         self._filter = conf.get(CassandraExtractor.FILTER_FUNCTION_KEY)
@@ -90,11 +91,11 @@ class CassandraExtractor(Extractor):
                     columns
                 )
 
-    def _get_keyspaces(self):
+    def _get_keyspaces(self) -> Dict[str, cassandra.metadata.KeyspaceMetadata]:
         return self._client.metadata.keyspaces
 
-    def _get_tables(self, keyspace):
+    def _get_tables(self, keyspace: str) -> Dict[str, cassandra.metadata.TableMetadata]:
         return self._client.metadata.keyspaces[keyspace].tables
 
-    def _get_columns(self, keyspace, table):
+    def _get_columns(self, keyspace: str, table: str) -> Dict[str, cassandra.metadata.ColumnMetadata]:
         return self._client.metadata.keyspaces[keyspace].tables[table].columns

--- a/databuilder/extractor/csv_extractor.py
+++ b/databuilder/extractor/csv_extractor.py
@@ -20,8 +20,7 @@ class CsvExtractor(Extractor):
     An Extractor that extracts records via CSV.
     """
 
-    def init(self, conf):
-        # type: (ConfigTree) -> None
+    def init(self, conf: ConfigTree) -> None:
         """
         :param conf:
         """
@@ -35,8 +34,7 @@ class CsvExtractor(Extractor):
             self.model_class = getattr(mod, class_name)
         self._load_csv()
 
-    def _load_csv(self):
-        # type: () -> None
+    def _load_csv(self) -> None:
         """
         Create an iterator to execute sql.
         """
@@ -51,8 +49,7 @@ class CsvExtractor(Extractor):
             results = self.results
         self.iter = iter(results)
 
-    def extract(self):
-        # type: () -> Any
+    def extract(self) -> Any:
         """
         Yield the csv result one at a time.
         convert the result to model if a model_class is provided
@@ -64,8 +61,7 @@ class CsvExtractor(Extractor):
         except Exception as e:
             raise e
 
-    def get_scope(self):
-        # type: () -> str
+    def get_scope(self) -> str:
         return 'extractor.csv'
 
 
@@ -78,8 +74,7 @@ class CsvTableColumnExtractor(Extractor):
     An Extractor that combines Table and Column CSVs.
     """
 
-    def init(self, conf):
-        # type: (ConfigTree) -> None
+    def init(self, conf: ConfigTree) -> None:
         """
         :param conf:
         """
@@ -94,8 +89,7 @@ class CsvTableColumnExtractor(Extractor):
                                                      schema=schema,
                                                      tbl=tbl)
 
-    def _load_csv(self):
-        # type: () -> None
+    def _load_csv(self) -> None:
         """
         Create an iterator to execute sql.
         """
@@ -144,8 +138,7 @@ class CsvTableColumnExtractor(Extractor):
             results.append(table)
         self._iter = iter(results)
 
-    def extract(self):
-        # type: () -> Any
+    def extract(self) -> Any:
         """
         Yield the csv result one at a time.
         convert the result to model if a model_class is provided
@@ -157,6 +150,5 @@ class CsvTableColumnExtractor(Extractor):
         except Exception as e:
             raise e
 
-    def get_scope(self):
-        # type: () -> str
+    def get_scope(self) -> str:
         return 'extractor.csvtablecolumn'

--- a/databuilder/extractor/csv_extractor.py
+++ b/databuilder/extractor/csv_extractor.py
@@ -83,7 +83,12 @@ class CsvTableColumnExtractor(Extractor):
         self.column_file_location = conf.get_string(CsvTableColumnExtractor.COLUMN_FILE_LOCATION)
         self._load_csv()
 
-    def _get_key(self, db, cluster, schema, tbl):
+    def _get_key(self,
+                 db: str,
+                 cluster: str,
+                 schema: str,
+                 tbl: str
+                 ) -> str:
         return TableMetadata.TABLE_KEY_FORMAT.format(db=db,
                                                      cluster=cluster,
                                                      schema=schema,
@@ -102,8 +107,8 @@ class CsvTableColumnExtractor(Extractor):
             db = column_dict['database']
             cluster = column_dict['cluster']
             schema = column_dict['schema']
-            table = column_dict['table_name']
-            id = self._get_key(db, cluster, schema, table)
+            table_name = column_dict['table_name']
+            id = self._get_key(db, cluster, schema, table_name)
             column = ColumnMetadata(
                 name=column_dict['name'],
                 description=column_dict['description'],
@@ -121,8 +126,8 @@ class CsvTableColumnExtractor(Extractor):
             db = table_dict['database']
             cluster = table_dict['cluster']
             schema = table_dict['schema']
-            table = table_dict['name']
-            id = self._get_key(db, cluster, schema, table)
+            table_name = table_dict['name']
+            id = self._get_key(db, cluster, schema, table_name)
             columns = parsed_columns[id]
             if columns is None:
                 columns = []
@@ -132,7 +137,9 @@ class CsvTableColumnExtractor(Extractor):
                                   name=table_dict['name'],
                                   description=table_dict['description'],
                                   columns=columns,
-                                  is_view=table_dict['is_view'],
+                                  # TODO: this possibly should parse stringified booleans;
+                                  # right now it only will be false for empty strings
+                                  is_view=bool(table_dict['is_view']),
                                   tags=table_dict['tags']
                                   )
             results.append(table)

--- a/databuilder/extractor/dashboard/mode_analytics/mode_dashboard_charts_extractor.py
+++ b/databuilder/extractor/dashboard/mode_analytics/mode_dashboard_charts_extractor.py
@@ -25,8 +25,7 @@ class ModeDashboardChartsExtractor(Extractor):
 
     """
 
-    def init(self, conf):
-        # type: (ConfigTree) -> None
+    def init(self, conf: ConfigTree) -> None:
         self._conf = conf
 
         restapi_query = self._build_restapi_query()
@@ -54,26 +53,22 @@ class ModeDashboardChartsExtractor(Extractor):
 
         self._transformer = ChainedTransformer(transformers=transformers)
 
-    def extract(self):
-        # type: () -> Any
-
+    def extract(self) -> Any:
         record = self._extractor.extract()
         if not record:
             return None
 
         return self._transformer.transform(record=record)
 
-    def get_scope(self):
-        # type: () -> str
+    def get_scope(self) -> str:
         return 'extractor.mode_dashboard_chart'
 
-    def _build_restapi_query(self):
+    def _build_restapi_query(self) -> RestApiQuery:
         """
         Build REST API Query. To get Mode Dashboard last execution, it needs to call three APIs (spaces API, reports
         API, and run API) joining together.
         :return: A RestApiQuery that provides Mode Dashboard execution (run)
         """
-        # type: () -> RestApiQuery
 
         spaces_query = ModeDashboardUtils.get_spaces_query_api(conf=self._conf)
         params = ModeDashboardUtils.get_auth_params(conf=self._conf)

--- a/databuilder/extractor/dashboard/mode_analytics/mode_dashboard_charts_extractor.py
+++ b/databuilder/extractor/dashboard/mode_analytics/mode_dashboard_charts_extractor.py
@@ -4,14 +4,14 @@
 import logging
 
 from pyhocon import ConfigTree, ConfigFactory  # noqa: F401
-from typing import Any  # noqa: F401
+from typing import Any, List  # noqa: F401
 
 from databuilder import Scoped
 from databuilder.extractor.base_extractor import Extractor
 from databuilder.extractor.dashboard.mode_analytics.mode_dashboard_utils import ModeDashboardUtils
 from databuilder.rest_api.mode_analytics.mode_paginated_rest_api_query import ModePaginatedRestApiQuery
 from databuilder.rest_api.rest_api_query import RestApiQuery
-from databuilder.transformer.base_transformer import ChainedTransformer
+from databuilder.transformer.base_transformer import ChainedTransformer, Transformer
 from databuilder.transformer.dict_to_model import DictToModel, MODEL_CLASS
 from databuilder.transformer.template_variable_substitution_transformer import \
     TemplateVariableSubstitutionTransformer, FIELD_NAME, TEMPLATE
@@ -35,7 +35,7 @@ class ModeDashboardChartsExtractor(Extractor):
         )
 
         # Constructing URL using resource path via TemplateVariableSubstitutionTransformer
-        transformers = []
+        transformers: List[Transformer] = []
         chart_url_transformer = TemplateVariableSubstitutionTransformer()
         chart_url_transformer.init(
             conf=Scoped.get_scoped_conf(self._conf, chart_url_transformer.get_scope()).with_fallback(

--- a/databuilder/extractor/dashboard/mode_analytics/mode_dashboard_executions_extractor.py
+++ b/databuilder/extractor/dashboard/mode_analytics/mode_dashboard_executions_extractor.py
@@ -4,14 +4,14 @@
 import logging
 
 from pyhocon import ConfigTree, ConfigFactory  # noqa: F401
-from typing import Any  # noqa: F401
+from typing import Any, List  # noqa: F401
 
 from databuilder import Scoped
 from databuilder.extractor.base_extractor import Extractor
 from databuilder.extractor.dashboard.mode_analytics.mode_dashboard_utils import ModeDashboardUtils
 from databuilder.rest_api.mode_analytics.mode_paginated_rest_api_query import ModePaginatedRestApiQuery
 from databuilder.rest_api.rest_api_query import RestApiQuery
-from databuilder.transformer.base_transformer import ChainedTransformer
+from databuilder.transformer.base_transformer import ChainedTransformer, Transformer
 from databuilder.transformer.dict_to_model import DictToModel, MODEL_CLASS
 from databuilder.transformer.timestamp_string_to_epoch import TimestampStringToEpoch, FIELD_NAME
 
@@ -35,7 +35,7 @@ class ModeDashboardExecutionsExtractor(Extractor):
 
         # Payload from RestApiQuery has timestamp which is ISO8601. Here we are using TimestampStringToEpoch to
         # transform into epoch and then using DictToModel to convert Dictionary to Model
-        transformers = []
+        transformers: List[Transformer] = []
         timestamp_str_to_epoch_transformer = TimestampStringToEpoch()
         timestamp_str_to_epoch_transformer.init(
             conf=Scoped.get_scoped_conf(self._conf, timestamp_str_to_epoch_transformer.get_scope()).with_fallback(

--- a/databuilder/extractor/dashboard/mode_analytics/mode_dashboard_executions_extractor.py
+++ b/databuilder/extractor/dashboard/mode_analytics/mode_dashboard_executions_extractor.py
@@ -24,8 +24,7 @@ class ModeDashboardExecutionsExtractor(Extractor):
 
     """
 
-    def init(self, conf):
-        # type: (ConfigTree) -> None
+    def init(self, conf: ConfigTree) -> None:
         self._conf = conf
 
         restapi_query = self._build_restapi_query()
@@ -53,25 +52,22 @@ class ModeDashboardExecutionsExtractor(Extractor):
 
         self._transformer = ChainedTransformer(transformers=transformers)
 
-    def extract(self):
-        # type: () -> Any
+    def extract(self) -> Any:
         record = self._extractor.extract()
         if not record:
             return None
 
         return self._transformer.transform(record=record)
 
-    def get_scope(self):
-        # type: () -> str
+    def get_scope(self) -> str:
         return 'extractor.mode_dashboard_execution'
 
-    def _build_restapi_query(self):
+    def _build_restapi_query(self) -> RestApiQuery:
         """
         Build REST API Query. To get Mode Dashboard last execution, it needs to call three APIs (spaces API, reports
         API, and run API) joining together.
         :return: A RestApiQuery that provides Mode Dashboard execution (run)
         """
-        # type: () -> RestApiQuery
 
         spaces_query = ModeDashboardUtils.get_spaces_query_api(conf=self._conf)
         params = ModeDashboardUtils.get_auth_params(conf=self._conf)

--- a/databuilder/extractor/dashboard/mode_analytics/mode_dashboard_extractor.py
+++ b/databuilder/extractor/dashboard/mode_analytics/mode_dashboard_extractor.py
@@ -34,9 +34,7 @@ class ModeDashboardExtractor(Extractor):
     Other information such as report run, owner, chart name, query name is in separate extractor.
     """
 
-    def init(self, conf):
-        # type: (ConfigTree) -> None
-
+    def init(self, conf: ConfigTree) -> None:
         self._conf = conf
 
         restapi_query = self._build_restapi_query()
@@ -77,27 +75,22 @@ class ModeDashboardExtractor(Extractor):
 
         self._transformer = ChainedTransformer(transformers=transformers)
 
-    def extract(self):
-        # type: () -> Any
-
+    def extract(self) -> Any:
         record = self._extractor.extract()
         if not record:
             return None
 
         return self._transformer.transform(record=record)
 
-    def get_scope(self):
-        # type: () -> str
-
+    def get_scope(self) -> str:
         return 'extractor.mode_dashboard'
 
-    def _build_restapi_query(self):
+    def _build_restapi_query(self) -> RestApiQuery:
         """
         Build REST API Query. To get Mode Dashboard metadata, it needs to call two APIs (spaces API and reports
         API) joining together.
         :return: A RestApiQuery that provides Mode Dashboard metadata
         """
-        # type: () -> RestApiQuery
 
         # https://mode.com/developer/api-reference/analytics/reports/#listReportsInSpace
         reports_url_template = 'https://app.mode.com/api/{organization}/spaces/{dashboard_group_id}/reports'

--- a/databuilder/extractor/dashboard/mode_analytics/mode_dashboard_extractor.py
+++ b/databuilder/extractor/dashboard/mode_analytics/mode_dashboard_extractor.py
@@ -4,14 +4,14 @@
 import logging
 
 from pyhocon import ConfigTree, ConfigFactory  # noqa: F401
-from typing import Any  # noqa: F401
+from typing import Any, List  # noqa: F401
 
 from databuilder import Scoped
 from databuilder.extractor.base_extractor import Extractor
 from databuilder.extractor.dashboard.mode_analytics.mode_dashboard_utils import ModeDashboardUtils
 from databuilder.rest_api.mode_analytics.mode_paginated_rest_api_query import ModePaginatedRestApiQuery
 from databuilder.rest_api.rest_api_query import RestApiQuery  # noqa: F401
-from databuilder.transformer.base_transformer import ChainedTransformer
+from databuilder.transformer.base_transformer import ChainedTransformer, Transformer
 from databuilder.transformer.dict_to_model import DictToModel, MODEL_CLASS
 from databuilder.transformer.template_variable_substitution_transformer import \
     TemplateVariableSubstitutionTransformer, TEMPLATE, FIELD_NAME as VAR_FIELD_NAME
@@ -43,7 +43,7 @@ class ModeDashboardExtractor(Extractor):
 
         # Payload from RestApiQuery has timestamp which is ISO8601. Here we are using TimestampStringToEpoch to
         # transform into epoch and then using DictToModel to convert Dictionary to Model
-        transformers = []
+        transformers: List[Transformer] = []
         timestamp_str_to_epoch_transformer = TimestampStringToEpoch()
         timestamp_str_to_epoch_transformer.init(
             conf=Scoped.get_scoped_conf(self._conf, timestamp_str_to_epoch_transformer.get_scope()).with_fallback(

--- a/databuilder/extractor/dashboard/mode_analytics/mode_dashboard_last_modified_timestamp_extractor.py
+++ b/databuilder/extractor/dashboard/mode_analytics/mode_dashboard_last_modified_timestamp_extractor.py
@@ -23,7 +23,7 @@ class ModeDashboardLastModifiedTimestampExtractor(ModeDashboardExecutionsExtract
 
     """
 
-    def __init__(self):
+    def __init__(self) -> None:
         super(ModeDashboardLastModifiedTimestampExtractor, self).__init__()
 
     def init(self, conf: ConfigTree) -> None:

--- a/databuilder/extractor/dashboard/mode_analytics/mode_dashboard_last_modified_timestamp_extractor.py
+++ b/databuilder/extractor/dashboard/mode_analytics/mode_dashboard_last_modified_timestamp_extractor.py
@@ -26,9 +26,7 @@ class ModeDashboardLastModifiedTimestampExtractor(ModeDashboardExecutionsExtract
     def __init__(self):
         super(ModeDashboardLastModifiedTimestampExtractor, self).__init__()
 
-    def init(self, conf):
-        # type: (ConfigTree) -> None
-
+    def init(self, conf: ConfigTree) -> None:
         conf = conf.with_fallback(
             ConfigFactory.from_dict({
                 STATIC_RECORD_DICT: {'product': 'mode'},
@@ -40,17 +38,15 @@ class ModeDashboardLastModifiedTimestampExtractor(ModeDashboardExecutionsExtract
         )
         super(ModeDashboardLastModifiedTimestampExtractor, self).init(conf)
 
-    def get_scope(self):
-        # type: () -> str
+    def get_scope(self) -> str:
         return 'extractor.mode_dashboard_last_modified_timestamp_execution'
 
-    def _build_restapi_query(self):
+    def _build_restapi_query(self) -> RestApiQuery:
         """
         Build REST API Query. To get Mode Dashboard last modified timestamp, it needs to call two APIs (spaces API,
         and reports API) joining together.
         :return: A RestApiQuery that provides Mode Dashboard last successful execution (run)
         """
-        # type: () -> RestApiQuery
 
         spaces_query = ModeDashboardUtils.get_spaces_query_api(conf=self._conf)
         params = ModeDashboardUtils.get_auth_params(conf=self._conf)

--- a/databuilder/extractor/dashboard/mode_analytics/mode_dashboard_last_successful_executions_extractor.py
+++ b/databuilder/extractor/dashboard/mode_analytics/mode_dashboard_last_successful_executions_extractor.py
@@ -25,9 +25,7 @@ class ModeDashboardLastSuccessfulExecutionExtractor(ModeDashboardExecutionsExtra
     def __init__(self):
         super(ModeDashboardLastSuccessfulExecutionExtractor, self).__init__()
 
-    def init(self, conf):
-        # type: (ConfigTree) -> None
-
+    def init(self, conf: ConfigTree) -> None:
         conf = conf.with_fallback(
             ConfigFactory.from_dict({
                 STATIC_RECORD_DICT: {'product': 'mode',
@@ -37,17 +35,15 @@ class ModeDashboardLastSuccessfulExecutionExtractor(ModeDashboardExecutionsExtra
         )
         super(ModeDashboardLastSuccessfulExecutionExtractor, self).init(conf)
 
-    def get_scope(self):
-        # type: () -> str
+    def get_scope(self) -> str:
         return 'extractor.mode_dashboard_last_successful_execution'
 
-    def _build_restapi_query(self):
+    def _build_restapi_query(self) -> RestApiQuery:
         """
         Build REST API Query. To get Mode Dashboard last successful execution, it needs to call two APIs (spaces API,
         and reports API) joining together.
         :return: A RestApiQuery that provides Mode Dashboard last successful execution (run)
         """
-        # type: () -> RestApiQuery
 
         spaces_query = ModeDashboardUtils.get_spaces_query_api(conf=self._conf)
         params = ModeDashboardUtils.get_auth_params(conf=self._conf)

--- a/databuilder/extractor/dashboard/mode_analytics/mode_dashboard_last_successful_executions_extractor.py
+++ b/databuilder/extractor/dashboard/mode_analytics/mode_dashboard_last_successful_executions_extractor.py
@@ -22,7 +22,7 @@ class ModeDashboardLastSuccessfulExecutionExtractor(ModeDashboardExecutionsExtra
 
     """
 
-    def __init__(self):
+    def __init__(self) -> None:
         super(ModeDashboardLastSuccessfulExecutionExtractor, self).__init__()
 
     def init(self, conf: ConfigTree) -> None:

--- a/databuilder/extractor/dashboard/mode_analytics/mode_dashboard_owner_extractor.py
+++ b/databuilder/extractor/dashboard/mode_analytics/mode_dashboard_owner_extractor.py
@@ -22,8 +22,7 @@ class ModeDashboardOwnerExtractor(Extractor):
 
     """
 
-    def init(self, conf):
-        # type: (ConfigTree) -> None
+    def init(self, conf: ConfigTree) -> None:
         self._conf = conf
 
         restapi_query = self._build_restapi_query()
@@ -36,22 +35,18 @@ class ModeDashboardOwnerExtractor(Extractor):
             )
         )
 
-    def extract(self):
-        # type: () -> Any
-
+    def extract(self) -> Any:
         return self._extractor.extract()
 
-    def get_scope(self):
-        # type: () -> str
+    def get_scope(self) -> str:
         return 'extractor.mode_dashboard_owner'
 
-    def _build_restapi_query(self):
+    def _build_restapi_query(self) -> RestApiQuery:
         """
         Build REST API Query. To get Mode Dashboard owner, it needs to call three APIs (spaces API, reports
         API, and user API) joining together.
         :return: A RestApiQuery that provides Mode Dashboard owner
         """
-        # type: () -> RestApiQuery
 
         # https://mode.com/developer/api-reference/analytics/reports/#listReportsInSpace
         report_url_template = 'https://app.mode.com/api/{organization}/spaces/{dashboard_group_id}/reports'

--- a/databuilder/extractor/dashboard/mode_analytics/mode_dashboard_queries_extractor.py
+++ b/databuilder/extractor/dashboard/mode_analytics/mode_dashboard_queries_extractor.py
@@ -27,8 +27,7 @@ class ModeDashboardQueriesExtractor(Extractor):
 
     """
 
-    def init(self, conf):
-        # type: (ConfigTree) -> None
+    def init(self, conf: ConfigTree) -> None:
         self._conf = conf
 
         restapi_query = self._build_restapi_query()
@@ -66,26 +65,22 @@ class ModeDashboardQueriesExtractor(Extractor):
 
         self._transformer = ChainedTransformer(transformers=transformers)
 
-    def extract(self):
-        # type: () -> Any
-
+    def extract(self) -> Any:
         record = self._extractor.extract()
         if not record:
             return None
 
         return self._transformer.transform(record=record)
 
-    def get_scope(self):
-        # type: () -> str
+    def get_scope(self) -> str:
         return 'extractor.mode_dashboard_query'
 
-    def _build_restapi_query(self):
+    def _build_restapi_query(self) -> RestApiQuery:
         """
         Build REST API Query. To get Mode Dashboard last execution, it needs to call three APIs (spaces API, reports
         API, and queries API) joining together.
         :return: A RestApiQuery that provides Mode Dashboard execution (run)
         """
-        # type: () -> RestApiQuery
 
         spaces_query = ModeDashboardUtils.get_spaces_query_api(conf=self._conf)
         params = ModeDashboardUtils.get_auth_params(conf=self._conf)

--- a/databuilder/extractor/dashboard/mode_analytics/mode_dashboard_queries_extractor.py
+++ b/databuilder/extractor/dashboard/mode_analytics/mode_dashboard_queries_extractor.py
@@ -4,14 +4,14 @@
 import logging
 
 from pyhocon import ConfigTree, ConfigFactory  # noqa: F401
-from typing import Any  # noqa: F401
+from typing import Any, List  # noqa: F401
 
 from databuilder import Scoped
 from databuilder.extractor.base_extractor import Extractor
 from databuilder.extractor.dashboard.mode_analytics.mode_dashboard_utils import ModeDashboardUtils
 from databuilder.rest_api.mode_analytics.mode_paginated_rest_api_query import ModePaginatedRestApiQuery
 from databuilder.rest_api.rest_api_query import RestApiQuery
-from databuilder.transformer.base_transformer import ChainedTransformer
+from databuilder.transformer.base_transformer import ChainedTransformer, Transformer
 from databuilder.transformer.dict_to_model import DictToModel, MODEL_CLASS
 from databuilder.transformer.regex_str_replace_transformer import RegexStrReplaceTransformer, \
     REGEX_REPLACE_TUPLE_LIST, ATTRIBUTE_NAME
@@ -37,7 +37,7 @@ class ModeDashboardQueriesExtractor(Extractor):
         )
 
         # Constructing URL using several ID via TemplateVariableSubstitutionTransformer
-        transformers = []
+        transformers: List[Transformer] = []
         variable_substitution_transformer = TemplateVariableSubstitutionTransformer()
         variable_substitution_transformer.init(
             conf=Scoped.get_scoped_conf(self._conf,

--- a/databuilder/extractor/dashboard/mode_analytics/mode_dashboard_usage_extractor.py
+++ b/databuilder/extractor/dashboard/mode_analytics/mode_dashboard_usage_extractor.py
@@ -19,32 +19,25 @@ class ModeDashboardUsageExtractor(Extractor):
     A Extractor that extracts Mode dashboard's accumulated view count
     """
 
-    def init(self, conf):
-        # type: (ConfigTree) -> None
-
+    def init(self, conf: ConfigTree) -> None:
         self._conf = conf
 
         restapi_query = self._build_restapi_query()
         self._extractor = ModeDashboardUtils.create_mode_rest_api_extractor(restapi_query=restapi_query,
                                                                             conf=self._conf)
 
-    def extract(self):
-        # type: () -> Any
-
+    def extract(self) -> Any:
         return self._extractor.extract()
 
-    def get_scope(self):
-        # type: () -> str
-
+    def get_scope(self) -> str:
         return 'extractor.mode_dashboard_usage'
 
-    def _build_restapi_query(self):
+    def _build_restapi_query(self) -> RestApiQuery:
         """
         Build REST API Query. To get Mode Dashboard usage, it needs to call two APIs (spaces API and reports
         API) joining together.
         :return: A RestApiQuery that provides Mode Dashboard metadata
         """
-        # type: () -> RestApiQuery
 
         # https://mode.com/developer/api-reference/analytics/reports/#listReportsInSpace
         reports_url_template = 'https://app.mode.com/api/{organization}/spaces/{dashboard_group_id}/reports'

--- a/databuilder/extractor/dashboard/mode_analytics/mode_dashboard_user_extractor.py
+++ b/databuilder/extractor/dashboard/mode_analytics/mode_dashboard_user_extractor.py
@@ -2,10 +2,10 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import logging
-from typing import Any  # noqa: F401
 
 from pyhocon import ConfigTree, ConfigFactory  # noqa: F401
 from requests.auth import HTTPBasicAuth
+from typing import Any, List  # noqa: F401
 
 from databuilder import Scoped
 from databuilder.extractor.base_extractor import Extractor
@@ -15,7 +15,7 @@ from databuilder.extractor.dashboard.mode_analytics.mode_dashboard_utils import 
 from databuilder.rest_api.base_rest_api_query import RestApiQuerySeed
 from databuilder.rest_api.rest_api_failure_handlers import HttpFailureSkipOnStatus
 from databuilder.rest_api.rest_api_query import RestApiQuery
-from databuilder.transformer.base_transformer import ChainedTransformer
+from databuilder.transformer.base_transformer import ChainedTransformer, Transformer
 from databuilder.transformer.dict_to_model import DictToModel, MODEL_CLASS
 from databuilder.transformer.remove_field_transformer import RemoveFieldTransformer, FIELD_NAMES
 
@@ -37,7 +37,7 @@ class ModeDashboardUserExtractor(Extractor):
         )
 
         # Remove all unnecessary fields because User model accepts all attributes and push it to Neo4j.
-        transformers = []
+        transformers: List[Transformer] = []
 
         remove_fields_transformer = RemoveFieldTransformer()
         remove_fields_transformer.init(

--- a/databuilder/extractor/dashboard/mode_analytics/mode_dashboard_user_extractor.py
+++ b/databuilder/extractor/dashboard/mode_analytics/mode_dashboard_user_extractor.py
@@ -27,8 +27,7 @@ class ModeDashboardUserExtractor(Extractor):
     An Extractor that extracts all Mode Dashboard user and add mode_user_id attribute to User model.
     """
 
-    def init(self, conf):
-        # type: (ConfigTree) -> None
+    def init(self, conf: ConfigTree) -> None:
         self._conf = conf
 
         restapi_query = self._build_restapi_query()
@@ -56,26 +55,22 @@ class ModeDashboardUserExtractor(Extractor):
 
         self._transformer = ChainedTransformer(transformers=transformers)
 
-    def extract(self):
-        # type: () -> Any
-
+    def extract(self) -> Any:
         record = self._extractor.extract()
         if not record:
             return None
 
         return self._transformer.transform(record=record)
 
-    def get_scope(self):
-        # type: () -> str
+    def get_scope(self) -> str:
         return 'extractor.mode_dashboard_owner'
 
-    def _build_restapi_query(self):
+    def _build_restapi_query(self) -> RestApiQuery:
         """
         Build REST API Query. To get Mode Dashboard owner, it needs to call three APIs (spaces API, reports
         API, and user API) joining together.
         :return: A RestApiQuery that provides Mode Dashboard owner
         """
-        # type: () -> RestApiQuery
 
         # Seed query record for next query api to join with
         seed_record = [{

--- a/databuilder/extractor/dashboard/mode_analytics/mode_dashboard_utils.py
+++ b/databuilder/extractor/dashboard/mode_analytics/mode_dashboard_utils.py
@@ -3,6 +3,7 @@
 
 from pyhocon import ConfigTree, ConfigFactory  # noqa: F401
 from requests.auth import HTTPBasicAuth
+from typing import Any, Dict
 
 from databuilder import Scoped
 from databuilder.extractor.dashboard.mode_analytics.mode_dashboard_constants import ORGANIZATION, MODE_ACCESS_TOKEN, \
@@ -43,7 +44,7 @@ class ModeDashboardUtils(object):
         return spaces_query
 
     @staticmethod
-    def get_auth_params(conf: ConfigTree):
+    def get_auth_params(conf: ConfigTree) -> Dict[str, Any]:
         params = {'auth': HTTPBasicAuth(conf.get_string(MODE_ACCESS_TOKEN),
                                         conf.get_string(MODE_PASSWORD_TOKEN)
                                         )
@@ -53,7 +54,7 @@ class ModeDashboardUtils(object):
     @staticmethod
     def create_mode_rest_api_extractor(restapi_query: BaseRestApiQuery,
                                        conf: ConfigTree
-                                       ):
+                                       ) -> RestAPIExtractor:
         """
         Creates RestAPIExtractor. Note that RestAPIExtractor is already initialized
         :param restapi_query:

--- a/databuilder/extractor/dashboard/mode_analytics/mode_dashboard_utils.py
+++ b/databuilder/extractor/dashboard/mode_analytics/mode_dashboard_utils.py
@@ -16,15 +16,13 @@ from databuilder.rest_api.rest_api_query import RestApiQuery  # noqa: F401
 class ModeDashboardUtils(object):
 
     @staticmethod
-    def get_spaces_query_api(conf,  # type: ConfigTree
-                             ):
+    def get_spaces_query_api(conf: ConfigTree) -> BaseRestApiQuery:
         """
         Provides RestApiQuerySeed where it will provides iterator of dictionaries as records where dictionary keys are
          organization, dashboard_group_id, dashboard_group and dashboard_group_description
         :param conf:
         :return:
         """
-        # type: (...) -> BaseRestApiQuery
 
         # https://mode.com/developer/api-reference/management/spaces/#listSpaces
         spaces_url_template = 'https://app.mode.com/api/{organization}/spaces?filter=all'
@@ -45,8 +43,7 @@ class ModeDashboardUtils(object):
         return spaces_query
 
     @staticmethod
-    def get_auth_params(conf,  # type: ConfigTree
-                        ):
+    def get_auth_params(conf: ConfigTree):
         params = {'auth': HTTPBasicAuth(conf.get_string(MODE_ACCESS_TOKEN),
                                         conf.get_string(MODE_PASSWORD_TOKEN)
                                         )
@@ -54,8 +51,8 @@ class ModeDashboardUtils(object):
         return params
 
     @staticmethod
-    def create_mode_rest_api_extractor(restapi_query,  # type: BaseRestApiQuery
-                                       conf,  # type: ConfigTree
+    def create_mode_rest_api_extractor(restapi_query: BaseRestApiQuery,
+                                       conf: ConfigTree
                                        ):
         """
         Creates RestAPIExtractor. Note that RestAPIExtractor is already initialized

--- a/databuilder/extractor/dashboard/redash/redash_dashboard_extractor.py
+++ b/databuilder/extractor/dashboard/redash/redash_dashboard_extractor.py
@@ -4,7 +4,7 @@
 import importlib
 
 from pyhocon import ConfigFactory, ConfigTree
-from typing import Any, Dict, Iterator
+from typing import Any, Dict, Iterator, Optional
 
 from databuilder.models.dashboard.dashboard_metadata import DashboardMetadata
 from databuilder.models.dashboard.dashboard_last_modified import DashboardLastModifiedTimestamp
@@ -93,7 +93,7 @@ class RedashDashboardExtractor(Extractor):
 
         self._extractor = self._build_extractor()
         self._transformer = self._build_transformer()
-        self._extract_iter = None
+        self._extract_iter: Optional[Iterator[Any]] = None
 
     def _is_published_dashboard(self, record: Dict[str, Any]) -> bool:
         return not (record['is_archived'] or record['is_draft'])
@@ -137,7 +137,8 @@ class RedashDashboardExtractor(Extractor):
             viz_widgets = get_visualization_widgets(widgets)
 
             # generate a description for this dashboard, since Redash does not have descriptions
-            dash_data['description'] = generate_dashboard_description(text_widgets, viz_widgets)
+            dash_data['description'] = generate_dashboard_description(
+                iter(text_widgets), iter(viz_widgets))
 
             yield DashboardMetadata(**dash_data)
 

--- a/databuilder/extractor/dashboard/redash/redash_dashboard_extractor.py
+++ b/databuilder/extractor/dashboard/redash/redash_dashboard_extractor.py
@@ -95,9 +95,7 @@ class RedashDashboardExtractor(Extractor):
         self._transformer = self._build_transformer()
         self._extract_iter = None
 
-    def _is_published_dashboard(self, record):
-        # type: Dict[str, Any] -> bool
-
+    def _is_published_dashboard(self, record: Dict[str, Any]) -> bool:
         return not (record['is_archived'] or record['is_draft'])
 
     def _get_extract_iter(self) -> Iterator[Any]:

--- a/databuilder/extractor/dashboard/redash/redash_dashboard_extractor.py
+++ b/databuilder/extractor/dashboard/redash/redash_dashboard_extractor.py
@@ -26,14 +26,16 @@ class TableRelationData:
     It is used as the type returned by the (optional) table parser.
     """
 
-    def __init__(self, database, cluster, schema, name):
-        # type: (str, str, str, str) -> None
+    def __init__(self,
+                 database: str,
+                 cluster: str,
+                 schema: str,
+                 name: str) -> None:
 
         self._data = {'db': database, 'cluster': cluster, 'schema': schema, 'tbl': name}
 
     @property
-    def key(self):
-        # type: () -> str
+    def key(self) -> str:
 
         return TableMetadata.TABLE_KEY_FORMAT.format(**self._data)
 
@@ -68,8 +70,7 @@ class RedashDashboardExtractor(Extractor):
     DASHBOARD_GROUP_ID = 'redash'
     DASHBOARD_GROUP_NAME = 'Redash'
 
-    def init(self, conf):
-        # type: (ConfigTree) -> None
+    def init(self, conf: ConfigTree) -> None:
 
         # required configuration
         self._redash_base_url = conf.get_string(RedashDashboardExtractor.REDASH_BASE_URL_KEY)
@@ -96,8 +97,7 @@ class RedashDashboardExtractor(Extractor):
 
         return not (record['is_archived'] or record['is_draft'])
 
-    def _get_extract_iter(self):
-        # type: () -> Iterator[Any]
+    def _get_extract_iter(self) -> Iterator[Any]:
 
         while True:
             record = self._extractor.extract()
@@ -171,8 +171,7 @@ class RedashDashboardExtractor(Extractor):
             if len(table_keys) > 0:
                 yield DashboardTable(table_ids=list(table_keys), **identity_data)
 
-    def extract(self):
-        # type: () -> Any
+    def extract(self) -> Any:
 
         if not self._extract_iter:
             self._extract_iter = self._get_extract_iter()
@@ -181,8 +180,7 @@ class RedashDashboardExtractor(Extractor):
         except StopIteration:
             return None
 
-    def _build_restapi_query(self):
-        # type: () -> RestApiQuery
+    def _build_restapi_query(self) -> RestApiQuery:
 
         dashes_query = RedashPaginatedRestApiQuery(
             query_to_join=EmptyRestApiQuerySeed(),
@@ -205,13 +203,11 @@ class RedashDashboardExtractor(Extractor):
             skip_no_result=True
         )
 
-    def _get_default_api_query_params(self):
-        # type: () -> Dict[str, Any]
+    def _get_default_api_query_params(self) -> Dict[str, Any]:
 
         return {'headers': get_auth_headers(self._api_key)}
 
-    def _build_extractor(self):
-        # type: () -> RestAPIExtractor
+    def _build_extractor(self) -> RestAPIExtractor:
 
         extractor = RestAPIExtractor()
         rest_api_extractor_conf = ConfigFactory.from_dict({
@@ -220,8 +216,7 @@ class RedashDashboardExtractor(Extractor):
         extractor.init(rest_api_extractor_conf)
         return extractor
 
-    def _build_transformer(self):
-        # type: () -> ChainedTransformer
+    def _build_transformer(self) -> ChainedTransformer:
 
         transformers = []
 
@@ -240,7 +235,6 @@ class RedashDashboardExtractor(Extractor):
 
         return ChainedTransformer(transformers=transformers)
 
-    def get_scope(self):
-        # type: () -> str
+    def get_scope(self) -> str:
 
         return 'extractor.redash_dashboard'

--- a/databuilder/extractor/dashboard/redash/redash_dashboard_extractor.py
+++ b/databuilder/extractor/dashboard/redash/redash_dashboard_extractor.py
@@ -2,7 +2,10 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import importlib
-from pyhocon import ConfigFactory
+
+from pyhocon import ConfigFactory, ConfigTree
+from typing import Any, Dict, Iterator
+
 from databuilder.models.dashboard.dashboard_metadata import DashboardMetadata
 from databuilder.models.dashboard.dashboard_last_modified import DashboardLastModifiedTimestamp
 from databuilder.models.dashboard.dashboard_owner import DashboardOwner

--- a/databuilder/extractor/dashboard/redash/redash_dashboard_extractor.py
+++ b/databuilder/extractor/dashboard/redash/redash_dashboard_extractor.py
@@ -137,8 +137,7 @@ class RedashDashboardExtractor(Extractor):
             viz_widgets = get_visualization_widgets(widgets)
 
             # generate a description for this dashboard, since Redash does not have descriptions
-            dash_data['description'] = generate_dashboard_description(
-                iter(text_widgets), iter(viz_widgets))
+            dash_data['description'] = generate_dashboard_description(text_widgets, viz_widgets)
 
             yield DashboardMetadata(**dash_data)
 

--- a/databuilder/extractor/dashboard/redash/redash_dashboard_utils.py
+++ b/databuilder/extractor/dashboard/redash/redash_dashboard_utils.py
@@ -1,7 +1,7 @@
 # Copyright Contributors to the Amundsen project.
 # SPDX-License-Identifier: Apache-2.0
 
-from typing import Any, Dict, Iterator, List
+from typing import Any, Dict, Iterable, List, Tuple
 
 from databuilder.rest_api.rest_api_query import RestApiQuery
 
@@ -18,8 +18,7 @@ class RedashVisualizationWidget:
         self._data = data
 
     @property
-    def raw_query(self):
-        # type () -> str
+    def raw_query(self) -> str:
         return self._data['visualization']['query']['query']
 
     @property
@@ -58,7 +57,7 @@ class RedashPaginatedRestApiQuery(RestApiQuery):
     Paginated Redash API queries
     """
 
-    def __init__(self, **kwargs) -> None:
+    def __init__(self, **kwargs: Any) -> None:
         super(RedashPaginatedRestApiQuery, self).__init__(**kwargs)
         if 'params' not in self._params:
             self._params['params'] = {}
@@ -83,7 +82,7 @@ class RedashPaginatedRestApiQuery(RestApiQuery):
             self._more_pages = True
 
 
-def sort_widgets(widgets: Iterator[Dict[str, Any]]) -> Iterator[Dict[str, Any]]:
+def sort_widgets(widgets: Iterable[Dict[str, Any]]) -> List[Dict[str, Any]]:
     """
     Sort raw widget data (as returned from the API) according to the position
     of the widgets in the dashboard (top to bottom, left to right)
@@ -91,7 +90,7 @@ def sort_widgets(widgets: Iterator[Dict[str, Any]]) -> Iterator[Dict[str, Any]]:
     so we do this to ensure that we look at widgets in a sensible order.
     """
 
-    def row_and_col(widget):
+    def row_and_col(widget: Dict[str, Any]) -> Tuple[Any, Any]:
         # these entities usually but not always have explicit rows and cols
         pos = widget['options'].get('position', {})
         return (pos.get('row', 0), pos.get('col', 0))
@@ -99,7 +98,7 @@ def sort_widgets(widgets: Iterator[Dict[str, Any]]) -> Iterator[Dict[str, Any]]:
     return sorted(widgets, key=row_and_col)
 
 
-def get_text_widgets(widgets: Iterator[Dict[str, Any]]) -> List[RedashTextWidget]:
+def get_text_widgets(widgets: Iterable[Dict[str, Any]]) -> List[RedashTextWidget]:
     """
     From the raw set of widget data returned from the API, filter down
     to text widgets and return them as a list of `RedashTextWidget`
@@ -109,7 +108,7 @@ def get_text_widgets(widgets: Iterator[Dict[str, Any]]) -> List[RedashTextWidget
             if 'text' in widget and 'visualization' not in widget]
 
 
-def get_visualization_widgets(widgets: Iterator[Dict[str, Any]]) -> List[RedashVisualizationWidget]:
+def get_visualization_widgets(widgets: Iterable[Dict[str, Any]]) -> List[RedashVisualizationWidget]:
     """
     From the raw set of widget data returned from the API, filter down
     to visualization widgets and return them as a list of `RedashVisualizationWidget`
@@ -123,8 +122,8 @@ def get_auth_headers(api_key: str) -> Dict[str, str]:
     return {'Authorization': 'Key {}'.format(api_key)}
 
 
-def generate_dashboard_description(text_widgets: Iterator[RedashTextWidget],
-                                   viz_widgets: Iterator[RedashVisualizationWidget]) -> str:
+def generate_dashboard_description(text_widgets: List[RedashTextWidget],
+                                   viz_widgets: List[RedashVisualizationWidget]) -> str:
     """
     Redash doesn't have dashboard descriptions, so we'll make our own.
     If there exist any text widgets, concatenate them,

--- a/databuilder/extractor/dashboard/redash/redash_dashboard_utils.py
+++ b/databuilder/extractor/dashboard/redash/redash_dashboard_utils.py
@@ -4,8 +4,7 @@
 from databuilder.rest_api.rest_api_query import RestApiQuery
 
 
-def sort_widgets(widgets):
-    # type: (Iterator[Dict[str, Any]]) -> Iterator[Dict[str, Any]]
+def sort_widgets(widgets: Iterator[Dict[str, Any]]) -> Iterator[Dict[str, Any]]:
     """
     Sort raw widget data (as returned from the API) according to the position
     of the widgets in the dashboard (top to bottom, left to right)
@@ -21,8 +20,7 @@ def sort_widgets(widgets):
     return sorted(widgets, key=row_and_col)
 
 
-def get_text_widgets(widgets):
-    # type: (Iterator[Dict[str, Any]]) -> List[RedashTextWidget]
+def get_text_widgets(widgets: Iterator[Dict[str, Any]]) -> List[RedashTextWidget]:
     """
     From the raw set of widget data returned from the API, filter down
     to text widgets and return them as a list of `RedashTextWidget`
@@ -32,8 +30,7 @@ def get_text_widgets(widgets):
             if 'text' in widget and 'visualization' not in widget]
 
 
-def get_visualization_widgets(widgets):
-    # type: (Iterator[Dict[str, Any]]) -> List[RedashVisualizationWidget]
+def get_visualization_widgets(widgets: Iterator[Dict[str, Any]]) -> List[RedashVisualizationWidget]:
     """
     From the raw set of widget data returned from the API, filter down
     to visualization widgets and return them as a list of `RedashVisualizationWidget`
@@ -43,13 +40,12 @@ def get_visualization_widgets(widgets):
             if 'visualization' in widget]
 
 
-def get_auth_headers(api_key):
-    # type: (str) -> Dict[str, str]
+def get_auth_headers(api_key: str) -> Dict[str, str]:
     return {'Authorization': 'Key {}'.format(api_key)}
 
 
-def generate_dashboard_description(text_widgets, viz_widgets):
-    # type: (Iterator[RedashTextWidget], Iterator[RedashVisualizationWidget]) -> str
+def generate_dashboard_description(text_widgets: Iterator[RedashTextWidget],
+                                   viz_widgets: Iterator[RedashVisualizationWidget]) -> str:
     """
     Redash doesn't have dashboard descriptions, so we'll make our own.
     If there exist any text widgets, concatenate them,
@@ -75,8 +71,7 @@ class RedashVisualizationWidget:
     The query name acts like a title for the widget on the dashboard.
     """
 
-    def __init__(self, data):
-        # type: (Dict[str, Any]) -> None
+    def __init__(self, data: Dict[str, Any]) -> None:
         self._data = data
 
     @property
@@ -85,23 +80,19 @@ class RedashVisualizationWidget:
         return self._data['visualization']['query']['query']
 
     @property
-    def data_source_id(self):
-        # type: () -> int
+    def data_source_id(self) -> int:
         return self._data['visualization']['query']['data_source_id']
 
     @property
-    def query_id(self):
-        # type: () -> int
+    def query_id(self) -> int:
         return self._data['visualization']['query']['id']
 
     @property
-    def query_relative_url(self):
-        # type: () -> str
+    def query_relative_url(self) -> str:
         return '/queries/{id}'.format(id=self.query_id)
 
     @property
-    def query_name(self):
-        # type: () -> str
+    def query_name(self) -> str:
         return self._data['visualization']['query']['name']
 
 
@@ -111,13 +102,11 @@ class RedashTextWidget:
     It pretty much just contains a single text property (Markdown).
     """
 
-    def __init__(self, data):
-        # type: (Dict[str, Any]) -> None
+    def __init__(self, data: Dict[str, Any]) -> None:
         self._data = data
 
     @property
-    def text(self):
-        # type: () -> str
+    def text(self) -> str:
         return self._data['text']
 
 
@@ -126,27 +115,22 @@ class RedashPaginatedRestApiQuery(RestApiQuery):
     Paginated Redash API queries
     """
 
-    def __init__(self, **kwargs):
-        # type: (...) -> None
+    def __init__(self, **kwargs) -> None:
         super(RedashPaginatedRestApiQuery, self).__init__(**kwargs)
         if 'params' not in self._params:
             self._params['params'] = {}
         self._params['params']['page'] = 1
 
-    def _total_records(self, res):
-        # type: (Dict[str, Any]) -> int
+    def _total_records(self, res: Dict[str, Any]) -> int:
         return res['count']
 
-    def _max_record_on_page(self, res):
-        # type: (Dict[str, Any]) -> int
+    def _max_record_on_page(self, res: Dict[str, Any]) -> int:
         return res['page_size'] * res['page']
 
-    def _next_page(self, res):
-        # type: (Dict[str, Any]) -> int
+    def _next_page(self, res: Dict[str, Any]) -> int:
         return res['page'] + 1
 
-    def _post_process(self, response):
-        # type: (Any) -> None
+    def _post_process(self, response: Any) -> None:
         parsed = response.json()
 
         if self._max_record_on_page(parsed) >= self._total_records(parsed):

--- a/databuilder/extractor/db2_metadata_extractor.py
+++ b/databuilder/extractor/db2_metadata_extractor.py
@@ -52,8 +52,7 @@ class Db2MetadataExtractor(Extractor):
         {WHERE_CLAUSE_SUFFIX_KEY: ' ', CLUSTER_KEY: DEFAULT_CLUSTER_NAME}
     )
 
-    def init(self, conf):
-        # type: (ConfigTree) -> None
+    def init(self, conf: ConfigTree) -> None:
         conf = conf.with_fallback(Db2MetadataExtractor.DEFAULT_CONFIG)
         self._cluster = '{}'.format(conf.get_string(Db2MetadataExtractor.CLUSTER_KEY))
 
@@ -75,10 +74,9 @@ class Db2MetadataExtractor(Extractor):
         LOGGER.info('SQL for Db2 metadata: {}'.format(self.sql_stmt))
 
         self._alchemy_extractor.init(sql_alch_conf)
-        self._extract_iter = None  # type: Union[None, Iterator]
+        self._extract_iter: Union[None, Iterator] = None
 
-    def extract(self):
-        # type: () -> Union[TableMetadata, None]
+    def extract(self) -> Union[TableMetadata, None]:
         if not self._extract_iter:
             self._extract_iter = self._get_extract_iter()
         try:
@@ -86,12 +84,10 @@ class Db2MetadataExtractor(Extractor):
         except StopIteration:
             return None
 
-    def get_scope(self):
-        # type: () -> str
+    def get_scope(self) -> str:
         return 'extractor.db2_metadata'
 
-    def _get_extract_iter(self):
-        # type: () -> Iterator[TableMetadata]
+    def _get_extract_iter(self) -> Iterator[TableMetadata]:
         """
         Using itertools.groupby and raw level iterator, it groups to table and yields TableMetadata
         :return:
@@ -110,8 +106,7 @@ class Db2MetadataExtractor(Extractor):
                                 last_row['description'],
                                 columns)
 
-    def _get_raw_extract_iter(self):
-        # type: () -> Iterator[Dict[str, Any]]
+    def _get_raw_extract_iter(self) -> Iterator[Dict[str, Any]]:
         """
         Provides iterator of result row from SQLAlchemy extractor
         :return:
@@ -121,8 +116,7 @@ class Db2MetadataExtractor(Extractor):
             yield row
             row = self._alchemy_extractor.extract()
 
-    def _get_table_key(self, row):
-        # type: (Dict[str, Any]) -> Union[TableKey, None]
+    def _get_table_key(self, row: Dict[str, Any]) -> Union[TableKey, None]:
         """
         Table key consists of schema and table name
         :param row:

--- a/databuilder/extractor/db_api_extractor.py
+++ b/databuilder/extractor/db_api_extractor.py
@@ -20,8 +20,7 @@ class DBAPIExtractor(Extractor):
     CONNECTION_CONFIG_KEY = 'connection'
     SQL_CONFIG_KEY = 'sql'
 
-    def init(self, conf):
-        # type: (ConfigTree) -> None
+    def init(self, conf: ConfigTree) -> None:
         """
         Receives a {Connection} object and {sql} to execute.
         An optional model class can be passed, in which, sql result row
@@ -31,7 +30,7 @@ class DBAPIExtractor(Extractor):
         :return:
         """
         self.conf = conf
-        self.connection = conf.get(DBAPIExtractor.CONNECTION_CONFIG_KEY)  # type: Any
+        self.connection: Any = conf.get(DBAPIExtractor.CONNECTION_CONFIG_KEY)
         self.cursor = self.connection.cursor()
         self.sql = conf.get(DBAPIExtractor.SQL_CONFIG_KEY)
 
@@ -43,8 +42,7 @@ class DBAPIExtractor(Extractor):
 
         self._iter = iter(self._execute_query())
 
-    def _execute_query(self):
-        # type: () -> Iterable[Any]
+    def _execute_query(self) -> Iterable[Any]:
         """
         Use cursor to execute the {sql}
         :return:
@@ -53,8 +51,7 @@ class DBAPIExtractor(Extractor):
         self.cursor.execute(self.sql)
         return self.cursor.fetchall()
 
-    def extract(self):
-        # type: () -> Any
+    def extract(self) -> Any:
         """
         Fetch one sql result row, convert to {model_class} if specified before
         returning.
@@ -72,8 +69,7 @@ class DBAPIExtractor(Extractor):
         else:
             return result
 
-    def close(self):
-        # type: () -> None
+    def close(self) -> None:
         """
         close cursor and connection handlers
         :return:
@@ -84,6 +80,5 @@ class DBAPIExtractor(Extractor):
         except Exception as e:
             LOGGER.warning("Exception encountered while closing up connection handler!", e)
 
-    def get_scope(self):
-        # type: () -> str
+    def get_scope(self) -> str:
         return 'extractor.dbapi'

--- a/databuilder/extractor/druid_metadata_extractor.py
+++ b/databuilder/extractor/druid_metadata_extractor.py
@@ -43,8 +43,7 @@ class DruidMetadataExtractor(Extractor):
     DEFAULT_CONFIG = ConfigFactory.from_dict({WHERE_CLAUSE_SUFFIX_KEY: ' ',
                                               CLUSTER_KEY: 'gold'})
 
-    def init(self, conf):
-        # type: (ConfigTree) -> None
+    def init(self, conf: ConfigTree) -> None:
         conf = conf.with_fallback(DruidMetadataExtractor.DEFAULT_CONFIG)
         self._cluster = '{}'.format(conf.get_string(DruidMetadataExtractor.CLUSTER_KEY))
 
@@ -57,10 +56,9 @@ class DruidMetadataExtractor(Extractor):
             .with_fallback(ConfigFactory.from_dict({SQLAlchemyExtractor.EXTRACT_SQL: self.sql_stmt}))
 
         self._alchemy_extractor.init(sql_alch_conf)
-        self._extract_iter = None  # type: Union[None, Iterator]
+        self._extract_iter: Union[None, Iterator] = None
 
-    def extract(self):
-        # type: () -> Union[TableMetadata, None]
+    def extract(self) -> Union[TableMetadata, None]:
         if not self._extract_iter:
             self._extract_iter = self._get_extract_iter()
         try:
@@ -68,12 +66,10 @@ class DruidMetadataExtractor(Extractor):
         except StopIteration:
             return None
 
-    def get_scope(self):
-        # type: () -> str
+    def get_scope(self) -> str:
         return 'extractor.druid_metadata'
 
-    def _get_extract_iter(self):
-        # type: () -> Iterator[TableMetadata]
+    def _get_extract_iter(self) -> Iterator[TableMetadata]:
         """
         Using itertools.groupby and raw level iterator, it groups to table and yields TableMetadata
         :return:
@@ -94,8 +90,7 @@ class DruidMetadataExtractor(Extractor):
                                 description='',
                                 columns=columns)
 
-    def _get_raw_extract_iter(self):
-        # type: () -> Iterator[Dict[str, Any]]
+    def _get_raw_extract_iter(self) -> Iterator[Dict[str, Any]]:
         """
         Provides iterator of result row from dbapi extractor
         :return:
@@ -105,8 +100,7 @@ class DruidMetadataExtractor(Extractor):
             yield row
             row = self._alchemy_extractor.extract()
 
-    def _get_table_key(self, row):
-        # type: (Dict[str, Any]) -> Union[TableKey, None]
+    def _get_table_key(self, row: Dict[str, Any]) -> Union[TableKey, None]:
         """
         Table key consists of schema and table name
         :param row:

--- a/databuilder/extractor/generic_extractor.py
+++ b/databuilder/extractor/generic_extractor.py
@@ -15,15 +15,14 @@ class GenericExtractor(Extractor):
     """
     EXTRACTION_ITEMS = 'extraction_items'
 
-    def init(self, conf):
-        # type: (ConfigTree) -> None
+    def init(self, conf: ConfigTree) -> None:
         """
         Receives a list of dictionaries which is used for extraction
         :param conf:
         :return:
         """
         self.conf = conf
-        self.values = conf.get(GenericExtractor.EXTRACTION_ITEMS)  # type: Iterable[Any]
+        self.values: Iterable[Any] = conf.get(GenericExtractor.EXTRACTION_ITEMS)
 
         model_class = conf.get('model_class', None)
         if model_class:
@@ -37,8 +36,7 @@ class GenericExtractor(Extractor):
         else:
             self._iter = iter(self.values)
 
-    def extract(self):
-        # type: () -> Any
+    def extract(self) -> Any:
         """
         Fetch one sql result row, convert to {model_class} if specified before
         returning.
@@ -50,6 +48,5 @@ class GenericExtractor(Extractor):
         except StopIteration:
             return None
 
-    def get_scope(self):
-        # type: () -> str
+    def get_scope(self) -> str:
         return 'extractor.generic'

--- a/databuilder/extractor/glue_extractor.py
+++ b/databuilder/extractor/glue_extractor.py
@@ -4,7 +4,7 @@
 import boto3
 
 from pyhocon import ConfigFactory, ConfigTree  # noqa: F401
-from typing import Iterator, Union, Dict, Any  # noqa: F401
+from typing import Iterator, Union, Dict, Any, List  # noqa: F401
 
 from databuilder.extractor.base_extractor import Extractor
 from databuilder.models.table_metadata import TableMetadata, ColumnMetadata
@@ -19,7 +19,7 @@ class GlueExtractor(Extractor):
     FILTER_KEY = 'filters'
     DEFAULT_CONFIG = ConfigFactory.from_dict({CLUSTER_KEY: 'gold', FILTER_KEY: None})
 
-    def init(self, conf):
+    def init(self, conf: ConfigTree) -> None:
         conf = conf.with_fallback(GlueExtractor.DEFAULT_CONFIG)
         self._cluster = '{}'.format(conf.get_string(GlueExtractor.CLUSTER_KEY))
         self._filters = conf.get(GlueExtractor.FILTER_KEY)
@@ -73,7 +73,7 @@ class GlueExtractor(Extractor):
         tables = self._search_tables()
         return iter(tables)
 
-    def _search_tables(self):
+    def _search_tables(self) -> List[Dict[str, Any]]:
         tables = []
         kwargs = {}
         if self._filters is not None:

--- a/databuilder/extractor/glue_extractor.py
+++ b/databuilder/extractor/glue_extractor.py
@@ -24,10 +24,9 @@ class GlueExtractor(Extractor):
         self._cluster = '{}'.format(conf.get_string(GlueExtractor.CLUSTER_KEY))
         self._filters = conf.get(GlueExtractor.FILTER_KEY)
         self._glue = boto3.client('glue')
-        self._extract_iter = None  # type: Union[None, Iterator]
+        self._extract_iter: Union[None, Iterator] = None
 
-    def extract(self):
-        # type: () -> Union[TableMetadata, None]
+    def extract(self) -> Union[TableMetadata, None]:
         if not self._extract_iter:
             self._extract_iter = self._get_extract_iter()
         try:
@@ -35,12 +34,10 @@ class GlueExtractor(Extractor):
         except StopIteration:
             return None
 
-    def get_scope(self):
-        # type: () -> str
+    def get_scope(self) -> str:
         return 'extractor.glue'
 
-    def _get_extract_iter(self):
-        # type: () -> Iterator[TableMetadata]
+    def _get_extract_iter(self) -> Iterator[TableMetadata]:
         """
         It gets all tables and yields TableMetadata
         :return:
@@ -68,8 +65,7 @@ class GlueExtractor(Extractor):
                 row.get('TableType') == 'VIRTUAL_VIEW',
             )
 
-    def _get_raw_extract_iter(self):
-        # type: () -> Iterator[Dict[str, Any]]
+    def _get_raw_extract_iter(self) -> Iterator[Dict[str, Any]]:
         """
         Provides iterator of results row from glue client
         :return:

--- a/databuilder/extractor/hive_table_last_updated_extractor.py
+++ b/databuilder/extractor/hive_table_last_updated_extractor.py
@@ -21,8 +21,7 @@ LOGGER = logging.getLogger(__name__)
 OLDEST_TIMESTAMP = datetime.fromtimestamp(0, UTC)
 
 
-def fs_error_handler(f):
-    # type: (Any) -> Any
+def fs_error_handler(f: Any) -> Any:
     """
     A Decorator that handles error from FileSystem for HiveTableLastUpdatedExtractor use case
     If it's client side error, it logs in INFO level, and other errors is logged as error level with stacktrace.
@@ -32,8 +31,7 @@ def fs_error_handler(f):
     """
 
     @wraps(f)
-    def wrapper(*args, **kwargs):
-        # type: (Any, Any) -> Any
+    def wrapper(*args: Any, **kwargs: Any) -> Any:
         try:
             return f(*args, **kwargs)
         except Exception as e:
@@ -107,8 +105,7 @@ class HiveTableLastUpdatedExtractor(Extractor):
                                               FS_WORKER_TIMEOUT_SEC: 60,
                                               FILE_CHECK_THRESHOLD: -1})
 
-    def init(self, conf):
-        # type: (ConfigTree) -> None
+    def init(self, conf: ConfigTree) -> None:
         self._conf = conf.with_fallback(HiveTableLastUpdatedExtractor.DEFAULT_CONFIG)
 
         pool_size = self._conf.get_int(HiveTableLastUpdatedExtractor.FS_WORKER_POOL_SIZE)
@@ -125,10 +122,9 @@ class HiveTableLastUpdatedExtractor(Extractor):
         self._last_updated_filecheck_threshold \
             = self._conf.get_int(HiveTableLastUpdatedExtractor.FILE_CHECK_THRESHOLD)
 
-        self._extract_iter = None  # type: Union[None, Iterator]
+        self._extract_iter: Union[None, Iterator] = None
 
-    def _get_partitioned_table_sql_alchemy_extractor(self):
-        # type: (...) -> Extractor
+    def _get_partitioned_table_sql_alchemy_extractor(self) -> Extractor:
         """
         Getting an SQLAlchemy extractor that extracts last updated timestamp for partitioned table.
         :return: SQLAlchemyExtractor
@@ -146,8 +142,7 @@ class HiveTableLastUpdatedExtractor(Extractor):
         sql_alchemy_extractor.init(sql_alchemy_conf)
         return sql_alchemy_extractor
 
-    def _get_non_partitioned_table_sql_alchemy_extractor(self):
-        # type: () -> Extractor
+    def _get_non_partitioned_table_sql_alchemy_extractor(self) -> Extractor:
         """
         Getting an SQLAlchemy extractor that extracts storage location for non-partitioned table for further probing
         last updated timestamp
@@ -175,14 +170,12 @@ class HiveTableLastUpdatedExtractor(Extractor):
         sql_alchemy_extractor.init(sql_alchemy_conf)
         return sql_alchemy_extractor
 
-    def _get_filesystem(self):
-        # type: () -> FileSystem
+    def _get_filesystem(self) -> FileSystem:
         fs = FileSystem()
         fs.init(Scoped.get_scoped_conf(self._conf, fs.get_scope()))
         return fs
 
-    def extract(self):
-        # type: () -> Union[TableLastUpdated, None]
+    def extract(self) -> Union[TableLastUpdated, None]:
         if not self._extract_iter:
             self._extract_iter = self._get_extract_iter()
         try:
@@ -190,12 +183,10 @@ class HiveTableLastUpdatedExtractor(Extractor):
         except StopIteration:
             return None
 
-    def get_scope(self):
-        # type: () -> str
+    def get_scope(self) -> str:
         return 'extractor.hive_table_last_updated'
 
-    def _get_extract_iter(self):
-        # type: () -> Iterator[TableLastUpdated]
+    def _get_extract_iter(self) -> Iterator[TableLastUpdated]:
         """
         An iterator that utilizes Generator pattern. First it provides TableLastUpdated objects for partitioned
         table, straight from partitioned_table_extractor (SQLAlchemyExtractor)
@@ -240,11 +231,10 @@ class HiveTableLastUpdatedExtractor(Extractor):
             non_partitioned_tbl_row = self._non_partitioned_table_extractor.extract()
 
     def _get_last_updated_datetime_from_filesystem(self,
-                                                   table,  # type: str
-                                                   schema,  # type: str
-                                                   storage_location,  # type: str
-                                                   ):
-        # type: (...) -> Union[TableLastUpdated, None]
+                                                   table: str,
+                                                   schema: str,
+                                                   storage_location: str,
+                                                   ) -> Union[TableLastUpdated, None]:
         """
         Fetching metadata within files under storage_location to get latest timestamp.
         (First level only under storage_location)
@@ -303,8 +293,7 @@ class HiveTableLastUpdatedExtractor(Extractor):
         return result
 
     @fs_error_handler
-    def _ls(self, path):
-        # type: (str) -> List[str]
+    def _ls(self, path: str) -> List[str]:
         """
         An wrapper to FileSystem.ls to use fs_error_handler decorator
         :param path:
@@ -314,12 +303,11 @@ class HiveTableLastUpdatedExtractor(Extractor):
 
     @fs_error_handler
     def _get_timestamp(self,
-                       path,  # type: str
-                       schema,  # type: str
-                       table,  # type: str
-                       storage_location,  # type: str
-                       ):
-        # type: (...) -> Union[datetime, None]
+                       path: str,
+                       schema: str,
+                       table: str,
+                       storage_location: str,
+                       ) -> Union[datetime, None]:
         """
         An wrapper to FileSystem.ls to use fs_error_handler decorator
         :param path:

--- a/databuilder/extractor/hive_table_metadata_extractor.py
+++ b/databuilder/extractor/hive_table_metadata_extractor.py
@@ -62,8 +62,7 @@ class HiveTableMetadataExtractor(Extractor):
     DEFAULT_CONFIG = ConfigFactory.from_dict({WHERE_CLAUSE_SUFFIX_KEY: ' ',
                                               CLUSTER_KEY: 'gold'})
 
-    def init(self, conf):
-        # type: (ConfigTree) -> None
+    def init(self, conf: ConfigTree) -> None:
         conf = conf.with_fallback(HiveTableMetadataExtractor.DEFAULT_CONFIG)
         self._cluster = '{}'.format(conf.get_string(HiveTableMetadataExtractor.CLUSTER_KEY))
 
@@ -79,10 +78,9 @@ class HiveTableMetadataExtractor(Extractor):
             .with_fallback(ConfigFactory.from_dict({SQLAlchemyExtractor.EXTRACT_SQL: self.sql_stmt}))
 
         self._alchemy_extractor.init(sql_alch_conf)
-        self._extract_iter = None  # type: Union[None, Iterator]
+        self._extract_iter: Union[None, Iterator] = None
 
-    def extract(self):
-        # type: () -> Union[TableMetadata, None]
+    def extract(self) -> Union[TableMetadata, None]:
         if not self._extract_iter:
             self._extract_iter = self._get_extract_iter()
         try:
@@ -90,12 +88,10 @@ class HiveTableMetadataExtractor(Extractor):
         except StopIteration:
             return None
 
-    def get_scope(self):
-        # type: () -> str
+    def get_scope(self) -> str:
         return 'extractor.hive_table_metadata'
 
-    def _get_extract_iter(self):
-        # type: () -> Iterator[TableMetadata]
+    def _get_extract_iter(self) -> Iterator[TableMetadata]:
         """
         Using itertools.groupby and raw level iterator, it groups to table and yields TableMetadata
         :return:
@@ -115,8 +111,7 @@ class HiveTableMetadataExtractor(Extractor):
                                 columns,
                                 is_view=is_view)
 
-    def _get_raw_extract_iter(self):
-        # type: () -> Iterator[Dict[str, Any]]
+    def _get_raw_extract_iter(self) -> Iterator[Dict[str, Any]]:
         """
         Provides iterator of result row from SQLAlchemy extractor
         :return:
@@ -126,8 +121,7 @@ class HiveTableMetadataExtractor(Extractor):
             yield row
             row = self._alchemy_extractor.extract()
 
-    def _get_table_key(self, row):
-        # type: (Dict[str, Any]) -> Union[TableKey, None]
+    def _get_table_key(self, row: Dict[str, Any]) -> Union[TableKey, None]:
         """
         Table key consists of schema and table name
         :param row:

--- a/databuilder/extractor/kafka_source_extractor.py
+++ b/databuilder/extractor/kafka_source_extractor.py
@@ -112,8 +112,7 @@ class KafkaSourceExtractor(Extractor, Callback):
                     # Users need to figure out how to rewind the consumer offset
                     raise Exception('Encounter exception when transform the record')
 
-    def on_success(self):
-        # Type: () -> None
+    def on_success(self) -> None:
         """
         Commit the offset
         once:
@@ -129,13 +128,11 @@ class KafkaSourceExtractor(Extractor, Callback):
             self.consumer.commit(asynchronous=False)
             self.consumer.close()
 
-    def on_failure(self):
-        # Type: () -> None
+    def on_failure(self) -> None:
         if self.consumer:
             self.consumer.close()
 
-    def consume(self):
-        # Type: () -> Any
+    def consume(self) -> Any:
         """
         Consume messages from a give list of topic
 

--- a/databuilder/extractor/kafka_source_extractor.py
+++ b/databuilder/extractor/kafka_source_extractor.py
@@ -47,13 +47,12 @@ class KafkaSourceExtractor(Extractor, Callback):
     # The value transformer to deserde the Kafka message
     RAW_VALUE_TRANSFORMER = 'raw_value_transformer'
 
-    def init(self, conf):
-        # type: (ConfigTree) -> None
+    def init(self, conf: ConfigTree) -> None:
         self.conf = conf
         self.consumer_config = conf.get_config(KafkaSourceExtractor.CONSUMER_CONFIG).\
             as_plain_ordered_dict()
 
-        self.topic_names = conf.get_list(KafkaSourceExtractor.TOPIC_NAME_LIST)  # type: list
+        self.topic_names: list = conf.get_list(KafkaSourceExtractor.TOPIC_NAME_LIST)
 
         if not self.topic_names:
             raise Exception('Kafka topic needs to be provided by the user.')
@@ -94,8 +93,7 @@ class KafkaSourceExtractor(Extractor, Callback):
         except Exception:
             raise RuntimeError('Consumer could not start correctly!')
 
-    def extract(self):
-        # type: () -> Any
+    def extract(self) -> Any:
         """
         :return: Provides a record or None if no more to extract
         """
@@ -170,6 +168,5 @@ class KafkaSourceExtractor(Extractor, Callback):
         finally:
             return records
 
-    def get_scope(self):
-        # type: () -> str
+    def get_scope(self) -> str:
         return 'extractor.kafka_source'

--- a/databuilder/extractor/kafka_source_extractor.py
+++ b/databuilder/extractor/kafka_source_extractor.py
@@ -6,6 +6,8 @@ import importlib
 import logging
 
 from confluent_kafka import Consumer, KafkaException, KafkaError
+from pyhocon import ConfigTree
+from typing import Any
 
 from databuilder import Scoped
 from databuilder.callback.call_back import Callback

--- a/databuilder/extractor/mssql_metadata_extractor.py
+++ b/databuilder/extractor/mssql_metadata_extractor.py
@@ -73,8 +73,7 @@ class MSSQLMetadataExtractor(Extractor):
 
     DEFAULT_WHERE_CLAUSE_VALUE = 'and tbl.table_schema in {schemas}'
 
-    def init(self, conf):
-        # type: (ConfigTree) -> None
+    def init(self, conf: ConfigTree) -> None:
         conf = conf.with_fallback(MSSQLMetadataExtractor.DEFAULT_CONFIG)
 
         self._cluster = '{}'.format(
@@ -117,10 +116,9 @@ class MSSQLMetadataExtractor(Extractor):
             )
 
         self._alchemy_extractor.init(sql_alch_conf)
-        self._extract_iter = None  # type: Union[None, Iterator]
+        self._extract_iter: Union[None, Iterator] = None
 
-    def extract(self):
-        # type: () -> Union[TableMetadata, None]
+    def extract(self) -> Union[TableMetadata, None]:
         if not self._extract_iter:
             self._extract_iter = self._get_extract_iter()
         try:
@@ -128,12 +126,10 @@ class MSSQLMetadataExtractor(Extractor):
         except StopIteration:
             return None
 
-    def get_scope(self):
-        # type: () -> str
+    def get_scope(self) -> str:
         return 'extractor.mssql_metadata'
 
-    def _get_extract_iter(self):
-        # type: () -> Iterator[TableMetadata]
+    def _get_extract_iter(self) -> Iterator[TableMetadata]:
         """
         Using itertools.groupby and raw level iterator,
         it groups to table and yields TableMetadata
@@ -160,8 +156,7 @@ class MSSQLMetadataExtractor(Extractor):
                 columns,
                 tags=last_row['schema_name'])
 
-    def _get_raw_extract_iter(self):
-        # type: () -> Iterator[Dict[str, Any]]
+    def _get_raw_extract_iter(self) -> Iterator[Dict[str, Any]]:
         """
         Provides iterator of result row from SQLAlchemy extractor
         :return:
@@ -171,8 +166,7 @@ class MSSQLMetadataExtractor(Extractor):
             yield row
             row = self._alchemy_extractor.extract()
 
-    def _get_table_key(self, row):
-        # type: (Dict[str, Any]) -> Union[TableKey, None]
+    def _get_table_key(self, row: Dict[str, Any]) -> Union[TableKey, None]:
         """
         Table key consists of schema and table name
         :param row:

--- a/databuilder/extractor/mysql_metadata_extractor.py
+++ b/databuilder/extractor/mysql_metadata_extractor.py
@@ -58,8 +58,7 @@ class MysqlMetadataExtractor(Extractor):
         {WHERE_CLAUSE_SUFFIX_KEY: ' ', CLUSTER_KEY: DEFAULT_CLUSTER_NAME, USE_CATALOG_AS_CLUSTER_NAME: True}
     )
 
-    def init(self, conf):
-        # type: (ConfigTree) -> None
+    def init(self, conf: ConfigTree) -> None:
         conf = conf.with_fallback(MysqlMetadataExtractor.DEFAULT_CONFIG)
         self._cluster = '{}'.format(conf.get_string(MysqlMetadataExtractor.CLUSTER_KEY))
 
@@ -84,10 +83,9 @@ class MysqlMetadataExtractor(Extractor):
         LOGGER.info('SQL for mysql metadata: {}'.format(self.sql_stmt))
 
         self._alchemy_extractor.init(sql_alch_conf)
-        self._extract_iter = None  # type: Union[None, Iterator]
+        self._extract_iter: Union[None, Iterator] = None
 
-    def extract(self):
-        # type: () -> Union[TableMetadata, None]
+    def extract(self) -> Union[TableMetadata, None]:
         if not self._extract_iter:
             self._extract_iter = self._get_extract_iter()
         try:
@@ -95,12 +93,10 @@ class MysqlMetadataExtractor(Extractor):
         except StopIteration:
             return None
 
-    def get_scope(self):
-        # type: () -> str
+    def get_scope(self) -> str:
         return 'extractor.mysql_metadata'
 
-    def _get_extract_iter(self):
-        # type: () -> Iterator[TableMetadata]
+    def _get_extract_iter(self) -> Iterator[TableMetadata]:
         """
         Using itertools.groupby and raw level iterator, it groups to table and yields TableMetadata
         :return:
@@ -120,8 +116,7 @@ class MysqlMetadataExtractor(Extractor):
                                 columns,
                                 is_view=last_row['is_view'])
 
-    def _get_raw_extract_iter(self):
-        # type: () -> Iterator[Dict[str, Any]]
+    def _get_raw_extract_iter(self) -> Iterator[Dict[str, Any]]:
         """
         Provides iterator of result row from SQLAlchemy extractor
         :return:
@@ -131,8 +126,7 @@ class MysqlMetadataExtractor(Extractor):
             yield row
             row = self._alchemy_extractor.extract()
 
-    def _get_table_key(self, row):
-        # type: (Dict[str, Any]) -> Union[TableKey, None]
+    def _get_table_key(self, row: Dict[str, Any]) -> Union[TableKey, None]:
         """
         Table key consists of schema and table name
         :param row:

--- a/databuilder/extractor/neo4j_es_last_updated_extractor.py
+++ b/databuilder/extractor/neo4j_es_last_updated_extractor.py
@@ -15,8 +15,7 @@ class Neo4jEsLastUpdatedExtractor(GenericExtractor):
     Extractor to extract last updated timestamp for neo4j and Es
     """
 
-    def init(self, conf):
-        # type: (ConfigTree) -> None
+    def init(self, conf: ConfigTree) -> None:
         """
         Receives a list of dictionaries which is used for extraction
         :param conf:
@@ -36,8 +35,7 @@ class Neo4jEsLastUpdatedExtractor(GenericExtractor):
         else:
             raise RuntimeError('model class needs to be provided!')
 
-    def extract(self):
-        # type: () -> Any
+    def extract(self) -> Any:
         """
         Fetch one sql result row, convert to {model_class} if specified before
         returning.
@@ -49,6 +47,5 @@ class Neo4jEsLastUpdatedExtractor(GenericExtractor):
         except StopIteration:
             return None
 
-    def get_scope(self):
-        # type: () -> str
+    def get_scope(self) -> str:
         return 'extractor.neo4j_es_last_updated'

--- a/databuilder/extractor/neo4j_extractor.py
+++ b/databuilder/extractor/neo4j_extractor.py
@@ -33,8 +33,7 @@ class Neo4jExtractor(Extractor):
                                               NEO4J_ENCRYPTED: True,
                                               NEO4J_VALIDATE_SSL: False})
 
-    def init(self, conf):
-        # type: (ConfigTree) -> None
+    def init(self, conf: ConfigTree) -> None:
         """
         Establish connections and import data model class if provided
         :param conf:
@@ -44,7 +43,7 @@ class Neo4jExtractor(Extractor):
         self.cypher_query = conf.get_string(Neo4jExtractor.CYPHER_QUERY_CONFIG_KEY)
         self.driver = self._get_driver()
 
-        self._extract_iter = None  # type: Union[None, Iterator]
+        self._extract_iter: Union[None, Iterator] = None
 
         model_class = conf.get(Neo4jExtractor.MODEL_CLASS_CONFIG_KEY, None)
         if model_class:
@@ -52,8 +51,7 @@ class Neo4jExtractor(Extractor):
             mod = importlib.import_module(module_name)
             self.model_class = getattr(mod, class_name)
 
-    def close(self):
-        # type: () -> None
+    def close(self) -> None:
         """
         close connection to neo4j cluster
         """
@@ -62,8 +60,7 @@ class Neo4jExtractor(Extractor):
         except Exception as e:
             LOGGER.error("Exception encountered while closing the graph driver", e)
 
-    def _get_driver(self):
-        # type: () -> Any
+    def _get_driver(self) -> Any:
         """
         Create a Neo4j connection to Database
         """
@@ -77,8 +74,7 @@ class Neo4jExtractor(Extractor):
                                     encrypted=self.conf.get_bool(Neo4jExtractor.NEO4J_ENCRYPTED),
                                     trust=trust)
 
-    def _execute_query(self, tx):
-        # type: (Any) -> Any
+    def _execute_query(self, tx: Any) -> Any:
         """
         Create an iterator to execute sql.
         """
@@ -86,8 +82,7 @@ class Neo4jExtractor(Extractor):
         result = tx.run(self.cypher_query)
         return result
 
-    def _get_extract_iter(self):
-        # type: () -> Iterator[Any]
+    def _get_extract_iter(self) -> Iterator[Any]:
         """
         Execute {cypher_query} and yield result one at a time
         """
@@ -102,8 +97,7 @@ class Neo4jExtractor(Extractor):
                 else:
                     yield result
 
-    def extract(self):
-        # type: () -> Any
+    def extract(self) -> Any:
         """
         Return {result} object as it is or convert to object of
         {model_class}, if specified.
@@ -116,6 +110,5 @@ class Neo4jExtractor(Extractor):
         except StopIteration:
             return None
 
-    def get_scope(self):
-        # type: () -> str
+    def get_scope(self) -> str:
         return 'extractor.neo4j'

--- a/databuilder/extractor/neo4j_search_data_extractor.py
+++ b/databuilder/extractor/neo4j_search_data_extractor.py
@@ -120,8 +120,7 @@ class Neo4jSearchDataExtractor(Extractor):
         'dashboard': DEFAULT_NEO4J_DASHBOARD_CYPHER_QUERY
     }
 
-    def init(self, conf):
-        # type: (ConfigTree) -> None
+    def init(self, conf: ConfigTree) -> None:
         """
         Initialize Neo4jExtractor object from configuration and use that for extraction
         """
@@ -142,33 +141,30 @@ class Neo4jSearchDataExtractor(Extractor):
         # initialize neo4j_extractor from configs
         self.neo4j_extractor.init(Scoped.get_scoped_conf(self.conf, self.neo4j_extractor.get_scope()))
 
-    def close(self):
-        # type: () -> None
+    def close(self) -> None:
         """
         Use close() method specified by neo4j_extractor
         to close connection to neo4j cluster
         """
         self.neo4j_extractor.close()
 
-    def extract(self):
-        # type: () -> Any
+    def extract(self) -> Any:
         """
         Invoke extract() method defined by neo4j_extractor
         """
         return self.neo4j_extractor.extract()
 
-    def get_scope(self):
-        # type: () -> str
+    def get_scope(self) -> str:
         return 'extractor.search_data'
 
-    def _add_publish_tag_filter(self, publish_tag, cypher_query):
+    def _add_publish_tag_filter(self, publish_tag: str, cypher_query: str) -> str:
         """
         Adds publish tag filter into Cypher query
         :param publish_tag: value of publish tag.
         :param cypher_query:
         :return:
         """
-        # type: (str, str) -> str
+
         if not publish_tag:
             publish_tag_filter = ''
         else:

--- a/databuilder/extractor/postgres_metadata_extractor.py
+++ b/databuilder/extractor/postgres_metadata_extractor.py
@@ -53,8 +53,7 @@ class PostgresMetadataExtractor(Extractor):
         {WHERE_CLAUSE_SUFFIX_KEY: ' ', CLUSTER_KEY: DEFAULT_CLUSTER_NAME, USE_CATALOG_AS_CLUSTER_NAME: True}
     )
 
-    def init(self, conf):
-        # type: (ConfigTree) -> None
+    def init(self, conf: ConfigTree) -> None:
         conf = conf.with_fallback(PostgresMetadataExtractor.DEFAULT_CONFIG)
         self._cluster = '{}'.format(conf.get_string(PostgresMetadataExtractor.CLUSTER_KEY))
 
@@ -79,10 +78,9 @@ class PostgresMetadataExtractor(Extractor):
         LOGGER.info('SQL for postgres metadata: {}'.format(self.sql_stmt))
 
         self._alchemy_extractor.init(sql_alch_conf)
-        self._extract_iter = None  # type: Union[None, Iterator]
+        self._extract_iter: Union[None, Iterator] = None
 
-    def extract(self):
-        # type: () -> Union[TableMetadata, None]
+    def extract(self) -> Union[TableMetadata, None]:
         if not self._extract_iter:
             self._extract_iter = self._get_extract_iter()
         try:
@@ -90,12 +88,10 @@ class PostgresMetadataExtractor(Extractor):
         except StopIteration:
             return None
 
-    def get_scope(self):
-        # type: () -> str
+    def get_scope(self) -> str:
         return 'extractor.postgres_metadata'
 
-    def _get_extract_iter(self):
-        # type: () -> Iterator[TableMetadata]
+    def _get_extract_iter(self) -> Iterator[TableMetadata]:
         """
         Using itertools.groupby and raw level iterator, it groups to table and yields TableMetadata
         :return:
@@ -114,8 +110,7 @@ class PostgresMetadataExtractor(Extractor):
                                 last_row['description'],
                                 columns)
 
-    def _get_raw_extract_iter(self):
-        # type: () -> Iterator[Dict[str, Any]]
+    def _get_raw_extract_iter(self) -> Iterator[Dict[str, Any]]:
         """
         Provides iterator of result row from SQLAlchemy extractor
         :return:
@@ -125,8 +120,7 @@ class PostgresMetadataExtractor(Extractor):
             yield row
             row = self._alchemy_extractor.extract()
 
-    def _get_table_key(self, row):
-        # type: (Dict[str, Any]) -> Union[TableKey, None]
+    def _get_table_key(self, row: Dict[str, Any]) -> Union[TableKey, None]:
         """
         Table key consists of schema and table name
         :param row:

--- a/databuilder/extractor/presto_view_metadata_extractor.py
+++ b/databuilder/extractor/presto_view_metadata_extractor.py
@@ -45,8 +45,7 @@ class PrestoViewMetadataExtractor(Extractor):
     DEFAULT_CONFIG = ConfigFactory.from_dict({WHERE_CLAUSE_SUFFIX_KEY: ' ',
                                               CLUSTER_KEY: 'gold'})
 
-    def init(self, conf):
-        # type: (ConfigTree) -> None
+    def init(self, conf: ConfigTree) -> None:
         conf = conf.with_fallback(PrestoViewMetadataExtractor.DEFAULT_CONFIG)
         self._cluster = '{}'.format(conf.get_string(PrestoViewMetadataExtractor.CLUSTER_KEY))
 
@@ -60,10 +59,9 @@ class PrestoViewMetadataExtractor(Extractor):
             .with_fallback(ConfigFactory.from_dict({SQLAlchemyExtractor.EXTRACT_SQL: self.sql_stmt}))
 
         self._alchemy_extractor.init(sql_alch_conf)
-        self._extract_iter = None  # type: Union[None, Iterator]
+        self._extract_iter: Union[None, Iterator] = None
 
-    def extract(self):
-        # type: () -> Union[TableMetadata, None]
+    def extract(self) -> Union[TableMetadata, None]:
         if not self._extract_iter:
             self._extract_iter = self._get_extract_iter()
         try:
@@ -71,12 +69,10 @@ class PrestoViewMetadataExtractor(Extractor):
         except StopIteration:
             return None
 
-    def get_scope(self):
-        # type: () -> str
+    def get_scope(self) -> str:
         return 'extractor.presto_view_metadata'
 
-    def _get_extract_iter(self):
-        # type: () -> Iterator[TableMetadata]
+    def _get_extract_iter(self) -> Iterator[TableMetadata]:
         """
         Using itertools.groupby and raw level iterator, it groups to table and yields TableMetadata
         :return:
@@ -93,8 +89,8 @@ class PrestoViewMetadataExtractor(Extractor):
                                 is_view=True)
             row = self._alchemy_extractor.extract()
 
-    def _get_column_metadata(self, view_original_text):
-        # type: (str) -> List[ColumnMetadata]
+    def _get_column_metadata(self,
+                             view_original_text: str) -> List[ColumnMetadata]:
         """
         Get Column Metadata from VIEW_ORIGINAL_TEXT from TBLS table for Presto Views.
         Columns are sorted the same way as they appear in Presto Create View SQL.

--- a/databuilder/extractor/presto_view_metadata_extractor.py
+++ b/databuilder/extractor/presto_view_metadata_extractor.py
@@ -6,7 +6,7 @@ import json
 import logging
 
 from pyhocon import ConfigFactory, ConfigTree  # noqa: F401
-from typing import Iterator, Union, Dict, Any  # noqa: F401
+from typing import Iterator, Union, Dict, Any, List  # noqa: F401
 
 from databuilder import Scoped
 from databuilder.extractor.base_extractor import Extractor

--- a/databuilder/extractor/restapi/rest_api_extractor.py
+++ b/databuilder/extractor/restapi/rest_api_extractor.py
@@ -28,11 +28,10 @@ class RestAPIExtractor(Extractor):
     This extractor almost entirely depends on RestApiQuery.
     """
 
-    def init(self, conf):
-        # type: (ConfigTree) -> None
+    def init(self, conf: ConfigTree) -> None:
 
-        self._restapi_query = conf.get(REST_API_QUERY)  # type: BaseRestApiQuery
-        self._iterator = None  # type: Iterator[Dict[str, Any]]
+        self._restapi_query: BaseRestApiQuery = conf.get(REST_API_QUERY)
+        self._iterator: Iterator[Dict[str, Any]] = None
         self._static_dict = conf.get(STATIC_RECORD_DICT, dict())
         LOGGER.info('static record: {}'.format(self._static_dict))
 
@@ -42,8 +41,7 @@ class RestAPIExtractor(Extractor):
             mod = importlib.import_module(module_name)
             self.model_class = getattr(mod, class_name)
 
-    def extract(self):
-        # type: () -> Any
+    def extract(self) -> Any:
         """
         Fetch one result row from RestApiQuery, convert to {model_class} if specified before
         returning.
@@ -66,7 +64,6 @@ class RestAPIExtractor(Extractor):
 
         return record
 
-    def get_scope(self):
-        # type: () -> str
+    def get_scope(self) -> str:
 
         return 'extractor.restapi'

--- a/databuilder/extractor/restapi/rest_api_extractor.py
+++ b/databuilder/extractor/restapi/rest_api_extractor.py
@@ -3,7 +3,7 @@
 
 import logging
 import importlib
-from typing import Iterator, Any  # noqa: F401
+from typing import Any, Iterator, Dict, Optional  # noqa: F401
 
 from pyhocon import ConfigTree  # noqa: F401
 
@@ -31,7 +31,7 @@ class RestAPIExtractor(Extractor):
     def init(self, conf: ConfigTree) -> None:
 
         self._restapi_query: BaseRestApiQuery = conf.get(REST_API_QUERY)
-        self._iterator: Iterator[Dict[str, Any]] = None
+        self._iterator: Optional[Iterator[Dict[str, Any]]] = None
         self._static_dict = conf.get(STATIC_RECORD_DICT, dict())
         LOGGER.info('static record: {}'.format(self._static_dict))
 

--- a/databuilder/extractor/snowflake_metadata_extractor.py
+++ b/databuilder/extractor/snowflake_metadata_extractor.py
@@ -70,8 +70,7 @@ class SnowflakeMetadataExtractor(Extractor):
          SNOWFLAKE_DATABASE_KEY: 'prod'}
     )
 
-    def init(self, conf):
-        # type: (ConfigTree) -> None
+    def init(self, conf: ConfigTree) -> None:
         conf = conf.with_fallback(SnowflakeMetadataExtractor.DEFAULT_CONFIG)
         self._cluster = '{}'.format(conf.get_string(SnowflakeMetadataExtractor.CLUSTER_KEY))
 
@@ -96,10 +95,9 @@ class SnowflakeMetadataExtractor(Extractor):
             .with_fallback(ConfigFactory.from_dict({SQLAlchemyExtractor.EXTRACT_SQL: self.sql_stmt}))
 
         self._alchemy_extractor.init(sql_alch_conf)
-        self._extract_iter = None  # type: Union[None, Iterator]
+        self._extract_iter: Union[None, Iterator] = None
 
-    def extract(self):
-        # type: () -> Union[TableMetadata, None]
+    def extract(self) -> Union[TableMetadata, None]:
         if not self._extract_iter:
             self._extract_iter = self._get_extract_iter()
         try:
@@ -107,12 +105,10 @@ class SnowflakeMetadataExtractor(Extractor):
         except StopIteration:
             return None
 
-    def get_scope(self):
-        # type: () -> str
+    def get_scope(self) -> str:
         return 'extractor.snowflake'
 
-    def _get_extract_iter(self):
-        # type: () -> Iterator[TableMetadata]
+    def _get_extract_iter(self) -> Iterator[TableMetadata]:
         """
         Using itertools.groupby and raw level iterator, it groups to table and yields TableMetadata
         :return:
@@ -136,8 +132,7 @@ class SnowflakeMetadataExtractor(Extractor):
                                 columns,
                                 last_row['is_view'] == 'true')
 
-    def _get_raw_extract_iter(self):
-        # type: () -> Iterator[Dict[str, Any]]
+    def _get_raw_extract_iter(self) -> Iterator[Dict[str, Any]]:
         """
         Provides iterator of result row from SQLAlchemy extractor
         :return:
@@ -147,8 +142,7 @@ class SnowflakeMetadataExtractor(Extractor):
             yield row
             row = self._alchemy_extractor.extract()
 
-    def _get_table_key(self, row):
-        # type: (Dict[str, Any]) -> Union[TableKey, None]
+    def _get_table_key(self, row: Dict[str, Any]) -> Union[TableKey, None]:
         """
         Table key consists of schema and table name
         :param row:

--- a/databuilder/extractor/sql_alchemy_extractor.py
+++ b/databuilder/extractor/sql_alchemy_extractor.py
@@ -18,8 +18,7 @@ class SQLAlchemyExtractor(Extractor):
     An Extractor that extracts records via SQLAlchemy. Database that supports SQLAlchemy can use this extractor
     """
 
-    def init(self, conf):
-        # type: (ConfigTree) -> None
+    def init(self, conf: ConfigTree) -> None:
         """
         Establish connections and import data model class if provided
         :param conf:
@@ -37,8 +36,7 @@ class SQLAlchemyExtractor(Extractor):
             self.model_class = getattr(mod, class_name)
         self._execute_query()
 
-    def _get_connection(self):
-        # type: () -> Any
+    def _get_connection(self) -> Any:
         """
         Create a SQLAlchemy connection to Database
         """
@@ -46,8 +44,7 @@ class SQLAlchemyExtractor(Extractor):
         conn = engine.connect()
         return conn
 
-    def _execute_query(self):
-        # type: () -> None
+    def _execute_query(self) -> None:
         """
         Create an iterator to execute sql.
         """
@@ -61,8 +58,7 @@ class SQLAlchemyExtractor(Extractor):
             results = self.results
         self.iter = iter(results)
 
-    def extract(self):
-        # type: () -> Any
+    def extract(self) -> Any:
         """
         Yield the sql result one at a time.
         convert the result to model if a model_class is provided
@@ -74,6 +70,5 @@ class SQLAlchemyExtractor(Extractor):
         except Exception as e:
             raise e
 
-    def get_scope(self):
-        # type: () -> str
+    def get_scope(self) -> str:
         return 'extractor.sqlalchemy'

--- a/databuilder/filesystem/filesystem.py
+++ b/databuilder/filesystem/filesystem.py
@@ -14,8 +14,7 @@ LOGGER = logging.getLogger(__name__)
 CLIENT_ERRORS = {'ClientError', 'FileNotFoundError', 'ParamValidationError'}
 
 
-def is_client_side_error(e):
-    # type: (Exception) -> bool
+def is_client_side_error(e: Exception) -> bool:
     """
     An method that determines if the error is client side error within FileSystem context
     :param e:
@@ -24,8 +23,7 @@ def is_client_side_error(e):
     return e.__class__.__name__ in CLIENT_ERRORS
 
 
-def is_retriable_error(e):
-    # type: (Exception) -> bool
+def is_retriable_error(e: Exception) -> bool:
     """
     An method that determines if the error is retriable error within FileSystem context
     :param e:
@@ -59,9 +57,8 @@ class FileSystem(Scoped):
     DEFAULT_CONFIG = ConfigFactory.from_dict({FILE_METADATA_MAPPING_KEY: default_metadata_mapping})
 
     def init(self,
-             conf  # type: ConfigTree
-             ):
-        # type: (...) -> None
+             conf: ConfigTree
+             ) -> None:
         """
         Initialize Filesystem with DASK file system instance
         Dask file system supports multiple remote storage such as S3, HDFS, Google cloud storage,
@@ -81,8 +78,7 @@ class FileSystem(Scoped):
 
     @retry(retry_on_exception=is_retriable_error, stop_max_attempt_number=3, wait_exponential_multiplier=1000,
            wait_exponential_max=5000)
-    def ls(self, path):
-        # type: (str) -> List[str]
+    def ls(self, path: str) -> List[str]:
         """
         A scope for the config. Typesafe config supports nested config.
         Scope, string, is used to basically peel off nested config
@@ -92,15 +88,13 @@ class FileSystem(Scoped):
 
     @retry(retry_on_exception=is_retriable_error, stop_max_attempt_number=3, wait_exponential_multiplier=1000,
            wait_exponential_max=5000)
-    def is_file(self, path):
-        # type: (str) -> bool
+    def is_file(self, path: str) -> bool:
         contents = self._dask_fs.ls(path)
         return len(contents) == 1 and contents[0] == path
 
     @retry(retry_on_exception=is_retriable_error, stop_max_attempt_number=3, wait_exponential_multiplier=1000,
            wait_exponential_max=5000)
-    def info(self, path):
-        # type: (str) -> FileMetadata
+    def info(self, path: str) -> FileMetadata:
         """
         Metadata information about the file. It utilizes _metadata_key_mapping when fetching metadata so that it can
         deal with different keys
@@ -112,6 +106,5 @@ class FileSystem(Scoped):
                           size=metadata_dict[self._metadata_key_mapping[FileSystem.SIZE]])
         return fm
 
-    def get_scope(self):
-        # type: () -> str
+    def get_scope(self) -> str:
         return 'filesystem'

--- a/databuilder/filesystem/metadata.py
+++ b/databuilder/filesystem/metadata.py
@@ -7,16 +7,14 @@ from datetime import datetime  # noqa: F401
 class FileMetadata(object):
 
     def __init__(self,
-                 path,  # type: str
-                 last_updated,  # type: datetime
-                 size  # type: int
-                 ):
-        # type: (...) -> None
+                 path: str,
+                 last_updated: datetime,
+                 size: int
+                 ) -> None:
         self.path = path
         self.last_updated = last_updated
         self.size = size
 
-    def __repr__(self):
-        # type: () -> str
+    def __repr__(self) -> str:
         return """FileMetadata(path={!r}, last_updated={!r}, size={!r})""" \
             .format(self.path, self.last_updated, self.size)

--- a/databuilder/job/base_job.py
+++ b/databuilder/job/base_job.py
@@ -16,19 +16,16 @@ class Job(Scoped):
     A Databuilder job that represents single work unit.
     """
     @abc.abstractmethod
-    def init(self, conf):
-        # type: (ConfigTree) -> None
+    def init(self, conf: ConfigTree) -> None:
         pass
 
     @abc.abstractmethod
-    def launch(self):
-        # type: () -> None
+    def launch(self) -> None:
         """
         Launch a job
         :return: None
         """
         pass
 
-    def get_scope(self):
-        # type: () -> str
+    def get_scope(self) -> str:
         return 'job'

--- a/databuilder/job/job.py
+++ b/databuilder/job/job.py
@@ -30,10 +30,9 @@ class DefaultJob(Job):
     """
 
     def __init__(self,
-                 conf,
-                 task,
-                 publisher=NoopPublisher()):
-        # type: (ConfigTree, Task, Publisher) -> None
+                 conf: ConfigTree,
+                 task: Task,
+                 publisher: Publisher = NoopPublisher()) -> None:
         self.task = task
         self.conf = conf
         self.publisher = publisher
@@ -46,16 +45,13 @@ class DefaultJob(Job):
         else:
             self.statsd = None
 
-    def init(self, conf):
-        # type: (ConfigTree) -> None
+    def init(self, conf: ConfigTree) -> None:
         pass
 
-    def _init(self):
-        # type: () -> None
+    def _init(self) -> None:
         self.task.init(self.conf)
 
-    def launch(self):
-        # type: () -> None
+    def launch(self) -> None:
         """
         Launch a job by initializing job, run task and publish.
         :return:

--- a/databuilder/loader/base_loader.py
+++ b/databuilder/loader/base_loader.py
@@ -14,15 +14,12 @@ class Loader(Scoped):
     A loader loads to the destination or to the staging area
     """
     @abc.abstractmethod
-    def init(self, conf):
-        # type: (ConfigTree) -> None
+    def init(self, conf: ConfigTree) -> None:
         pass
 
     @abc.abstractmethod
-    def load(self, record):
-        # type: (Any) -> None
+    def load(self, record: Any) -> None:
         pass
 
-    def get_scope(self):
-        # type: () -> str
+    def get_scope(self) -> str:
         return 'loader'

--- a/databuilder/loader/file_system_csv_loader.py
+++ b/databuilder/loader/file_system_csv_loader.py
@@ -15,8 +15,7 @@ class FileSystemCSVLoader(Loader):
     Loader class to write csv files to Local FileSystem
     """
 
-    def init(self, conf):
-        # type: (ConfigTree) -> None
+    def init(self, conf: ConfigTree) -> None:
         """
         Initialize file handlers from conf
         :param conf:
@@ -27,8 +26,7 @@ class FileSystemCSVLoader(Loader):
 
         self.file_handler = open(self.file_path, self.file_mode)
 
-    def load(self, record):
-        # type: (Any) -> None
+    def load(self, record: Any) -> None:
         """
         Write record object as csv to file
         :param record:
@@ -45,8 +43,7 @@ class FileSystemCSVLoader(Loader):
         self.writer.writerow(vars(record))
         self.file_handler.flush()
 
-    def close(self):
-        # type: () -> None
+    def close(self) -> None:
         """
         Close file handlers
         :return:
@@ -58,6 +55,5 @@ class FileSystemCSVLoader(Loader):
             logging.warning("Failed trying to close a file handler! %s",
                             str(e))
 
-    def get_scope(self):
-        # type: () -> str
+    def get_scope(self) -> str:
         return "loader.filesystem.csv"

--- a/databuilder/loader/file_system_elasticsearch_json_loader.py
+++ b/databuilder/loader/file_system_elasticsearch_json_loader.py
@@ -16,8 +16,7 @@ class FSElasticsearchJSONLoader(Loader):
     FILE_PATH_CONFIG_KEY = 'file_path'
     FILE_MODE_CONFIG_KEY = 'mode'
 
-    def init(self, conf):
-        # type: (ConfigTree) -> None
+    def init(self, conf: ConfigTree) -> None:
         """
 
         :param conf:
@@ -31,8 +30,7 @@ class FSElasticsearchJSONLoader(Loader):
         self._ensure_directory_exists(file_dir)
         self.file_handler = open(self.file_path, self.file_mode)
 
-    def _ensure_directory_exists(self, path):
-        # type: (str) -> None
+    def _ensure_directory_exists(self, path: str) -> None:
         """
         Check to ensure file directory exists; create the directories otherwise
         :param path:
@@ -43,8 +41,7 @@ class FSElasticsearchJSONLoader(Loader):
 
         os.makedirs(path)
 
-    def load(self, record):
-        # type: (ElasticsearchDocument) -> None
+    def load(self, record: ElasticsearchDocument) -> None:
         """
         Write a record in json format to file
         :param record:
@@ -59,8 +56,7 @@ class FSElasticsearchJSONLoader(Loader):
         self.file_handler.write(record.to_json())
         self.file_handler.flush()
 
-    def close(self):
-        # type: () -> None
+    def close(self) -> None:
         """
         close the file handler
         :return:
@@ -68,6 +64,5 @@ class FSElasticsearchJSONLoader(Loader):
         if self.file_handler:
             self.file_handler.close()
 
-    def get_scope(self):
-        # type: () -> str
+    def get_scope(self) -> str:
         return 'loader.filesystem.elasticsearch'

--- a/databuilder/loader/file_system_neo4j_csv_loader.py
+++ b/databuilder/loader/file_system_neo4j_csv_loader.py
@@ -38,14 +38,12 @@ class FsNeo4jCSVLoader(Loader):
         FORCE_CREATE_DIR: False
     })
 
-    def __init__(self):
-        # type: () -> None
-        self._node_file_mapping = {}  # type: Dict[Any, DictWriter]
-        self._relation_file_mapping = {}  # type: Dict[Any, DictWriter]
+    def __init__(self) -> None:
+        self._node_file_mapping: Dict[Any, DictWriter] = {}
+        self._relation_file_mapping: Dict[Any, DictWriter] = {}
         self._closer = Closer()
 
-    def init(self, conf):
-        # type: (ConfigTree) -> None
+    def init(self, conf: ConfigTree) -> None:
         """
         Initializing FsNeo4jCsvLoader by creating directory for node files
         and relationship files. Note that the directory defined in
@@ -65,8 +63,7 @@ class FsNeo4jCSVLoader(Loader):
         self._create_directory(self._node_dir)
         self._create_directory(self._relation_dir)
 
-    def _create_directory(self, path):
-        # type: (str) -> None
+    def _create_directory(self, path: str) -> None:
         """
         Validate directory does not exist, creates it, register deletion of
         created directory function to Job.closer.
@@ -82,8 +79,7 @@ class FsNeo4jCSVLoader(Loader):
 
         os.makedirs(path)
 
-        def _delete_dir():
-            # type: () -> None
+        def _delete_dir() -> None:
             if not self._delete_created_dir:
                 LOGGER.warn('Skip Deleting directory {}'.format(path))
                 return
@@ -94,8 +90,7 @@ class FsNeo4jCSVLoader(Loader):
         # Directory should be deleted after publish is finished
         Job.closer.register(_delete_dir)
 
-    def load(self, csv_serializable):
-        # type: (Neo4jCsvSerializable) -> None
+    def load(self, csv_serializable: Neo4jCsvSerializable) -> None:
         """
         Writes Neo4jCsvSerializable into CSV files.
         There are multiple CSV files that this method writes.
@@ -141,13 +136,12 @@ class FsNeo4jCSVLoader(Loader):
             relation_dict = csv_serializable.next_relation()
 
     def _get_writer(self,
-                    csv_record_dict,  # type: Dict[str, Any]
-                    file_mapping,  # type: Dict[Any, DictWriter]
-                    key,  # type: Any
-                    dir_path,  # type: str
-                    file_suffix  # type: str
-                    ):
-        # type: (...) -> DictWriter
+                    csv_record_dict: Dict[str, Any],
+                    file_mapping: Dict[Any, DictWriter],
+                    key: Any,
+                    dir_path: str,
+                    file_suffix: str
+                    ) -> DictWriter:
         """
         Finds a writer based on csv record, key.
         If writer does not exist, it's creates a csv writer and update the
@@ -169,8 +163,7 @@ class FsNeo4jCSVLoader(Loader):
         writer = csv.DictWriter(file_out, fieldnames=csv_record_dict.keys(),
                                 quoting=csv.QUOTE_NONNUMERIC)
 
-        def file_out_close():
-            # type: () -> None
+        def file_out_close() -> None:
             LOGGER.info('Closing file IO {}'.format(file_out))
             file_out.close()
         self._closer.register(file_out_close)
@@ -180,14 +173,12 @@ class FsNeo4jCSVLoader(Loader):
 
         return writer
 
-    def close(self):
-        # type: () -> None
+    def close(self) -> None:
         """
         Any closeable callable registered in _closer, it will close.
         :return:
         """
         self._closer.close()
 
-    def get_scope(self):
-        # type: () -> str
+    def get_scope(self) -> str:
         return "loader.filesystem_csv_neo4j"

--- a/databuilder/loader/generic_loader.py
+++ b/databuilder/loader/generic_loader.py
@@ -27,8 +27,7 @@ class GenericLoader(Loader):
     Loader class to call back a function provided by user
     """
 
-    def init(self, conf):
-        # type: (ConfigTree) -> None
+    def init(self, conf: ConfigTree) -> None:
         """
         Initialize file handlers from conf
         :param conf:
@@ -36,8 +35,7 @@ class GenericLoader(Loader):
         self.conf = conf
         self._callback_func = self.conf.get(CALLBACK_FUNCTION, log_call_back)
 
-    def load(self, record):
-        # type: (Optional[Any]) -> None
+    def load(self, record: Optional[Any]) -> None:
         """
         Write record to function
         :param record:
@@ -48,10 +46,8 @@ class GenericLoader(Loader):
 
         self._callback_func(record)
 
-    def close(self):
-        # type: () -> None
+    def close(self) -> None:
         pass
 
-    def get_scope(self):
-        # type: () -> str
+    def get_scope(self) -> str:
         return "loader.generic"

--- a/databuilder/loader/generic_loader.py
+++ b/databuilder/loader/generic_loader.py
@@ -13,7 +13,7 @@ LOGGER = logging.getLogger(__name__)
 CALLBACK_FUNCTION = 'callback_function'
 
 
-def log_call_back(record):
+def log_call_back(record: Optional[Any]) -> None:
     """
     A Sample callback function. Implement any function follows this function's signature to fit your needs.
     :param record:

--- a/databuilder/models/application.py
+++ b/databuilder/models/application.py
@@ -29,7 +29,7 @@ class Application(Neo4jCsvSerializable):
 
     def __init__(self,
                  task_id: str,
-                 dag_id: str,,
+                 dag_id: str,
                  application_url_template: str,
                  db_name: str = 'hive',
                  cluster: str = 'gold',

--- a/databuilder/models/application.py
+++ b/databuilder/models/application.py
@@ -28,16 +28,15 @@ class Application(Neo4jCsvSerializable):
     TABLE_APPLICATION_RELATION_TYPE = 'DERIVED_FROM'
 
     def __init__(self,
-                 task_id,  # type: str
-                 dag_id,  # type: str,
-                 application_url_template,  # type: str
-                 db_name='hive',  # type: str
-                 cluster='gold',  # type: str
-                 schema='',  # type: str
-                 table_name='',  # type: str
-                 exec_date='',  # type: str
-                 ):
-        # type: (...) -> None
+                 task_id: str,
+                 dag_id: str,,
+                 application_url_template: str,
+                 db_name: str = 'hive',
+                 cluster: str = 'gold',
+                 schema: str = '',
+                 table_name: str = '',
+                 exec_date: str = '',
+                 ) -> None:
         self.task = task_id
 
         # todo: need to modify this hack
@@ -49,38 +48,33 @@ class Application(Neo4jCsvSerializable):
         self._node_iter = iter(self.create_nodes())
         self._relation_iter = iter(self.create_relation())
 
-    def create_next_node(self):
-        # type: (...) -> Union[Dict[str, Any], None]
+    def create_next_node(self) -> Union[Dict[str, Any], None]:
         # creates new node
         try:
             return next(self._node_iter)
         except StopIteration:
             return None
 
-    def create_next_relation(self):
-        # type: (...) -> Union[Dict[str, Any], None]
+    def create_next_relation(self) -> Union[Dict[str, Any], None]:
         try:
             return next(self._relation_iter)
         except StopIteration:
             return None
 
-    def get_table_model_key(self):
-        # type: (...) -> str
+    def get_table_model_key(self) -> str:
         # returns formatted string for table name
         return TableMetadata.TABLE_KEY_FORMAT.format(db=self.database,
                                                      schema=self.schema,
                                                      tbl=self.table,
                                                      cluster=self.cluster)
 
-    def get_application_model_key(self):
-        # type: (...) -> str
+    def get_application_model_key(self) -> str:
         # returns formatting string for application of type dag
         return Application.APPLICATION_KEY_FORMAT.format(cluster=self.cluster,
                                                          dag=self.dag,
                                                          task=self.task)
 
-    def create_nodes(self):
-        # type: () -> List[Dict[str, Any]]
+    def create_nodes(self) -> List[Dict[str, Any]]:
         """
         Create a list of Neo4j node records
         :return:
@@ -102,8 +96,7 @@ class Application(Neo4jCsvSerializable):
 
         return results
 
-    def create_relation(self):
-        # type: () -> List[Dict[str, Any]]
+    def create_relation(self) -> List[Dict[str, Any]]:
         """
         Create a list of relations between application and table nodes
         :return:

--- a/databuilder/models/column_usage_model.py
+++ b/databuilder/models/column_usage_model.py
@@ -30,15 +30,14 @@ class ColumnUsageModel(Neo4jCsvSerializable):
     READ_RELATION_COUNT = READ_RELATION_COUNT_PROPERTY
 
     def __init__(self,
-                 database,     # type: str
-                 cluster,      # type: str
-                 schema,  # type: str
-                 table_name,   # type: str
-                 column_name,  # type: str
-                 user_email,   # type: str
-                 read_count,   # type: int
-                 ):
-        # type: (...) -> None
+                 database: str,
+                 cluster: str,
+                 schema: str,
+                 table_name: str,
+                 column_name: str,
+                 user_email: str,
+                 read_count: int,
+                 ) -> None:
         self.database = database
         self.cluster = cluster
         self.schema = schema
@@ -50,16 +49,14 @@ class ColumnUsageModel(Neo4jCsvSerializable):
         self._node_iter = iter(self.create_nodes())
         self._relation_iter = iter(self.create_relation())
 
-    def create_next_node(self):
-        # type: () -> Union[Dict[str, Any], None]
+    def create_next_node(self) -> Union[Dict[str, Any], None]:
 
         try:
             return next(self._node_iter)
         except StopIteration:
             return None
 
-    def create_nodes(self):
-        # type: () -> List[Dict[str, Any]]
+    def create_nodes(self) -> List[Dict[str, Any]]:
         """
         Create a list of Neo4j node records
         :return:
@@ -67,16 +64,14 @@ class ColumnUsageModel(Neo4jCsvSerializable):
 
         return User(email=self.user_email).create_nodes()
 
-    def create_next_relation(self):
-        # type: () -> Union[Dict[str, Any], None]
+    def create_next_relation(self) -> Union[Dict[str, Any], None]:
 
         try:
             return next(self._relation_iter)
         except StopIteration:
             return None
 
-    def create_relation(self):
-        # type: () -> Iterator[Any]
+    def create_relation(self) -> Iterator[Any]:
         return [{
             RELATION_START_LABEL: TableMetadata.TABLE_NODE_LABEL,
             RELATION_END_LABEL: User.USER_NODE_LABEL,
@@ -87,19 +82,16 @@ class ColumnUsageModel(Neo4jCsvSerializable):
             ColumnUsageModel.READ_RELATION_COUNT: self.read_count
         }]
 
-    def _get_table_key(self):
-        # type: (ColumnReader) -> str
+    def _get_table_key(self: ColumnReader) -> str:
         return TableMetadata.TABLE_KEY_FORMAT.format(db=self.database,
                                                      cluster=self.cluster,
                                                      schema=self.schema,
                                                      tbl=self.table_name)
 
-    def _get_user_key(self, email):
-        # type: (str) -> str
+    def _get_user_key(self, email: str) -> str:
         return User.get_user_model_key(email=email)
 
-    def __repr__(self):
-        # type: () -> str
+    def __repr__(self) -> str:
         return 'TableColumnUsage({!r}, {!r}, {!r}, {!r}, {!r}, {!r}, {!r})'.format(self.database,
                                                                                    self.cluster,
                                                                                    self.schema,

--- a/databuilder/models/column_usage_model.py
+++ b/databuilder/models/column_usage_model.py
@@ -1,7 +1,7 @@
 # Copyright Contributors to the Amundsen project.
 # SPDX-License-Identifier: Apache-2.0
 
-from typing import Union, Dict, Any, Iterator  # noqa: F401
+from typing import Union, Dict, Any, Iterable, List  # noqa: F401
 
 from databuilder.models.neo4j_csv_serde import (
     Neo4jCsvSerializable, RELATION_START_KEY, RELATION_END_KEY,
@@ -71,7 +71,7 @@ class ColumnUsageModel(Neo4jCsvSerializable):
         except StopIteration:
             return None
 
-    def create_relation(self) -> Iterator[Any]:
+    def create_relation(self) -> Iterable[Any]:
         return [{
             RELATION_START_LABEL: TableMetadata.TABLE_NODE_LABEL,
             RELATION_END_LABEL: User.USER_NODE_LABEL,
@@ -82,7 +82,7 @@ class ColumnUsageModel(Neo4jCsvSerializable):
             ColumnUsageModel.READ_RELATION_COUNT: self.read_count
         }]
 
-    def _get_table_key(self: ColumnReader) -> str:
+    def _get_table_key(self) -> str:
         return TableMetadata.TABLE_KEY_FORMAT.format(db=self.database,
                                                      cluster=self.cluster,
                                                      schema=self.schema,

--- a/databuilder/models/dashboard/dashboard_chart.py
+++ b/databuilder/models/dashboard/dashboard_chart.py
@@ -24,15 +24,15 @@ class DashboardChart(Neo4jCsvSerializable):
     CHART_REVERSE_RELATION_TYPE = 'CHART_OF'
 
     def __init__(self,
-                 dashboard_group_id,  # type: Optional[str]
-                 dashboard_id,  # type: Optional[str]
-                 query_id,  # type: str
-                 chart_id,  # type: str
-                 chart_name=None,  # type: Optional[str]
-                 chart_type=None,  # type: Optional[str]
-                 chart_url=None,  # type: Optional[str]
-                 product='',  # type: Optional[str]
-                 cluster='gold',  # type: str
+                 dashboard_group_id: Optional[str],
+                 dashboard_id: Optional[str],
+                 query_id: str,
+                 chart_id: str,
+                 chart_name: Optional[str] = None,
+                 chart_type: Optional[str] = None,
+                 chart_url: Optional[str] = None,
+                 product: Optional[str] = '',
+                 cluster: str = 'gold',
                  **kwargs
                  ):
         self._dashboard_group_id = dashboard_group_id
@@ -47,15 +47,13 @@ class DashboardChart(Neo4jCsvSerializable):
         self._node_iterator = self._create_node_iterator()
         self._relation_iterator = self._create_relation_iterator()
 
-    def create_next_node(self):
-        # type: () -> Union[Dict[str, Any], None]
+    def create_next_node(self) -> Union[Dict[str, Any], None]:
         try:
             return next(self._node_iterator)
         except StopIteration:
             return None
 
-    def _create_node_iterator(self):  # noqa: C901
-        # type: () -> Iterator[[Dict[str, Any]]]
+    def _create_node_iterator(self) -> Iterator[[Dict[str, Any]]]:  # noqa: C901
         node = {
             NODE_LABEL: DashboardChart.DASHBOARD_CHART_LABEL,
             NODE_KEY: self._get_chart_node_key(),
@@ -73,15 +71,13 @@ class DashboardChart(Neo4jCsvSerializable):
 
         yield node
 
-    def create_next_relation(self):
-        # type: () -> Union[Dict[str, Any], None]
+    def create_next_relation(self) -> Union[Dict[str, Any], None]:
         try:
             return next(self._relation_iterator)
         except StopIteration:
             return None
 
-    def _create_relation_iterator(self):
-        # type: () -> Iterator[[Dict[str, Any]]]
+    def _create_relation_iterator(self) -> Iterator[[Dict[str, Any]]]:
         yield {
             RELATION_START_LABEL: DashboardQuery.DASHBOARD_QUERY_LABEL,
             RELATION_END_LABEL: DashboardChart.DASHBOARD_CHART_LABEL,

--- a/databuilder/models/dashboard/dashboard_chart.py
+++ b/databuilder/models/dashboard/dashboard_chart.py
@@ -33,8 +33,8 @@ class DashboardChart(Neo4jCsvSerializable):
                  chart_url: Optional[str] = None,
                  product: Optional[str] = '',
                  cluster: str = 'gold',
-                 **kwargs
-                 ):
+                 **kwargs: Any
+                 ) -> None:
         self._dashboard_group_id = dashboard_group_id
         self._dashboard_id = dashboard_id
         self._query_id = query_id
@@ -93,7 +93,7 @@ class DashboardChart(Neo4jCsvSerializable):
             RELATION_REVERSE_TYPE: DashboardChart.CHART_REVERSE_RELATION_TYPE
         }
 
-    def _get_chart_node_key(self):
+    def _get_chart_node_key(self) -> str:
         return DashboardChart.DASHBOARD_CHART_KEY_FORMAT.format(
             product=self._product,
             cluster=self._cluster,
@@ -103,7 +103,7 @@ class DashboardChart(Neo4jCsvSerializable):
             chart_id=self._chart_id
         )
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return 'DashboardChart({!r}, {!r}, {!r}, {!r}, {!r}, {!r}, {!r}, {!r}, {!r})'.format(
             self._dashboard_group_id,
             self._dashboard_id,

--- a/databuilder/models/dashboard/dashboard_chart.py
+++ b/databuilder/models/dashboard/dashboard_chart.py
@@ -53,7 +53,7 @@ class DashboardChart(Neo4jCsvSerializable):
         except StopIteration:
             return None
 
-    def _create_node_iterator(self) -> Iterator[[Dict[str, Any]]]:  # noqa: C901
+    def _create_node_iterator(self) -> Iterator[Dict[str, Any]]:  # noqa: C901
         node = {
             NODE_LABEL: DashboardChart.DASHBOARD_CHART_LABEL,
             NODE_KEY: self._get_chart_node_key(),
@@ -77,7 +77,7 @@ class DashboardChart(Neo4jCsvSerializable):
         except StopIteration:
             return None
 
-    def _create_relation_iterator(self) -> Iterator[[Dict[str, Any]]]:
+    def _create_relation_iterator(self) -> Iterator[Dict[str, Any]]:
         yield {
             RELATION_START_LABEL: DashboardQuery.DASHBOARD_QUERY_LABEL,
             RELATION_END_LABEL: DashboardChart.DASHBOARD_CHART_LABEL,

--- a/databuilder/models/dashboard/dashboard_execution.py
+++ b/databuilder/models/dashboard/dashboard_execution.py
@@ -27,13 +27,13 @@ class DashboardExecution(Neo4jCsvSerializable):
     LAST_SUCCESSFUL_EXECUTION_ID = '_last_successful_execution'
 
     def __init__(self,
-                 dashboard_group_id,  # type: Optional[str]
-                 dashboard_id,  # type: Optional[str]
-                 execution_timestamp,  # type: int
-                 execution_state,  # type: str
-                 execution_id=LAST_EXECUTION_ID,  # type: str
-                 product='',  # type: Optional[str]
-                 cluster='gold',  # type: str
+                 dashboard_group_id: Optional[str],
+                 dashboard_id: Optional[str],
+                 execution_timestamp: int,
+                 execution_state: str,
+                 execution_id: str = LAST_EXECUTION_ID,
+                 product: Optional[str] = '',
+                 cluster: str = 'gold',
                  **kwargs
                  ):
         self._dashboard_group_id = dashboard_group_id
@@ -46,15 +46,13 @@ class DashboardExecution(Neo4jCsvSerializable):
         self._node_iterator = self._create_node_iterator()
         self._relation_iterator = self._create_relation_iterator()
 
-    def create_next_node(self):
-        # type: () -> Union[Dict[str, Any], None]
+    def create_next_node(self) -> Union[Dict[str, Any], None]:
         try:
             return next(self._node_iterator)
         except StopIteration:
             return None
 
-    def _create_node_iterator(self):  # noqa: C901
-        # type: () -> Iterator[[Dict[str, Any]]]
+    def _create_node_iterator(self) -> Iterator[[Dict[str, Any]]]:  # noqa: C901
         yield {
             NODE_LABEL: DashboardExecution.DASHBOARD_EXECUTION_LABEL,
             NODE_KEY: self._get_last_execution_node_key(),
@@ -62,15 +60,13 @@ class DashboardExecution(Neo4jCsvSerializable):
             'state': self._execution_state
         }
 
-    def create_next_relation(self):
-        # type: () -> Union[Dict[str, Any], None]
+    def create_next_relation(self) -> Union[Dict[str, Any], None]:
         try:
             return next(self._relation_iterator)
         except StopIteration:
             return None
 
-    def _create_relation_iterator(self):
-        # type: () -> Iterator[[Dict[str, Any]]]
+    def _create_relation_iterator(self) -> Iterator[[Dict[str, Any]]]:
         yield {
             RELATION_START_LABEL: DashboardMetadata.DASHBOARD_NODE_LABEL,
             RELATION_END_LABEL: DashboardExecution.DASHBOARD_EXECUTION_LABEL,

--- a/databuilder/models/dashboard/dashboard_execution.py
+++ b/databuilder/models/dashboard/dashboard_execution.py
@@ -52,7 +52,7 @@ class DashboardExecution(Neo4jCsvSerializable):
         except StopIteration:
             return None
 
-    def _create_node_iterator(self) -> Iterator[[Dict[str, Any]]]:  # noqa: C901
+    def _create_node_iterator(self) -> Iterator[Dict[str, Any]]:  # noqa: C901
         yield {
             NODE_LABEL: DashboardExecution.DASHBOARD_EXECUTION_LABEL,
             NODE_KEY: self._get_last_execution_node_key(),
@@ -66,7 +66,7 @@ class DashboardExecution(Neo4jCsvSerializable):
         except StopIteration:
             return None
 
-    def _create_relation_iterator(self) -> Iterator[[Dict[str, Any]]]:
+    def _create_relation_iterator(self) -> Iterator[Dict[str, Any]]:
         yield {
             RELATION_START_LABEL: DashboardMetadata.DASHBOARD_NODE_LABEL,
             RELATION_END_LABEL: DashboardExecution.DASHBOARD_EXECUTION_LABEL,

--- a/databuilder/models/dashboard/dashboard_execution.py
+++ b/databuilder/models/dashboard/dashboard_execution.py
@@ -34,8 +34,8 @@ class DashboardExecution(Neo4jCsvSerializable):
                  execution_id: str = LAST_EXECUTION_ID,
                  product: Optional[str] = '',
                  cluster: str = 'gold',
-                 **kwargs
-                 ):
+                 **kwargs: Any
+                 ) -> None:
         self._dashboard_group_id = dashboard_group_id
         self._dashboard_id = dashboard_id
         self._execution_timestamp = execution_timestamp
@@ -81,7 +81,7 @@ class DashboardExecution(Neo4jCsvSerializable):
             RELATION_REVERSE_TYPE: DashboardExecution.EXECUTION_DASHBOARD_RELATION_TYPE
         }
 
-    def _get_last_execution_node_key(self):
+    def _get_last_execution_node_key(self) -> str:
         return DashboardExecution.DASHBOARD_EXECUTION_KEY_FORMAT.format(
             product=self._product,
             cluster=self._cluster,
@@ -90,7 +90,7 @@ class DashboardExecution(Neo4jCsvSerializable):
             execution_id=self._execution_id
         )
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return 'DashboardExecution({!r}, {!r}, {!r}, {!r}, {!r}, {!r}, {!r})'.format(
             self._dashboard_group_id,
             self._dashboard_id,

--- a/databuilder/models/dashboard/dashboard_last_modified.py
+++ b/databuilder/models/dashboard/dashboard_last_modified.py
@@ -44,7 +44,7 @@ class DashboardLastModifiedTimestamp(Neo4jCsvSerializable):
         except StopIteration:
             return None
 
-    def _create_node_iterator(self) -> Iterator[[Dict[str, Any]]]:  # noqa: C901
+    def _create_node_iterator(self) -> Iterator[Dict[str, Any]]:  # noqa: C901
         yield {
             NODE_LABEL: timestamp_constants.NODE_LABEL,
             NODE_KEY: self._get_last_modified_node_key(),
@@ -58,7 +58,7 @@ class DashboardLastModifiedTimestamp(Neo4jCsvSerializable):
         except StopIteration:
             return None
 
-    def _create_relation_iterator(self) -> Iterator[[Dict[str, Any]]]:
+    def _create_relation_iterator(self) -> Iterator[Dict[str, Any]]:
         yield {
             RELATION_START_LABEL: DashboardMetadata.DASHBOARD_NODE_LABEL,
             RELATION_END_LABEL: timestamp_constants.NODE_LABEL,

--- a/databuilder/models/dashboard/dashboard_last_modified.py
+++ b/databuilder/models/dashboard/dashboard_last_modified.py
@@ -29,7 +29,7 @@ class DashboardLastModifiedTimestamp(Neo4jCsvSerializable):
                  product: Optional[str] = '',
                  cluster: str = 'gold',
                  **kwargs: Any
-                 ):
+                 ) -> None:
         self._dashboard_group_id = dashboard_group_id
         self._dashboard_id = dashboard_id
         self._last_modified_timestamp = last_modified_timestamp
@@ -73,7 +73,7 @@ class DashboardLastModifiedTimestamp(Neo4jCsvSerializable):
             RELATION_REVERSE_TYPE: timestamp_constants.LASTUPDATED_REVERSE_RELATION_TYPE
         }
 
-    def _get_last_modified_node_key(self):
+    def _get_last_modified_node_key(self) -> str:
         return DashboardLastModifiedTimestamp.DASHBOARD_LAST_MODIFIED_KEY_FORMAT.format(
             product=self._product,
             cluster=self._cluster,
@@ -81,7 +81,7 @@ class DashboardLastModifiedTimestamp(Neo4jCsvSerializable):
             dashboard_id=self._dashboard_id,
         )
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return 'DashboardLastModifiedTimestamp({!r}, {!r}, {!r}, {!r}, {!r})'.format(
             self._dashboard_group_id,
             self._dashboard_id,

--- a/databuilder/models/dashboard/dashboard_last_modified.py
+++ b/databuilder/models/dashboard/dashboard_last_modified.py
@@ -23,11 +23,11 @@ class DashboardLastModifiedTimestamp(Neo4jCsvSerializable):
                                          '{dashboard_id}/_last_modified_timestamp'
 
     def __init__(self,
-                 dashboard_group_id,  # type: Optional[str]
-                 dashboard_id,  # type: Optional[str]
-                 last_modified_timestamp,  # type: int
-                 product='',  # type: Optional[str]
-                 cluster='gold',  # type: str
+                 dashboard_group_id: Optional[str],
+                 dashboard_id: Optional[str],
+                 last_modified_timestamp: int,
+                 product: Optional[str] = '',
+                 cluster: str = 'gold',
                  **kwargs
                  ):
         self._dashboard_group_id = dashboard_group_id
@@ -38,15 +38,13 @@ class DashboardLastModifiedTimestamp(Neo4jCsvSerializable):
         self._node_iterator = self._create_node_iterator()
         self._relation_iterator = self._create_relation_iterator()
 
-    def create_next_node(self):
-        # type: () -> Union[Dict[str, Any], None]
+    def create_next_node(self) -> Union[Dict[str, Any], None]:
         try:
             return next(self._node_iterator)
         except StopIteration:
             return None
 
-    def _create_node_iterator(self):  # noqa: C901
-        # type: () -> Iterator[[Dict[str, Any]]]
+    def _create_node_iterator(self) -> Iterator[[Dict[str, Any]]]:  # noqa: C901
         yield {
             NODE_LABEL: timestamp_constants.NODE_LABEL,
             NODE_KEY: self._get_last_modified_node_key(),
@@ -54,15 +52,13 @@ class DashboardLastModifiedTimestamp(Neo4jCsvSerializable):
             timestamp_constants.TIMESTAMP_NAME_PROPERTY: timestamp_constants.TimestampName.last_updated_timestamp.name,
         }
 
-    def create_next_relation(self):
-        # type: () -> Union[Dict[str, Any], None]
+    def create_next_relation(self) -> Union[Dict[str, Any], None]:
         try:
             return next(self._relation_iterator)
         except StopIteration:
             return None
 
-    def _create_relation_iterator(self):
-        # type: () -> Iterator[[Dict[str, Any]]]
+    def _create_relation_iterator(self) -> Iterator[[Dict[str, Any]]]:
         yield {
             RELATION_START_LABEL: DashboardMetadata.DASHBOARD_NODE_LABEL,
             RELATION_END_LABEL: timestamp_constants.NODE_LABEL,

--- a/databuilder/models/dashboard/dashboard_last_modified.py
+++ b/databuilder/models/dashboard/dashboard_last_modified.py
@@ -28,7 +28,7 @@ class DashboardLastModifiedTimestamp(Neo4jCsvSerializable):
                  last_modified_timestamp: int,
                  product: Optional[str] = '',
                  cluster: str = 'gold',
-                 **kwargs
+                 **kwargs: Any
                  ):
         self._dashboard_group_id = dashboard_group_id
         self._dashboard_id = dashboard_id

--- a/databuilder/models/dashboard/dashboard_metadata.py
+++ b/databuilder/models/dashboard/dashboard_metadata.py
@@ -73,7 +73,7 @@ class DashboardMetadata(Neo4jCsvSerializable):
                  created_timestamp: Optional[int] = None,
                  dashboard_group_url: Optional[str] = None,
                  dashboard_url: Optional[str] = None,
-                 **kwargs
+                 **kwargs: Any
                  ) -> None:
 
         self.dashboard_group = dashboard_group
@@ -88,8 +88,8 @@ class DashboardMetadata(Neo4jCsvSerializable):
         self.created_timestamp = created_timestamp
         self.dashboard_group_url = dashboard_group_url
         self.dashboard_url = dashboard_url
-        self._processed_cluster = set()
-        self._processed_dashboard_group = set()
+        self._processed_cluster: Set[str] = set()
+        self._processed_dashboard_group: Set[str] = set()
         self._node_iterator = self._create_next_node()
         self._relation_iterator = self._create_next_relation()
 
@@ -133,12 +133,6 @@ class DashboardMetadata(Neo4jCsvSerializable):
                                                                    cluster=self.cluster,
                                                                    product=self.product)
 
-    def _get_dashboard_last_reload_time_key(self) -> str:
-        return DashboardMetadata.DASHBOARD_LAST_RELOAD_TIME_FORMAT.format(dashboard_group=self.dashboard_group,
-                                                                          dashboard_name=self.dashboard_id,
-                                                                          cluster=self.cluster,
-                                                                          product=self.product)
-
     def create_next_node(self) -> Union[Dict[str, Any], None]:
         try:
             return next(self._node_iterator)
@@ -156,7 +150,7 @@ class DashboardMetadata(Neo4jCsvSerializable):
             }
 
         # Dashboard node
-        dashboard_node = {
+        dashboard_node: Dict[str, Any] = {
             NODE_LABEL: DashboardMetadata.DASHBOARD_NODE_LABEL,
             NODE_KEY: self._get_dashboard_key(),
             DashboardMetadata.DASHBOARD_NAME: self.dashboard_name,

--- a/databuilder/models/dashboard/dashboard_metadata.py
+++ b/databuilder/models/dashboard/dashboard_metadata.py
@@ -57,25 +57,24 @@ class DashboardMetadata(Neo4jCsvSerializable):
     DASHBOARD_TAG_RELATION_TYPE = 'TAG'
     TAG_DASHBOARD_RELATION_TYPE = 'TAG_OF'
 
-    serialized_nodes = set()  # type: Set[Any]
-    serialized_rels = set()  # type: Set[Any]
+    serialized_nodes: Set[Any] = set()
+    serialized_rels: Set[Any] = set()
 
     def __init__(self,
-                 dashboard_group,  # type: str
-                 dashboard_name,  # type: str
-                 description,  # type: Union[str, None]
-                 tags=None,  # type: List
-                 cluster='gold',  # type: str
-                 product='',  # type: Optional[str]
-                 dashboard_group_id=None,  # type: Optional[str]
-                 dashboard_id=None,  # type: Optional[str]
-                 dashboard_group_description=None,  # type: Optional[str]
-                 created_timestamp=None,  # type: Optional[int]
-                 dashboard_group_url=None,  # type: Optional[str]
-                 dashboard_url=None,  # type: Optional[str]
+                 dashboard_group: str,
+                 dashboard_name: str,
+                 description: Union[str, None],
+                 tags: List = None,
+                 cluster: str = 'gold',
+                 product: Optional[str] = '',
+                 dashboard_group_id: Optional[str] = None,
+                 dashboard_id: Optional[str] = None,
+                 dashboard_group_description: Optional[str] = None,
+                 created_timestamp: Optional[int] = None,
+                 dashboard_group_url: Optional[str] = None,
+                 dashboard_url: Optional[str] = None,
                  **kwargs
-                 ):
-        # type: (...) -> None
+                 ) -> None:
 
         self.dashboard_group = dashboard_group
         self.dashboard_name = dashboard_name
@@ -94,8 +93,7 @@ class DashboardMetadata(Neo4jCsvSerializable):
         self._node_iterator = self._create_next_node()
         self._relation_iterator = self._create_next_relation()
 
-    def __repr__(self):
-        # type: () -> str
+    def __repr__(self) -> str:
         return 'DashboardMetadata({!r}, {!r}, {!r}, {!r}, {!r}, {!r}, {!r}, {!r}, {!r}, {!r})' \
             .format(self.dashboard_group,
                     self.dashboard_name,
@@ -109,53 +107,45 @@ class DashboardMetadata(Neo4jCsvSerializable):
                     self.dashboard_url,
                     )
 
-    def _get_cluster_key(self):
-        # type: () -> str
+    def _get_cluster_key(self) -> str:
         return DashboardMetadata.CLUSTER_KEY_FORMAT.format(cluster=self.cluster,
                                                            product=self.product)
 
-    def _get_dashboard_key(self):
-        # type: () -> str
+    def _get_dashboard_key(self) -> str:
         return DashboardMetadata.DASHBOARD_KEY_FORMAT.format(dashboard_group=self.dashboard_group_id,
                                                              dashboard_name=self.dashboard_id,
                                                              cluster=self.cluster,
                                                              product=self.product)
 
-    def _get_dashboard_description_key(self):
-        # type: () -> str
+    def _get_dashboard_description_key(self) -> str:
         return DashboardMetadata.DASHBOARD_DESCRIPTION_FORMAT.format(dashboard_group=self.dashboard_group_id,
                                                                      dashboard_name=self.dashboard_id,
                                                                      cluster=self.cluster,
                                                                      product=self.product)
 
-    def _get_dashboard_group_description_key(self):
-        # type: () -> str
+    def _get_dashboard_group_description_key(self) -> str:
         return DashboardMetadata.DASHBOARD_GROUP_DESCRIPTION_KEY_FORMAT.format(dashboard_group=self.dashboard_group_id,
                                                                                cluster=self.cluster,
                                                                                product=self.product)
 
-    def _get_dashboard_group_key(self):
-        # type: () -> str
+    def _get_dashboard_group_key(self) -> str:
         return DashboardMetadata.DASHBOARD_GROUP_KEY_FORMAT.format(dashboard_group=self.dashboard_group_id,
                                                                    cluster=self.cluster,
                                                                    product=self.product)
 
-    def _get_dashboard_last_reload_time_key(self):
-        # type: () -> str
+    def _get_dashboard_last_reload_time_key(self) -> str:
         return DashboardMetadata.DASHBOARD_LAST_RELOAD_TIME_FORMAT.format(dashboard_group=self.dashboard_group,
                                                                           dashboard_name=self.dashboard_id,
                                                                           cluster=self.cluster,
                                                                           product=self.product)
 
-    def create_next_node(self):
-        # type: () -> Union[Dict[str, Any], None]
+    def create_next_node(self) -> Union[Dict[str, Any], None]:
         try:
             return next(self._node_iterator)
         except StopIteration:
             return None
 
-    def _create_next_node(self):
-        # type: () -> Iterator[Any]
+    def _create_next_node(self) -> Iterator[Any]:
         # Cluster node
         if not self._get_cluster_key() in self._processed_cluster:
             self._processed_cluster.add(self._get_cluster_key())
@@ -212,15 +202,13 @@ class DashboardMetadata(Neo4jCsvSerializable):
                        NODE_KEY: TagMetadata.get_tag_key(tag),
                        TagMetadata.TAG_TYPE: 'dashboard'}
 
-    def create_next_relation(self):
-        # type: () -> Union[Dict[str, Any], None]
+    def create_next_relation(self) -> Union[Dict[str, Any], None]:
         try:
             return next(self._relation_iterator)
         except StopIteration:
             return None
 
-    def _create_next_relation(self):
-        # type: () -> Iterator[Any]
+    def _create_next_relation(self) -> Iterator[Any]:
 
         # Cluster <-> Dashboard group
         yield {

--- a/databuilder/models/dashboard/dashboard_metadata.py
+++ b/databuilder/models/dashboard/dashboard_metadata.py
@@ -3,7 +3,7 @@
 
 from collections import namedtuple
 
-from typing import Any, Union, Iterator, Dict, Set, Optional  # noqa: F401
+from typing import Any, Dict, Iterator, List, Optional, Set, Union  # noqa: F401
 
 from databuilder.models.cluster import cluster_constants
 from databuilder.models.neo4j_csv_serde import (

--- a/databuilder/models/dashboard/dashboard_owner.py
+++ b/databuilder/models/dashboard/dashboard_owner.py
@@ -51,7 +51,7 @@ class DashboardOwner(Neo4jCsvSerializable):
         except StopIteration:
             return None
 
-    def _create_relation_iterator(self) -> Iterator[[Dict[str, Any]]]:
+    def _create_relation_iterator(self) -> Iterator[Dict[str, Any]]:
         yield {
             RELATION_START_LABEL: DashboardMetadata.DASHBOARD_NODE_LABEL,
             RELATION_END_LABEL: User.USER_NODE_LABEL,

--- a/databuilder/models/dashboard/dashboard_owner.py
+++ b/databuilder/models/dashboard/dashboard_owner.py
@@ -32,8 +32,8 @@ class DashboardOwner(Neo4jCsvSerializable):
                  email: str,
                  product: Optional[str] = '',
                  cluster: str = 'gold',
-                 **kwargs
-                 ):
+                 **kwargs: Any
+                 ) -> None:
         self._dashboard_group_id = dashboard_group_id
         self._dashboard_id = dashboard_id
         self._email = email
@@ -66,7 +66,7 @@ class DashboardOwner(Neo4jCsvSerializable):
             RELATION_REVERSE_TYPE: OWNER_OF_OBJECT_RELATION_TYPE
         }
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return 'DashboardOwner({!r}, {!r}, {!r}, {!r}, {!r})'.format(
             self._dashboard_group_id,
             self._dashboard_id,

--- a/databuilder/models/dashboard/dashboard_owner.py
+++ b/databuilder/models/dashboard/dashboard_owner.py
@@ -27,11 +27,11 @@ class DashboardOwner(Neo4jCsvSerializable):
     EXECUTION_DASHBOARD_RELATION_TYPE = 'LAST_EXECUTION_OF'
 
     def __init__(self,
-                 dashboard_group_id,  # type: str
-                 dashboard_id,  # type: str
-                 email,  # type: str
-                 product='',  # type: Optional[str]
-                 cluster='gold',  # type: str
+                 dashboard_group_id: str,
+                 dashboard_id: str,
+                 email: str,
+                 product: Optional[str] = '',
+                 cluster: str = 'gold',
                  **kwargs
                  ):
         self._dashboard_group_id = dashboard_group_id
@@ -42,19 +42,16 @@ class DashboardOwner(Neo4jCsvSerializable):
 
         self._relation_iterator = self._create_relation_iterator()
 
-    def create_next_node(self):
-        # type: () -> Union[Dict[str, Any], None]
+    def create_next_node(self) -> Union[Dict[str, Any], None]:
         return None
 
-    def create_next_relation(self):
-        # type: () -> Union[Dict[str, Any], None]
+    def create_next_relation(self) -> Union[Dict[str, Any], None]:
         try:
             return next(self._relation_iterator)
         except StopIteration:
             return None
 
-    def _create_relation_iterator(self):
-        # type: () -> Iterator[[Dict[str, Any]]]
+    def _create_relation_iterator(self) -> Iterator[[Dict[str, Any]]]:
         yield {
             RELATION_START_LABEL: DashboardMetadata.DASHBOARD_NODE_LABEL,
             RELATION_END_LABEL: User.USER_NODE_LABEL,

--- a/databuilder/models/dashboard/dashboard_query.py
+++ b/databuilder/models/dashboard/dashboard_query.py
@@ -24,14 +24,14 @@ class DashboardQuery(Neo4jCsvSerializable):
     QUERY_DASHBOARD_RELATION_TYPE = 'QUERY_OF'
 
     def __init__(self,
-                 dashboard_group_id,  # type: Optional[str]
-                 dashboard_id,  # type: Optional[str]
-                 query_name,  # type: str
-                 query_id=None,  # type: Optional[str]
-                 url='',  # type: Optional[str]
-                 query_text=None,  # type: Optional[str]
-                 product='',  # type: Optional[str]
-                 cluster='gold',  # type: str
+                 dashboard_group_id: Optional[str],
+                 dashboard_id: Optional[str],
+                 query_name: str,
+                 query_id: Optional[str] = None,
+                 url: Optional[str] = '',
+                 query_text: Optional[str] = None,
+                 product: Optional[str] = '',
+                 cluster: str = 'gold',
                  **kwargs
                  ):
         self._dashboard_group_id = dashboard_group_id
@@ -45,15 +45,13 @@ class DashboardQuery(Neo4jCsvSerializable):
         self._node_iterator = self._create_node_iterator()
         self._relation_iterator = self._create_relation_iterator()
 
-    def create_next_node(self):
-        # type: () -> Union[Dict[str, Any], None]
+    def create_next_node(self) -> Union[Dict[str, Any], None]:
         try:
             return next(self._node_iterator)
         except StopIteration:
             return None
 
-    def _create_node_iterator(self):  # noqa: C901
-        # type: () -> Iterator[[Dict[str, Any]]]
+    def _create_node_iterator(self) -> Iterator[[Dict[str, Any]]]:  # noqa: C901
         node = {
             NODE_LABEL: DashboardQuery.DASHBOARD_QUERY_LABEL,
             NODE_KEY: self._get_query_node_key(),
@@ -69,15 +67,13 @@ class DashboardQuery(Neo4jCsvSerializable):
 
         yield node
 
-    def create_next_relation(self):
-        # type: () -> Union[Dict[str, Any], None]
+    def create_next_relation(self) -> Union[Dict[str, Any], None]:
         try:
             return next(self._relation_iterator)
         except StopIteration:
             return None
 
-    def _create_relation_iterator(self):
-        # type: () -> Iterator[[Dict[str, Any]]]
+    def _create_relation_iterator(self) -> Iterator[[Dict[str, Any]]]:
         yield {
             RELATION_START_LABEL: DashboardMetadata.DASHBOARD_NODE_LABEL,
             RELATION_END_LABEL: DashboardQuery.DASHBOARD_QUERY_LABEL,

--- a/databuilder/models/dashboard/dashboard_query.py
+++ b/databuilder/models/dashboard/dashboard_query.py
@@ -51,7 +51,7 @@ class DashboardQuery(Neo4jCsvSerializable):
         except StopIteration:
             return None
 
-    def _create_node_iterator(self) -> Iterator[[Dict[str, Any]]]:  # noqa: C901
+    def _create_node_iterator(self) -> Iterator[Dict[str, Any]]:  # noqa: C901
         node = {
             NODE_LABEL: DashboardQuery.DASHBOARD_QUERY_LABEL,
             NODE_KEY: self._get_query_node_key(),
@@ -73,7 +73,7 @@ class DashboardQuery(Neo4jCsvSerializable):
         except StopIteration:
             return None
 
-    def _create_relation_iterator(self) -> Iterator[[Dict[str, Any]]]:
+    def _create_relation_iterator(self) -> Iterator[Dict[str, Any]]:
         yield {
             RELATION_START_LABEL: DashboardMetadata.DASHBOARD_NODE_LABEL,
             RELATION_END_LABEL: DashboardQuery.DASHBOARD_QUERY_LABEL,

--- a/databuilder/models/dashboard/dashboard_query.py
+++ b/databuilder/models/dashboard/dashboard_query.py
@@ -32,8 +32,8 @@ class DashboardQuery(Neo4jCsvSerializable):
                  query_text: Optional[str] = None,
                  product: Optional[str] = '',
                  cluster: str = 'gold',
-                 **kwargs
-                 ):
+                 **kwargs: Any
+                 ) -> None:
         self._dashboard_group_id = dashboard_group_id
         self._dashboard_id = dashboard_id
         self._query_name = query_name
@@ -88,7 +88,7 @@ class DashboardQuery(Neo4jCsvSerializable):
             RELATION_REVERSE_TYPE: DashboardQuery.QUERY_DASHBOARD_RELATION_TYPE
         }
 
-    def _get_query_node_key(self):
+    def _get_query_node_key(self) -> str:
         return DashboardQuery.DASHBOARD_QUERY_KEY_FORMAT.format(
             product=self._product,
             cluster=self._cluster,
@@ -97,7 +97,7 @@ class DashboardQuery(Neo4jCsvSerializable):
             query_id=self._query_id
         )
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return 'DashboardQuery({!r}, {!r}, {!r}, {!r}, {!r}, {!r}, {!r}, {!r})'.format(
             self._dashboard_group_id,
             self._dashboard_id,

--- a/databuilder/models/dashboard/dashboard_table.py
+++ b/databuilder/models/dashboard/dashboard_table.py
@@ -27,11 +27,11 @@ class DashboardTable(Neo4jCsvSerializable):
     TABLE_DASHBOARD_RELATION_TYPE = 'TABLE_OF_DASHBOARD'
 
     def __init__(self,
-                 dashboard_group_id,  # type: str
-                 dashboard_id,  # type: str
-                 table_ids,  # type: List[str]
-                 product='',  # type: Optional[str]
-                 cluster='gold',  # type: str
+                 dashboard_group_id: str,
+                 dashboard_id: str,
+                 table_ids: List[str],
+                 product: Optional[str] = '',
+                 cluster: str = 'gold',
                  **kwargs
                  ):
         self._dashboard_group_id = dashboard_group_id
@@ -43,19 +43,16 @@ class DashboardTable(Neo4jCsvSerializable):
 
         self._relation_iterator = self._create_relation_iterator()
 
-    def create_next_node(self):
-        # type: () -> Union[Dict[str, Any], None]
+    def create_next_node(self) -> Union[Dict[str, Any], None]:
         return None
 
-    def create_next_relation(self):
-        # type: () -> Union[Dict[str, Any], None]
+    def create_next_relation(self) -> Union[Dict[str, Any], None]:
         try:
             return next(self._relation_iterator)
         except StopIteration:
             return None
 
-    def _create_relation_iterator(self):
-        # type: () -> Optional[None, Iterator[[Dict[str, Any]]]]
+    def _create_relation_iterator(self) -> Optional[None, Iterator[[Dict[str, Any]]]]:
         for table_id in self._table_ids:
             m = re.match('(\w+)://(\w+)\.(\w+)\/(\w+)', table_id)
             if m:

--- a/databuilder/models/dashboard/dashboard_table.py
+++ b/databuilder/models/dashboard/dashboard_table.py
@@ -52,7 +52,7 @@ class DashboardTable(Neo4jCsvSerializable):
         except StopIteration:
             return None
 
-    def _create_relation_iterator(self) -> Optional[None, Iterator[[Dict[str, Any]]]]:
+    def _create_relation_iterator(self) -> Optional[Iterator[Dict[str, Any]]]:
         for table_id in self._table_ids:
             m = re.match('(\w+)://(\w+)\.(\w+)\/(\w+)', table_id)
             if m:

--- a/databuilder/models/dashboard/dashboard_table.py
+++ b/databuilder/models/dashboard/dashboard_table.py
@@ -32,8 +32,8 @@ class DashboardTable(Neo4jCsvSerializable):
                  table_ids: List[str],
                  product: Optional[str] = '',
                  cluster: str = 'gold',
-                 **kwargs
-                 ):
+                 **kwargs: Any
+                 ) -> None:
         self._dashboard_group_id = dashboard_group_id
         self._dashboard_id = dashboard_id
         # A list of tables uri used in the dashboard
@@ -47,6 +47,9 @@ class DashboardTable(Neo4jCsvSerializable):
         return None
 
     def create_next_relation(self) -> Union[Dict[str, Any], None]:
+        if self._relation_iterator is None:
+            return None
+
         try:
             return next(self._relation_iterator)
         except StopIteration:
@@ -75,7 +78,7 @@ class DashboardTable(Neo4jCsvSerializable):
                     RELATION_REVERSE_TYPE: DashboardTable.TABLE_DASHBOARD_RELATION_TYPE
                 }
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return 'DashboardTable({!r}, {!r}, {!r}, {!r}, ({!r}))'.format(
             self._dashboard_group_id,
             self._dashboard_id,

--- a/databuilder/models/dashboard/dashboard_usage.py
+++ b/databuilder/models/dashboard/dashboard_usage.py
@@ -23,16 +23,15 @@ class DashboardUsage(Neo4jCsvSerializable):
     """
 
     def __init__(self,
-                 dashboard_group_id,  # type: Optional[str]
-                 dashboard_id,  # type: Optional[str]
-                 email,  # type: str
-                 view_count,  # type: int
-                 should_create_user_node=False,  # type: Optional[bool]
-                 product='',  # type: Optional[str]
-                 cluster='gold',  # type: Optional[str]
+                 dashboard_group_id: Optional[str],
+                 dashboard_id: Optional[str],
+                 email: str,
+                 view_count: int,
+                 should_create_user_node: Optional[bool] = False,
+                 product: Optional[str] = '',
+                 cluster: Optional[str] = 'gold',
                  **kwargs
-                 ):
-        # type: () -> None
+                 ) -> None:
         """
 
         :param dashboard_group_id:
@@ -57,20 +56,17 @@ class DashboardUsage(Neo4jCsvSerializable):
         self._should_create_user_node = bool(should_create_user_node)
         self._relation_iterator = self._create_relation_iterator()
 
-    def create_next_node(self):
-        # type: () -> Union[Dict[str, Any], None]
+    def create_next_node(self) -> Union[Dict[str, Any], None]:
         if self._should_create_user_node:
             return self._user_model.create_next_node()
 
-    def create_next_relation(self):
-        # type: () -> Union[Dict[str, Any], None]
+    def create_next_relation(self) -> Union[Dict[str, Any], None]:
         try:
             return next(self._relation_iterator)
         except StopIteration:
             return None
 
-    def _create_relation_iterator(self):
-        # type: () -> Iterator[[Dict[str, Any]]]
+    def _create_relation_iterator(self) -> Iterator[[Dict[str, Any]]]:
 
         yield {
             RELATION_START_LABEL: DashboardMetadata.DASHBOARD_NODE_LABEL,

--- a/databuilder/models/dashboard/dashboard_usage.py
+++ b/databuilder/models/dashboard/dashboard_usage.py
@@ -66,7 +66,7 @@ class DashboardUsage(Neo4jCsvSerializable):
         except StopIteration:
             return None
 
-    def _create_relation_iterator(self) -> Iterator[[Dict[str, Any]]]:
+    def _create_relation_iterator(self) -> Iterator[Dict[str, Any]]:
 
         yield {
             RELATION_START_LABEL: DashboardMetadata.DASHBOARD_NODE_LABEL,

--- a/databuilder/models/dashboard/dashboard_usage.py
+++ b/databuilder/models/dashboard/dashboard_usage.py
@@ -30,7 +30,7 @@ class DashboardUsage(Neo4jCsvSerializable):
                  should_create_user_node: Optional[bool] = False,
                  product: Optional[str] = '',
                  cluster: Optional[str] = 'gold',
-                 **kwargs
+                 **kwargs: Any
                  ) -> None:
         """
 
@@ -60,6 +60,8 @@ class DashboardUsage(Neo4jCsvSerializable):
         if self._should_create_user_node:
             return self._user_model.create_next_node()
 
+        return None
+
     def create_next_relation(self) -> Union[Dict[str, Any], None]:
         try:
             return next(self._relation_iterator)
@@ -67,7 +69,6 @@ class DashboardUsage(Neo4jCsvSerializable):
             return None
 
     def _create_relation_iterator(self) -> Iterator[Dict[str, Any]]:
-
         yield {
             RELATION_START_LABEL: DashboardMetadata.DASHBOARD_NODE_LABEL,
             RELATION_END_LABEL: User.USER_NODE_LABEL,
@@ -83,7 +84,7 @@ class DashboardUsage(Neo4jCsvSerializable):
             READ_RELATION_COUNT_PROPERTY: self._view_count
         }
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return 'DashboardUsage({!r}, {!r}, {!r}, {!r}, {!r}, {!r}, {!r})'.format(
             self._dashboard_group_id,
             self._dashboard_id,

--- a/databuilder/models/dashboard_elasticsearch_document.py
+++ b/databuilder/models/dashboard_elasticsearch_document.py
@@ -12,22 +12,21 @@ class DashboardESDocument(ElasticsearchDocument):
     """
 
     def __init__(self,
-                 group_name,  # type: str
-                 name,  # type: str
-                 description,  # type: Union[str, None]
-                 total_usage,  # type: int
-                 product='',  # type: Optional[str]
-                 cluster='',  # type: Optional[str]
-                 group_description=None,  # type: Optional[str]
-                 query_names=None,  # type:  Union[List[str], None]
-                 group_url=None,  # type: Optional[str]
-                 url=None,  # type: Optional[str]
-                 uri=None,  # type: Optional[str]
-                 last_successful_run_timestamp=None,  # type: Optional[int]
-                 tags=None,  # type: Optional[list[str]]
-                 badges=None,  # type: Optional[list[str]]
-                 ):
-        # type: (...) -> None
+                 group_name: str,
+                 name: str,
+                 description: Union[str, None],
+                 total_usage: int,
+                 product: Optional[str] = '',
+                 cluster: Optional[str] = '',
+                 group_description: Optional[str] = None,
+                 query_names: Union[List[str], None] = None,
+                 group_url: Optional[str] = None,
+                 url: Optional[str] = None,
+                 uri: Optional[str] = None,
+                 last_successful_run_timestamp: Optional[int] = None,
+                 tags: Optional[list[str]] = None,
+                 badges: Optional[list[str]] = None,
+                 ) -> None:
         self.group_name = group_name
         self.name = name
         self.description = description

--- a/databuilder/models/dashboard_elasticsearch_document.py
+++ b/databuilder/models/dashboard_elasticsearch_document.py
@@ -1,7 +1,7 @@
 # Copyright Contributors to the Amundsen project.
 # SPDX-License-Identifier: Apache-2.0
 
-from typing import List, Optional  # noqa: F401
+from typing import List, Optional, Union  # noqa: F401
 
 from databuilder.models.elasticsearch_document import ElasticsearchDocument
 

--- a/databuilder/models/dashboard_elasticsearch_document.py
+++ b/databuilder/models/dashboard_elasticsearch_document.py
@@ -24,8 +24,8 @@ class DashboardESDocument(ElasticsearchDocument):
                  url: Optional[str] = None,
                  uri: Optional[str] = None,
                  last_successful_run_timestamp: Optional[int] = None,
-                 tags: Optional[list[str]] = None,
-                 badges: Optional[list[str]] = None,
+                 tags: Optional[List[str]] = None,
+                 badges: Optional[List[str]] = None,
                  ) -> None:
         self.group_name = group_name
         self.name = name

--- a/databuilder/models/elasticsearch_document.py
+++ b/databuilder/models/elasticsearch_document.py
@@ -12,8 +12,7 @@ class ElasticsearchDocument:
     """
     __metaclass__ = ABCMeta
 
-    def to_json(self):
-        # type: () -> str
+    def to_json(self) -> str:
         """
         Convert object to json
         :return:

--- a/databuilder/models/metric_elasticsearch_document.py
+++ b/databuilder/models/metric_elasticsearch_document.py
@@ -12,13 +12,12 @@ class MetricESDocument(ElasticsearchDocument):
     """
 
     def __init__(self,
-                 name,  # type: str
-                 description,  # type: str
-                 type,  # type: str
-                 dashboards,  # type: List
-                 tags,  # type: List
-                 ):
-        # type: (...) -> None
+                 name: str,
+                 description: str,
+                 type: str,
+                 dashboards: List,
+                 tags: List,
+                 ) -> None:
         self.name = name
         self.description = description
         self.type = type

--- a/databuilder/models/metric_metadata.py
+++ b/databuilder/models/metric_metadata.py
@@ -3,7 +3,7 @@
 
 from collections import namedtuple
 
-from typing import Iterable, Any, Union, Iterator, Dict, Set  # noqa: F401
+from typing import Iterable, Any, Union, Iterator, Dict, Set, List  # noqa: F401
 
 # TODO: We could separate TagMetadata from table_metadata to own module
 from databuilder.models.table_metadata import TagMetadata

--- a/databuilder/models/metric_metadata.py
+++ b/databuilder/models/metric_metadata.py
@@ -108,9 +108,6 @@ class MetricMetadata(Neo4jCsvSerializable):
     def _get_metric_description_key(self) -> str:
         return MetricMetadata.METRIC_DESCRIPTION_FORMAT.format(name=self.name)
 
-    def _get_metric_expression_key(self) -> str:
-        return MetricMetadata.METRIC_EXPRESSION_KEY_FORMAT.format(name=self.name)
-
     def create_next_node(self) -> Union[Dict[str, Any], None]:
         try:
             return next(self._node_iterator)
@@ -145,7 +142,8 @@ class MetricMetadata(Neo4jCsvSerializable):
                    NODE_KEY: self._get_metric_type_key(),
                    'name': self.type}
 
-        others = []
+        # FIXME: this logic is wrong and does nothing presently
+        others: List[Any] = []
 
         for node_tuple in others:
             if node_tuple not in MetricMetadata.serialized_nodes:
@@ -208,7 +206,8 @@ class MetricMetadata(Neo4jCsvSerializable):
                 RELATION_REVERSE_TYPE: MetricMetadata.METRIC_TYPE_METRIC_RELATION_TYPE
             }
 
-        others = []
+        # FIXME: this logic is wrong and does nothing presently
+        others: List[Any] = []
 
         for rel_tuple in others:
             if rel_tuple not in MetricMetadata.serialized_rels:

--- a/databuilder/models/metric_metadata.py
+++ b/databuilder/models/metric_metadata.py
@@ -61,19 +61,18 @@ class MetricMetadata(Neo4jCsvSerializable):
     METRIC_TAG_RELATION_TYPE = 'TAG'
     TAG_METRIC_RELATION_TYPE = 'TAG_OF'
 
-    serialized_nodes = set()  # type: Set[Any]
-    serialized_rels = set()  # type: Set[Any]
+    serialized_nodes: Set[Any] = set()
+    serialized_rels: Set[Any] = set()
 
     def __init__(self,
-                 dashboard_group,  # type: str
-                 dashboard_name,  # type: str
-                 name,  # type: Union[str, None]
-                 expression,   # type: str
-                 description,   # type: str
-                 type,   # type: str
-                 tags,   # type: List
-                 ):
-        # type: (...) -> None
+                 dashboard_group: str,
+                 dashboard_name: str,
+                 name: Union[str, None],
+                 expression: str,
+                 description: str,
+                 type: str,
+                 tags: List,
+                 ) -> None:
 
         self.dashboard_group = dashboard_group
         self.dashboard_name = dashboard_name
@@ -85,8 +84,7 @@ class MetricMetadata(Neo4jCsvSerializable):
         self._node_iterator = self._create_next_node()
         self._relation_iterator = self._create_next_relation()
 
-    def __repr__(self):
-        # type: () -> str
+    def __repr__(self) -> str:
         return 'MetricMetadata({!r}, {!r}, {!r}, {!r}, {!r}, {!r}, {!r}'.format(
             self.dashboard_group,
             self.dashboard_name,
@@ -97,36 +95,29 @@ class MetricMetadata(Neo4jCsvSerializable):
             self.tags
         )
 
-    def _get_metric_key(self):
-        # type: () -> str
+    def _get_metric_key(self) -> str:
         return MetricMetadata.METRIC_KEY_FORMAT.format(name=self.name)
 
-    def _get_metric_type_key(self):
-        # type: () -> str
+    def _get_metric_type_key(self) -> str:
         return MetricMetadata.METRIC_TYPE_KEY_FORMAT.format(type=self.type)
 
-    def _get_dashboard_key(self):
-        # type: () -> str
+    def _get_dashboard_key(self) -> str:
         return MetricMetadata.DASHBOARD_KEY_FORMAT.format(dashboard_group=self.dashboard_group,
                                                           dashboard_name=self.dashboard_name)
 
-    def _get_metric_description_key(self):
-        # type: () -> str
+    def _get_metric_description_key(self) -> str:
         return MetricMetadata.METRIC_DESCRIPTION_FORMAT.format(name=self.name)
 
-    def _get_metric_expression_key(self):
-        # type: () -> str
+    def _get_metric_expression_key(self) -> str:
         return MetricMetadata.METRIC_EXPRESSION_KEY_FORMAT.format(name=self.name)
 
-    def create_next_node(self):
-        # type: () -> Union[Dict[str, Any], None]
+    def create_next_node(self) -> Union[Dict[str, Any], None]:
         try:
             return next(self._node_iterator)
         except StopIteration:
             return None
 
-    def _create_next_node(self):
-        # type: () -> Iterator[Any]
+    def _create_next_node(self) -> Iterator[Any]:
 
         # Metric node
         yield {NODE_LABEL: MetricMetadata.METRIC_NODE_LABEL,
@@ -165,15 +156,13 @@ class MetricMetadata(Neo4jCsvSerializable):
                     'name': node_tuple.name
                 }
 
-    def create_next_relation(self):
-        # type: () -> Union[Dict[str, Any], None]
+    def create_next_relation(self) -> Union[Dict[str, Any], None]:
         try:
             return next(self._relation_iterator)
         except StopIteration:
             return None
 
-    def _create_next_relation(self):
-        # type: () -> Iterator[Any]
+    def _create_next_relation(self) -> Iterator[Any]:
 
         # Dashboard > Metric relation
         yield {

--- a/databuilder/models/neo4j_csv_serde.py
+++ b/databuilder/models/neo4j_csv_serde.py
@@ -31,13 +31,11 @@ class Neo4jCsvSerializable(object, metaclass=abc.ABCMeta):
     Any model class that needs to be pushed to Neo4j should inherit this class.
     """
 
-    def __init__(self):
-        # type: () -> None
+    def __init__(self) -> None:
         pass
 
     @abc.abstractmethod
-    def create_next_node(self):
-        # type: () -> Union[Dict[str, Any], None]
+    def create_next_node(self) -> Union[Dict[str, Any], None]:
         """
         Creates dict where keys represent header in CSV and value represents
         row in CSV file. Should the class could have different types of
@@ -53,8 +51,7 @@ class Neo4jCsvSerializable(object, metaclass=abc.ABCMeta):
         raise NotImplementedError
 
     @abc.abstractmethod
-    def create_next_relation(self):
-        # type: () -> Union[Dict[str, Any], None]
+    def create_next_relation(self) -> Union[Dict[str, Any], None]:
         """
         Creates dict where keys represent header in CSV and value represents
         row in CSV file. Should the class could have different types of
@@ -69,8 +66,7 @@ class Neo4jCsvSerializable(object, metaclass=abc.ABCMeta):
         """
         raise NotImplementedError
 
-    def next_node(self):
-        # type: () -> Union[Dict[str, Any], None]
+    def next_node(self) -> Union[Dict[str, Any], None]:
         """
         Provides node(vertex) in dict form.
         Note that subsequent call can create different header (dict.keys())
@@ -86,8 +82,7 @@ class Neo4jCsvSerializable(object, metaclass=abc.ABCMeta):
         self._validate(NODE_REQUIRED_HEADERS, node_dict)
         return node_dict
 
-    def next_relation(self):
-        # type: () -> Union[Dict[str, Any], None]
+    def next_relation(self) -> Union[Dict[str, Any], None]:
         """
         Provides relation(edge) in dict form.
         Note that subsequent call can create different header (dict.keys())
@@ -103,8 +98,9 @@ class Neo4jCsvSerializable(object, metaclass=abc.ABCMeta):
         self._validate(RELATION_REQUIRED_HEADERS, relation_dict)
         return relation_dict
 
-    def _validate(self, required_set, val_dict):
-        # type: (Set[str], Dict[str, Any]) -> None
+    def _validate(self,
+                  required_set: Set[str],
+                  val_dict: Dict[str, Any]) -> None:
         """
         Validates dict that represents CSV header and a row.
          - Checks if it has required headers for either Node or Relation

--- a/databuilder/models/neo4j_csv_serde.py
+++ b/databuilder/models/neo4j_csv_serde.py
@@ -125,7 +125,7 @@ class Neo4jCsvSerializable(object, metaclass=abc.ABCMeta):
             elif header_col in TYPES:
                 if not val_col == val_col.upper():
                     raise RuntimeError(
-                        'TYPE needs to be upper case: '.format(val_col))
+                        'TYPE needs to be upper case: {}'.format(val_col))
 
         if required_count != len(required_set):
             raise RuntimeError(

--- a/databuilder/models/presto_query_logs.py
+++ b/databuilder/models/presto_query_logs.py
@@ -9,11 +9,10 @@ class PrestoQueryLogs:
     """
 
     def __init__(self,
-                 user,  # type: str
-                 query_text,  # type: str
-                 occurred_at  # type: str
-                 ):
-        # type: (...) -> None
+                 user: str,
+                 query_text: str,
+                 occurred_at: str
+                 ) -> None:
         self.user = user
         self.query_text = query_text
         self.occurred_at = occurred_at

--- a/databuilder/models/schema/schema.py
+++ b/databuilder/models/schema/schema.py
@@ -25,15 +25,13 @@ class SchemaModel(Neo4jCsvSerializable):
         self._node_iterator = self._create_node_iterator()
         self._relation_iterator = self._create_relation_iterator()
 
-    def create_next_node(self):
-        # type: () -> Union[Dict[str, Any], None]
+    def create_next_node(self) -> Union[Dict[str, Any], None]:
         try:
             return next(self._node_iterator)
         except StopIteration:
             return None
 
-    def _create_node_iterator(self):
-        # type: () -> Iterator[[Dict[str, Any]]]
+    def _create_node_iterator(self) -> Iterator[[Dict[str, Any]]]:
         yield {
             NODE_LABEL: SCHEMA_NODE_LABEL,
             NODE_KEY: self._schema_key,
@@ -43,8 +41,7 @@ class SchemaModel(Neo4jCsvSerializable):
         if self._description:
             yield self._description.get_node_dict(self._get_description_node_key())
 
-    def create_next_relation(self):
-        # type: () -> Union[Dict[str, Any], None]
+    def create_next_relation(self) -> Union[Dict[str, Any], None]:
         try:
             return next(self._relation_iterator)
         except StopIteration:
@@ -53,8 +50,7 @@ class SchemaModel(Neo4jCsvSerializable):
     def _get_description_node_key(self):
         return '{}/{}'.format(self._schema_key, self._description.get_description_id())
 
-    def _create_relation_iterator(self):
-        # type: () -> Iterator[[Dict[str, Any]]]
+    def _create_relation_iterator(self) -> Iterator[[Dict[str, Any]]]:
         if self._description:
             yield self._description.get_relation(start_node=SCHEMA_NODE_LABEL,
                                                  start_key=self._schema_key,

--- a/databuilder/models/schema/schema.py
+++ b/databuilder/models/schema/schema.py
@@ -12,11 +12,12 @@ from databuilder.models.table_metadata import DescriptionMetadata
 class SchemaModel(Neo4jCsvSerializable):
 
     def __init__(self,
-                 schema_key,
-                 schema,
-                 description=None,
-                 description_source=None,
-                 **kwargs):
+                 schema_key: str,
+                 schema: str,
+                 description: str=None,
+                 description_source: str=None,
+                 **kwargs: Any
+                 ) -> None:
         self._schema_key = schema_key
         self._schema = schema
         self._description = DescriptionMetadata.create_description_metadata(text=description,
@@ -47,8 +48,9 @@ class SchemaModel(Neo4jCsvSerializable):
         except StopIteration:
             return None
 
-    def _get_description_node_key(self):
-        return '{}/{}'.format(self._schema_key, self._description.get_description_id())
+    def _get_description_node_key(self) -> str:
+        desc = self._description.get_description_id() if self._description is not None else ''
+        return '{}/{}'.format(self._schema_key, desc)
 
     def _create_relation_iterator(self) -> Iterator[Dict[str, Any]]:
         if self._description:

--- a/databuilder/models/schema/schema.py
+++ b/databuilder/models/schema/schema.py
@@ -31,7 +31,7 @@ class SchemaModel(Neo4jCsvSerializable):
         except StopIteration:
             return None
 
-    def _create_node_iterator(self) -> Iterator[[Dict[str, Any]]]:
+    def _create_node_iterator(self) -> Iterator[Dict[str, Any]]:
         yield {
             NODE_LABEL: SCHEMA_NODE_LABEL,
             NODE_KEY: self._schema_key,
@@ -50,7 +50,7 @@ class SchemaModel(Neo4jCsvSerializable):
     def _get_description_node_key(self):
         return '{}/{}'.format(self._schema_key, self._description.get_description_id())
 
-    def _create_relation_iterator(self) -> Iterator[[Dict[str, Any]]]:
+    def _create_relation_iterator(self) -> Iterator[Dict[str, Any]]:
         if self._description:
             yield self._description.get_relation(start_node=SCHEMA_NODE_LABEL,
                                                  start_key=self._schema_key,

--- a/databuilder/models/table_column_usage.py
+++ b/databuilder/models/table_column_usage.py
@@ -18,15 +18,14 @@ class ColumnReader(object):
     """
 
     def __init__(self,
-                 database,  # type: str
-                 cluster,  # type: str
-                 schema,  # type: str
-                 table,  # type: str
-                 column,  # type: str
-                 user_email,  # type: str
-                 read_count=1  # type: int
-                 ):
-        # type: (...) -> None
+                 database: str,
+                 cluster: str,
+                 schema: str,
+                 table: str,
+                 column: str,
+                 user_email: str,
+                 read_count: int = 1
+                 ) -> None:
         self.database = database.lower()
         self.cluster = cluster.lower()
         self.schema = schema.lower()
@@ -35,8 +34,7 @@ class ColumnReader(object):
         self.user_email = user_email.lower()
         self.read_count = read_count
 
-    def __repr__(self):
-        # type: () -> str
+    def __repr__(self) -> str:
         return """\
 ColumnReader(database={!r}, cluster={!r}, schema={!r}, table={!r}, column={!r}, user_email={!r}, read_count={!r})"""\
             .format(self.database, self.cluster, self.schema, self.table, self.column, self.user_email, self.read_count)
@@ -57,9 +55,8 @@ class TableColumnUsage(Neo4jCsvSerializable):
     READ_RELATION_COUNT = 'read_count{}'.format(UNQUOTED_SUFFIX)
 
     def __init__(self,
-                 col_readers,  # type: Iterable[ColumnReader]
-                 ):
-        # type: (...) -> None
+                 col_readers: Iterable[ColumnReader],
+                 ) -> None:
         for col_reader in col_readers:
             if col_reader.column != '*':
                 raise NotImplementedError('Column is not supported yet {}'.format(col_readers))
@@ -68,31 +65,27 @@ class TableColumnUsage(Neo4jCsvSerializable):
         self._node_iterator = self._create_node_iterator()
         self._rel_iter = self._create_rel_iterator()
 
-    def create_next_node(self):
-        # type: () -> Union[Dict[str, Any], None]
+    def create_next_node(self) -> Union[Dict[str, Any], None]:
 
         try:
             return next(self._node_iterator)
         except StopIteration:
             return None
 
-    def _create_node_iterator(self):
-        # type: () -> Iterator[Any]
+    def _create_node_iterator(self) -> Iterator[Any]:
         for col_reader in self.col_readers:
             if col_reader.column == '*':
                 # using yield for better memory efficiency
                 yield User(email=col_reader.user_email).create_nodes()[0]
 
-    def create_next_relation(self):
-        # type: () -> Union[Dict[str, Any], None]
+    def create_next_relation(self) -> Union[Dict[str, Any], None]:
 
         try:
             return next(self._rel_iter)
         except StopIteration:
             return None
 
-    def _create_rel_iterator(self):
-        # type: () -> Iterator[Any]
+    def _create_rel_iterator(self) -> Iterator[Any]:
         for col_reader in self.col_readers:
             yield {
                 RELATION_START_LABEL: TableMetadata.TABLE_NODE_LABEL,
@@ -104,17 +97,14 @@ class TableColumnUsage(Neo4jCsvSerializable):
                 TableColumnUsage.READ_RELATION_COUNT: col_reader.read_count
             }
 
-    def _get_table_key(self, col_reader):
-        # type: (ColumnReader) -> str
+    def _get_table_key(self, col_reader: ColumnReader) -> str:
         return TableMetadata.TABLE_KEY_FORMAT.format(db=col_reader.database,
                                                      cluster=col_reader.cluster,
                                                      schema=col_reader.schema,
                                                      tbl=col_reader.table)
 
-    def _get_user_key(self, email):
-        # type: (str) -> str
+    def _get_user_key(self, email: str) -> str:
         return User.get_user_model_key(email=email)
 
-    def __repr__(self):
-        # type: () -> str
+    def __repr__(self) -> str:
         return 'TableColumnUsage(col_readers={!r})'.format(self.col_readers)

--- a/databuilder/models/table_elasticsearch_document.py
+++ b/databuilder/models/table_elasticsearch_document.py
@@ -23,7 +23,7 @@ class TableESDocument(ElasticsearchDocument):
                  column_descriptions: List[str],
                  total_usage: int,
                  unique_usage: int,
-                 tags: List[str],,
+                 tags: List[str],
                  badges: Optional[List[str]] = None,
                  display_name: Optional[str] = None,
                  schema_description: Optional[str] = None,

--- a/databuilder/models/table_elasticsearch_document.py
+++ b/databuilder/models/table_elasticsearch_document.py
@@ -12,24 +12,23 @@ class TableESDocument(ElasticsearchDocument):
     """
 
     def __init__(self,
-                 database,  # type: str
-                 cluster,  # type: str
-                 schema,  # type: str
-                 name,  # type: str
-                 key,  # type: str
-                 description,  # type: str
-                 last_updated_timestamp,  # type: Optional[int]
-                 column_names,  # type: List[str]
-                 column_descriptions,  # type: List[str]
-                 total_usage,  # type: int
-                 unique_usage,  # type: int
-                 tags,  # type: List[str],
-                 badges=None,  # type: Optional[List[str]]
-                 display_name=None,  # type: Optional[str]
-                 schema_description=None,  # type: Optional[str]
-                 programmatic_descriptions=[],  # type: List[str]
-                 ):
-        # type: (...) -> None
+                 database: str,
+                 cluster: str,
+                 schema: str,
+                 name: str,
+                 key: str,
+                 description: str,
+                 last_updated_timestamp: Optional[int],
+                 column_names: List[str],
+                 column_descriptions: List[str],
+                 total_usage: int,
+                 unique_usage: int,
+                 tags: List[str],,
+                 badges: Optional[List[str]] = None,
+                 display_name: Optional[str] = None,
+                 schema_description: Optional[str] = None,
+                 programmatic_descriptions: List[str] = [],
+                 ) -> None:
         self.database = database
         self.cluster = cluster
         self.schema = schema

--- a/databuilder/models/table_last_updated.py
+++ b/databuilder/models/table_last_updated.py
@@ -22,13 +22,12 @@ class TableLastUpdated(Neo4jCsvSerializable):
     LASTUPDATED_TABLE_RELATION_TYPE = timestamp_constants.LASTUPDATED_REVERSE_RELATION_TYPE
 
     def __init__(self,
-                 table_name,  # type: str
-                 last_updated_time_epoch,  # type: int
-                 schema,  # type: str
-                 db='hive',  # type: str
-                 cluster='gold'  # type: str
-                 ):
-        # type: (...) -> None
+                 table_name: str,
+                 last_updated_time_epoch: int,
+                 schema: str,
+                 db: str = 'hive',
+                 cluster: str = 'gold'
+                 ) -> None:
         self.table_name = table_name
         self.last_updated_time = int(last_updated_time_epoch)
         self.schema = schema
@@ -38,45 +37,39 @@ class TableLastUpdated(Neo4jCsvSerializable):
         self._node_iter = iter(self.create_nodes())
         self._relation_iter = iter(self.create_relation())
 
-    def __repr__(self):
-        # type: (...) -> str
+    def __repr__(self) -> str:
         return \
             """TableLastUpdated(table_name={!r}, last_updated_time={!r}, schema={!r}, db={!r}, cluster={!r})"""\
             .format(self.table_name, self.last_updated_time, self.schema, self.db, self.cluster)
 
-    def create_next_node(self):
-        # type: (...) -> Union[Dict[str, Any], None]
+    def create_next_node(self) -> Union[Dict[str, Any], None]:
         # creates new node
         try:
             return next(self._node_iter)
         except StopIteration:
             return None
 
-    def create_next_relation(self):
-        # type: (...) -> Union[Dict[str, Any], None]
+    def create_next_relation(self) -> Union[Dict[str, Any], None]:
         try:
             return next(self._relation_iter)
         except StopIteration:
             return None
 
-    def get_table_model_key(self):
-        # type: (...) -> str
+    def get_table_model_key(self) -> str:
         # returns formatted string for table name
         return TableMetadata.TABLE_KEY_FORMAT.format(db=self.db,
                                                      cluster=self.cluster,
                                                      schema=self.schema,
                                                      tbl=self.table_name)
 
-    def get_last_updated_model_key(self):
-        # type: (...) -> str
+    def get_last_updated_model_key(self) -> str:
         # returns formatted string for last updated name
         return TableLastUpdated.LAST_UPDATED_KEY_FORMAT.format(db=self.db,
                                                                cluster=self.cluster,
                                                                schema=self.schema,
                                                                tbl=self.table_name)
 
-    def create_nodes(self):
-        # type: () -> List[Dict[str, Any]]
+    def create_nodes(self) -> List[Dict[str, Any]]:
         """
         Create a list of Neo4j node records
         :return:
@@ -93,8 +86,7 @@ class TableLastUpdated(Neo4jCsvSerializable):
 
         return results
 
-    def create_relation(self):
-        # type: () -> List[Dict[str, Any]]
+    def create_relation(self) -> List[Dict[str, Any]]:
         """
         Create a list of relations mapping last updated node with table node
         :return:

--- a/databuilder/models/table_lineage.py
+++ b/databuilder/models/table_lineage.py
@@ -27,8 +27,7 @@ class TableLineage(Neo4jCsvSerializable):
                  table_name,  # type: str
                  cluster,  # type: str
                  downstream_deps=None,  # type: List
-                 ):
-        # type: (...) -> None
+                 ) -> None:
         self.db = db_name.lower()
         self.schema = schema.lower()
         self.table = table_name.lower()
@@ -40,38 +39,33 @@ class TableLineage(Neo4jCsvSerializable):
         self._node_iter = iter(self.create_nodes())
         self._relation_iter = iter(self.create_relation())
 
-    def create_next_node(self):
-        # type: (...) -> Union[Dict[str, Any], None]
+    def create_next_node(self) -> Union[Dict[str, Any], None]:
         # return the string representation of the data
         try:
             return next(self._node_iter)
         except StopIteration:
             return None
 
-    def create_next_relation(self):
-        # type: (...) -> Union[Dict[str, Any], None]
+    def create_next_relation(self) -> Union[Dict[str, Any], None]:
         try:
             return next(self._relation_iter)
         except StopIteration:
             return None
 
-    def get_table_model_key(self, db, cluster, schema, table):
-        # type: (...) -> str
+    def get_table_model_key(self, db, cluster, schema, table) -> str:
         return '{db}://{cluster}.{schema}/{table}'.format(db=db,
                                                           cluster=cluster,
                                                           schema=schema,
                                                           table=table)
 
-    def create_nodes(self):
-        # type: () -> List[Union[Dict[str, Any], None]]
+    def create_nodes(self) -> List[Union[Dict[str, Any], None]]:
         """
         It won't create any node for this model
         :return:
         """
         return []
 
-    def create_relation(self):
-        # type: () -> List[Dict[str, Any]]
+    def create_relation(self) -> List[Dict[str, Any]]:
         """
         Create a list of relation between source table and all the downstream tables
         :return:
@@ -99,8 +93,7 @@ class TableLineage(Neo4jCsvSerializable):
                 })
         return results
 
-    def __repr__(self):
-        # type: () -> str
+    def __repr__(self) -> str:
         return 'TableLineage({!r}, {!r}, {!r}, {!r})'.format(self.db,
                                                              self.cluster,
                                                              self.schema,

--- a/databuilder/models/table_lineage.py
+++ b/databuilder/models/table_lineage.py
@@ -12,7 +12,6 @@ from databuilder.models.table_metadata import TableMetadata
 
 
 class TableLineage(Neo4jCsvSerializable):
-    # type: (...) -> None
     """
     Table Lineage Model. It won't create nodes but create upstream/downstream rels.
     """
@@ -22,11 +21,11 @@ class TableLineage(Neo4jCsvSerializable):
     DEPENDENCY_ORIGIN_RELATION_TYPE = 'DOWNSTREAM'
 
     def __init__(self,
-                 db_name,  # type: str
-                 schema,  # type: str
-                 table_name,  # type: str
-                 cluster,  # type: str
-                 downstream_deps=None,  # type: List
+                 db_name: str,
+                 schema: str,
+                 table_name: str,
+                 cluster: str,
+                 downstream_deps: List=None,
                  ) -> None:
         self.db = db_name.lower()
         self.schema = schema.lower()
@@ -35,7 +34,7 @@ class TableLineage(Neo4jCsvSerializable):
         self.cluster = cluster.lower() if cluster else 'gold'
         # a list of downstream dependencies, each of which will follow
         # the same key
-        self.downstream_deps = downstream_deps
+        self.downstream_deps = downstream_deps or []
         self._node_iter = iter(self.create_nodes())
         self._relation_iter = iter(self.create_relation())
 
@@ -52,7 +51,12 @@ class TableLineage(Neo4jCsvSerializable):
         except StopIteration:
             return None
 
-    def get_table_model_key(self, db, cluster, schema, table) -> str:
+    def get_table_model_key(self,
+                            db: str,
+                            cluster: str,
+                            schema: str,
+                            table: str
+                            ) -> str:
         return '{db}://{cluster}.{schema}/{table}'.format(db=db,
                                                           cluster=cluster,
                                                           schema=schema,

--- a/databuilder/models/table_metadata.py
+++ b/databuilder/models/table_metadata.py
@@ -4,7 +4,7 @@
 import copy
 from collections import namedtuple
 
-from typing import Iterable, Any, Union, Iterator, Dict, Set  # noqa: F401
+from typing import Any, Dict, Iterable, Iterator, List, Set, Union  # noqa: F401
 
 from databuilder.models.cluster import cluster_constants
 from databuilder.models.neo4j_csv_serde import (

--- a/databuilder/models/table_metadata.py
+++ b/databuilder/models/table_metadata.py
@@ -27,7 +27,7 @@ class TagMetadata(Neo4jCsvSerializable):
     METRIC_TYPE = 'metric'
 
     def __init__(self,
-                 name: str,,
+                 name: str,
                  tag_type: str = 'default',
                  ):
         self._name = name

--- a/databuilder/models/table_metadata.py
+++ b/databuilder/models/table_metadata.py
@@ -63,6 +63,7 @@ class TagMetadata(Neo4jCsvSerializable):
         except StopIteration:
             return None
 
+
 # TODO: this should inherit from ProgrammaticDescription in amundsen-common
 class DescriptionMetadata:
     DESCRIPTION_NODE_LABEL = DESCRIPTION_NODE_LABEL_VAL
@@ -94,7 +95,7 @@ class DescriptionMetadata:
             self._label = self.PROGRAMMATIC_DESCRIPTION_NODE_LABEL
 
     @staticmethod
-    def create_description_metadata(text: Union[None,str],
+    def create_description_metadata(text: Union[None, str],
                                     source: Optional[str] = DEFAULT_SOURCE
                                     ) -> Optional['DescriptionMetadata']:
         # We do not want to create a node if there is no description text!
@@ -327,7 +328,7 @@ class TableMetadata(Neo4jCsvSerializable):
     @staticmethod
     def format_tags(tags: Union[List, str, None]) -> List:
         if tags is None:
-           tags = []
+            tags = []
         if isinstance(tags, str):
             tags = list(filter(None, tags.split(',')))
         if isinstance(tags, list):

--- a/databuilder/models/table_metadata.py
+++ b/databuilder/models/table_metadata.py
@@ -61,7 +61,7 @@ class TagMetadata(Neo4jCsvSerializable):
         except StopIteration:
             return None
 
-
+# TODO: this should inherit from ProgrammaticDescription in amundsen-common
 class DescriptionMetadata:
     DESCRIPTION_NODE_LABEL = DESCRIPTION_NODE_LABEL_VAL
     PROGRAMMATIC_DESCRIPTION_NODE_LABEL = 'Programmatic_Description'
@@ -93,7 +93,7 @@ class DescriptionMetadata:
 
     @staticmethod
     def create_description_metadata(text: Union[None,str],
-                                    source: str = DEFAULT_SOURCE) -> ProgrammaticDescription:
+                                    source: str = DEFAULT_SOURCE) -> 'DescriptionMetadata':
 
         # We do not want to create a node if there is no description text!
         if text is None:

--- a/databuilder/models/table_metadata.py
+++ b/databuilder/models/table_metadata.py
@@ -27,8 +27,8 @@ class TagMetadata(Neo4jCsvSerializable):
     METRIC_TYPE = 'metric'
 
     def __init__(self,
-                 name,  # type: str,
-                 tag_type='default',  # type: str
+                 name: str,,
+                 tag_type: str = 'default',
                  ):
         self._name = name
         self._tag_type = tag_type
@@ -36,8 +36,7 @@ class TagMetadata(Neo4jCsvSerializable):
         self._relations = iter([])
 
     @staticmethod
-    def get_tag_key(name):
-        # type: (str) -> str
+    def get_tag_key(name: str) -> str:
         if not name:
             return ''
         return TagMetadata.TAG_KEY_FORMAT.format(tag=name)
@@ -48,16 +47,14 @@ class TagMetadata(Neo4jCsvSerializable):
                 NODE_KEY: TagMetadata.get_tag_key(name),
                 TagMetadata.TAG_TYPE: tag_type}
 
-    def create_next_node(self):
-        # type: (...) -> Union[Dict[str, Any], None]
+    def create_next_node(self) -> Union[Dict[str, Any], None]:
         # return the string representation of the data
         try:
             return next(self._nodes)
         except StopIteration:
             return None
 
-    def create_next_relation(self):
-        # type: () -> Union[Dict[str, Any], None]
+    def create_next_relation(self) -> Union[Dict[str, Any], None]:
         # We don't emit any relations for Tag ingestion
         try:
             return next(self._relations)
@@ -79,8 +76,8 @@ class DescriptionMetadata:
     DEFAULT_SOURCE = "description"
 
     def __init__(self,
-                 text,  # type: Union[None, str]
-                 source=DEFAULT_SOURCE  # type: str
+                 text: Union[None, str],
+                 source: str = DEFAULT_SOURCE
                  ):
         """
         :param source: The unique source of what is populating this description.
@@ -95,8 +92,8 @@ class DescriptionMetadata:
             self._label = self.PROGRAMMATIC_DESCRIPTION_NODE_LABEL
 
     @staticmethod
-    def create_description_metadata(text, source=DEFAULT_SOURCE):
-        # type: (Union[None,str], str) -> ProgrammaticDescription
+    def create_description_metadata(text: Union[None,str],
+                                    source: str = DEFAULT_SOURCE) -> ProgrammaticDescription:
 
         # We do not want to create a node if there is no description text!
         if text is None:
@@ -107,15 +104,13 @@ class DescriptionMetadata:
             description_node = DescriptionMetadata(text=text, source=source)
         return description_node
 
-    def get_description_id(self):
-        # type: () -> str
+    def get_description_id(self) -> str:
         if self._source == self.DEFAULT_SOURCE:
             return "_description"
         else:
             return "_" + self._source + "_description"
 
-    def __repr__(self):
-        # type: () -> str
+    def __repr__(self) -> str:
         return 'DescriptionMetadata({!r}, {!r})'.format(self._source, self._text)
 
     def get_node_dict(self, node_key):
@@ -153,13 +148,12 @@ class ColumnMetadata:
     TAG_COL_RELATION_TYPE = 'TAG'
 
     def __init__(self,
-                 name,  # type: str
-                 description,  # type: Union[str, None]
-                 col_type,  # type: str
-                 sort_order,  # type: int
-                 tags=None  # type: Union[List[str], None]
-                 ):
-        # type: (...) -> None
+                 name: str,
+                 description: Union[str, None],
+                 col_type: str,
+                 sort_order: int,
+                 tags: Union[List[str], None] = None
+                 ) -> None:
         """
         TODO: Add stats
         :param name:
@@ -174,8 +168,7 @@ class ColumnMetadata:
         self.sort_order = sort_order
         self.tags = tags
 
-    def __repr__(self):
-        # type: () -> str
+    def __repr__(self) -> str:
         return 'ColumnMetadata({!r}, {!r}, {!r}, {!r})'.format(self.name,
                                                                self.description,
                                                                self.type,
@@ -227,22 +220,21 @@ class TableMetadata(Neo4jCsvSerializable):
     TAG_TABLE_RELATION_TYPE = 'TAG'
 
     # Only for deduping database, cluster, and schema (table and column will be always processed)
-    serialized_nodes = set()  # type: Set[Any]
-    serialized_rels = set()  # type: Set[Any]
+    serialized_nodes: Set[Any] = set()
+    serialized_rels: Set[Any] = set()
 
     def __init__(self,
-                 database,  # type: str
-                 cluster,  # type: str
-                 schema,  # type: str
-                 name,  # type: str
-                 description,  # type: Union[str, None]
-                 columns=None,  # type: Iterable[ColumnMetadata]
-                 is_view=False,  # type: bool
-                 tags=None,  # type: Union[List, str]
-                 description_source=None,  # type: Union[str, None]
-                 **kwargs  # type: Dict
-                 ):
-        # type: (...) -> None
+                 database: str,
+                 cluster: str,
+                 schema: str,
+                 name: str,
+                 description: Union[str, None],
+                 columns: Iterable[ColumnMetadata] = None,
+                 is_view: bool = False,
+                 tags: Union[List, str] = None,
+                 description_source: Union[str, None] = None,
+                 **kwargs: Dict
+                 ) -> None:
         """
         :param database:
         :param cluster:
@@ -272,8 +264,7 @@ class TableMetadata(Neo4jCsvSerializable):
         self._node_iterator = self._create_next_node()
         self._relation_iterator = self._create_next_relation()
 
-    def __repr__(self):
-        # type: () -> str
+    def __repr__(self) -> str:
         return 'TableMetadata({!r}, {!r}, {!r}, {!r} ' \
                '{!r}, {!r}, {!r}, {!r})'.format(self.database,
                                                 self.cluster,
@@ -284,46 +275,42 @@ class TableMetadata(Neo4jCsvSerializable):
                                                 self.is_view,
                                                 self.tags)
 
-    def _get_table_key(self):
-        # type: () -> str
+    def _get_table_key(self) -> str:
         return TableMetadata.TABLE_KEY_FORMAT.format(db=self.database,
                                                      cluster=self.cluster,
                                                      schema=self.schema,
                                                      tbl=self.name)
 
-    def _get_table_description_key(self, description):
-        # type: (DescriptionMetadata) -> str
+    def _get_table_description_key(self,
+                                   description: DescriptionMetadata) -> str:
         return TableMetadata.TABLE_DESCRIPTION_FORMAT.format(db=self.database,
                                                              cluster=self.cluster,
                                                              schema=self.schema,
                                                              tbl=self.name,
                                                              description_id=description.get_description_id())
 
-    def _get_database_key(self):
-        # type: () -> str
+    def _get_database_key(self) -> str:
         return TableMetadata.DATABASE_KEY_FORMAT.format(db=self.database)
 
-    def _get_cluster_key(self):
-        # type: () -> str
+    def _get_cluster_key(self) -> str:
         return TableMetadata.CLUSTER_KEY_FORMAT.format(db=self.database,
                                                        cluster=self.cluster)
 
-    def _get_schema_key(self):
-        # type: () -> str
+    def _get_schema_key(self) -> str:
         return TableMetadata.SCHEMA_KEY_FORMAT.format(db=self.database,
                                                       cluster=self.cluster,
                                                       schema=self.schema)
 
-    def _get_col_key(self, col):
-        # type: (ColumnMetadata) -> str
+    def _get_col_key(self, col: ColumnMetadata) -> str:
         return ColumnMetadata.COLUMN_KEY_FORMAT.format(db=self.database,
                                                        cluster=self.cluster,
                                                        schema=self.schema,
                                                        tbl=self.name,
                                                        col=col.name)
 
-    def _get_col_description_key(self, col, description):
-        # type: (ColumnMetadata, DescriptionMetadata) -> str
+    def _get_col_description_key(self,
+                                 col: ColumnMetadata,
+                                 description: DescriptionMetadata) -> str:
         return ColumnMetadata.COLUMN_DESCRIPTION_FORMAT.format(db=self.database,
                                                                cluster=self.cluster,
                                                                schema=self.schema,
@@ -339,15 +326,13 @@ class TableMetadata(Neo4jCsvSerializable):
             tags = [tag.lower().strip() for tag in tags]
         return tags
 
-    def create_next_node(self):
-        # type: () -> Union[Dict[str, Any], None]
+    def create_next_node(self) -> Union[Dict[str, Any], None]:
         try:
             return next(self._node_iterator)
         except StopIteration:
             return None
 
-    def _create_next_node(self):  # noqa: C901
-        # type: () -> Iterator[Any]
+    def _create_next_node(self) -> Iterator[Any]:  # noqa: C901
 
         table_node = {NODE_LABEL: TableMetadata.TABLE_NODE_LABEL,
                       NODE_KEY: self._get_table_key(),
@@ -407,15 +392,13 @@ class TableMetadata(Neo4jCsvSerializable):
                     'name': node_tuple.name
                 }
 
-    def create_next_relation(self):
-        # type: () -> Union[Dict[str, Any], None]
+    def create_next_relation(self) -> Union[Dict[str, Any], None]:
         try:
             return next(self._relation_iterator)
         except StopIteration:
             return None
 
-    def _create_next_relation(self):
-        # type: () -> Iterator[Any]
+    def _create_next_relation(self) -> Iterator[Any]:
 
         yield {
             RELATION_START_LABEL: TableMetadata.SCHEMA_NODE_LABEL,

--- a/databuilder/models/table_owner.py
+++ b/databuilder/models/table_owner.py
@@ -99,8 +99,7 @@ class TableOwner(Neo4jCsvSerializable):
 
         return results
 
-    def __repr__(self):
-        # type: () -> str
+    def __repr__(self) -> str:
         return 'TableOwner({!r}, {!r}, {!r}, {!r}, {!r})'.format(self.db,
                                                                  self.cluster,
                                                                  self.schema,

--- a/databuilder/models/table_source.py
+++ b/databuilder/models/table_source.py
@@ -99,8 +99,7 @@ class TableSource(Neo4jCsvSerializable):
         }]
         return results
 
-    def __repr__(self):
-        # type: () -> str
+    def __repr__(self) -> str:
         return 'TableSource({!r}, {!r}, {!r}, {!r}, {!r})'.format(self.db,
                                                                   self.cluster,
                                                                   self.schema,

--- a/databuilder/models/user.py
+++ b/databuilder/models/user.py
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import copy
-from typing import Union, Dict, Any  # noqa: F401
+from typing import Any, List, Dict, Optional  # noqa: F401
 
 from databuilder.models.neo4j_csv_serde import Neo4jCsvSerializable, NODE_KEY, \
     NODE_LABEL, RELATION_START_KEY, RELATION_START_LABEL, RELATION_END_KEY, \
@@ -11,7 +11,6 @@ from databuilder.publisher.neo4j_csv_publisher import UNQUOTED_SUFFIX
 
 
 class User(Neo4jCsvSerializable):
-    # type: (...) -> None
     """
     User model. This model doesn't define any relationship.
     """
@@ -34,22 +33,21 @@ class User(Neo4jCsvSerializable):
     MANAGER_USER_RELATION_TYPE = 'MANAGE'
 
     def __init__(self,
-                 email,  # type: str
-                 first_name='',  # type: str
-                 last_name='',  # type: str
-                 name='',  # type: str
-                 github_username='',  # type: str
-                 team_name='',  # type: str
-                 employee_type='',  # type: str
-                 manager_email='',  # type: str
-                 slack_id='',  # type: str
-                 is_active=True,  # type: bool
-                 updated_at=0,  # type: int
-                 role_name='',  # type: str
-                 do_not_update_empty_attribute=False,  # type: bool
-                 **kwargs  # type: Dict
-                 ):
-        # type: (...) -> None
+                 email: str,
+                 first_name: str='',
+                 last_name: str='',
+                 name: str='',
+                 github_username: str='',
+                 team_name: str='',
+                 employee_type: str='',
+                 manager_email: str='',
+                 slack_id: str='',
+                 is_active: bool=True,
+                 updated_at: int=0,
+                 role_name: str='',
+                 do_not_update_empty_attribute: bool=False,
+                 **kwargs: Any
+                 ) -> None:
         """
         This class models user node for Amundsen people.
 
@@ -93,16 +91,14 @@ class User(Neo4jCsvSerializable):
         self._node_iter = iter(self.create_nodes())
         self._rel_iter = iter(self.create_relation())
 
-    def create_next_node(self):
-        # type: (...) -> Union[Dict[str, Any], None]
+    def create_next_node(self) -> Optional[Dict[str, Any]]:
         # return the string representation of the data
         try:
             return next(self._node_iter)
         except StopIteration:
             return None
 
-    def create_next_relation(self):
-        # type: () -> Union[Dict[str, Any], None]
+    def create_next_relation(self) -> Optional[Dict[str, Any]]:
         """
         :return:
         """
@@ -113,14 +109,13 @@ class User(Neo4jCsvSerializable):
 
     @classmethod
     def get_user_model_key(cls,
-                           email=None):
-        # type: (...) -> str
+                           email: str=None
+                           ) -> str:
         if not email:
             return ''
         return User.USER_NODE_KEY_FORMAT.format(email=email)
 
-    def create_nodes(self):
-        # type: () -> List[Dict[str, Any]]
+    def create_nodes(self) -> List[Dict[str, Any]]:
         """
         Create a list of Neo4j node records
         :return:

--- a/databuilder/models/user.py
+++ b/databuilder/models/user.py
@@ -172,8 +172,7 @@ class User(Neo4jCsvSerializable):
             }]
         return []
 
-    def __repr__(self):
-        # type: () -> str
+    def __repr__(self) -> str:
         return 'User({!r}, {!r}, {!r}, {!r}, {!r}, ' \
                '{!r}, {!r}, {!r}, {!r}, {!r}, {!r}, {!r})'.format(self.first_name,
                                                                   self.last_name,

--- a/databuilder/models/user_elasticsearch_document.py
+++ b/databuilder/models/user_elasticsearch_document.py
@@ -10,22 +10,21 @@ class UserESDocument(ElasticsearchDocument):
     """
 
     def __init__(self,
-                 email,  # type: str
-                 first_name,  # type: str
-                 last_name,  # type: str
-                 full_name,  # type: str
-                 github_username,  # type: str
-                 team_name,  # type: str
-                 employee_type,  # type: str
-                 manager_email,  # type: str
-                 slack_id,  # type: str
-                 role_name,  # type: str
-                 is_active,  # type: bool
-                 total_read,  # type: int
-                 total_own,  # type: int
-                 total_follow,  # type: int
-                 ):
-        # type: (...) -> None
+                 email: str,
+                 first_name: str,
+                 last_name: str,
+                 full_name: str,
+                 github_username: str,
+                 team_name: str,
+                 employee_type: str,
+                 manager_email: str,
+                 slack_id: str,
+                 role_name: str,
+                 is_active: bool,
+                 total_read: int,
+                 total_own: int,
+                 total_follow: int,
+                 ) -> None:
         self.email = email
         self.first_name = first_name
         self.last_name = last_name

--- a/databuilder/publisher/base_publisher.py
+++ b/databuilder/publisher/base_publisher.py
@@ -4,6 +4,7 @@
 import abc
 
 from pyhocon import ConfigTree  # noqa: F401
+from typing import List
 
 from databuilder import Scoped
 from databuilder.callback import call_back
@@ -31,7 +32,7 @@ class Publisher(Scoped):
     def init(self, conf: ConfigTree) -> None:
         pass
 
-    def publish(self):
+    def publish(self) -> None:
         try:
             self.publish_impl()
         except Exception as e:

--- a/databuilder/publisher/base_publisher.py
+++ b/databuilder/publisher/base_publisher.py
@@ -24,7 +24,7 @@ class Publisher(Scoped):
 
     """
 
-    def __init__(self):
+    def __init__(self) -> None:
         self.call_backs: List[Callback] = []
 
     @abc.abstractmethod

--- a/databuilder/publisher/base_publisher.py
+++ b/databuilder/publisher/base_publisher.py
@@ -25,11 +25,10 @@ class Publisher(Scoped):
     """
 
     def __init__(self):
-        self.call_backs = []  # type: List[Callback]
+        self.call_backs: List[Callback] = []
 
     @abc.abstractmethod
-    def init(self, conf):
-        # type: (ConfigTree) -> None
+    def init(self, conf: ConfigTree) -> None:
         pass
 
     def publish(self):
@@ -41,8 +40,7 @@ class Publisher(Scoped):
         call_back.notify_callbacks(self.call_backs, is_success=True)
 
     @abc.abstractmethod
-    def publish_impl(self):
-        # type: () -> None
+    def publish_impl(self) -> None:
         """
         An implementation of publish method. Subclass of publisher is expected to write publish logic by overriding
         this method
@@ -50,8 +48,7 @@ class Publisher(Scoped):
         """
         pass
 
-    def register_call_back(self, callback):
-        # type: (Callback) -> None
+    def register_call_back(self, callback: Callback) -> None:
         """
         Register any callback method that needs to be notified when publisher is either able to successfully publish
         or failed to publish
@@ -60,24 +57,19 @@ class Publisher(Scoped):
         """
         self.call_backs.append(callback)
 
-    def get_scope(self):
-        # type: () -> str
+    def get_scope(self) -> str:
         return 'publisher'
 
 
 class NoopPublisher(Publisher):
-    def __init__(self):
-        # type: () -> None
+    def __init__(self) -> None:
         super(NoopPublisher, self).__init__()
 
-    def init(self, conf):
-        # type: (ConfigTree) -> None
+    def init(self, conf: ConfigTree) -> None:
         pass
 
-    def publish_impl(self):
-        # type: () -> None
+    def publish_impl(self) -> None:
         pass
 
-    def get_scope(self):
-        # type: () -> str
+    def get_scope(self) -> str:
         return 'publisher.noop'

--- a/databuilder/publisher/elasticsearch_publisher.py
+++ b/databuilder/publisher/elasticsearch_publisher.py
@@ -37,12 +37,10 @@ class ElasticsearchPublisher(Publisher):
 
     DEFAULT_ELASTICSEARCH_INDEX_MAPPING = TABLE_ELASTICSEARCH_INDEX_MAPPING
 
-    def __init__(self):
-        # type: () -> None
+    def __init__(self) -> None:
         super(ElasticsearchPublisher, self).__init__()
 
-    def init(self, conf):
-        # type: (ConfigTree) -> None
+    def init(self, conf: ConfigTree) -> None:
         self.conf = conf
 
         self.file_path = self.conf.get_string(ElasticsearchPublisher.FILE_PATH_CONFIG_KEY)
@@ -59,8 +57,7 @@ class ElasticsearchPublisher(Publisher):
                                                       10000)
         self.file_handler = open(self.file_path, self.file_mode)
 
-    def _fetch_old_index(self):
-        # type: () -> List[str]
+    def _fetch_old_index(self) -> List[str]:
         """
         Retrieve all indices that currently have {elasticsearch_alias} alias
         :return: list of elasticsearch indices
@@ -74,8 +71,7 @@ class ElasticsearchPublisher(Publisher):
             # return empty list on exception
             return []
 
-    def publish_impl(self):
-        # type: () -> None
+    def publish_impl(self) -> None:
         """
         Use Elasticsearch Bulk API to load data from file to a {new_index}.
         After upload, swap alias from {old_index} to {new_index} in a atomic operation
@@ -126,6 +122,5 @@ class ElasticsearchPublisher(Publisher):
         # perform alias update and index delete in single atomic operation
         self.elasticsearch_client.indices.update_aliases(update_action)
 
-    def get_scope(self):
-        # type: () -> str
+    def get_scope(self) -> str:
         return 'publisher.elasticsearch'

--- a/databuilder/publisher/neo4j_csv_publisher.py
+++ b/databuilder/publisher/neo4j_csv_publisher.py
@@ -127,12 +127,10 @@ class Neo4jCsvPublisher(Publisher):
     #TODO User UNWIND batch operation for better performance
     """
 
-    def __init__(self):
-        # type: () -> None
+    def __init__(self) -> None:
         super(Neo4jCsvPublisher, self).__init__()
 
-    def init(self, conf):
-        # type: (ConfigTree) -> None
+    def init(self, conf: ConfigTree) -> None:
         conf = conf.with_fallback(DEFAULT_CONFIG)
 
         self._count = 0  # type: int
@@ -168,8 +166,7 @@ class Neo4jCsvPublisher(Publisher):
         LOGGER.info('Publishing Node csv files {}, and Relation CSV files {}'
                     .format(self._node_files, self._relation_files))
 
-    def _list_files(self, conf, path_key):
-        # type: (ConfigTree, str) -> List[str]
+    def _list_files(self, conf: ConfigTree, path_key: str) -> List[str]:
         """
         List files from directory
         :param conf:
@@ -182,8 +179,7 @@ class Neo4jCsvPublisher(Publisher):
         path = conf.get_string(path_key)
         return [join(path, f) for f in listdir(path) if isfile(join(path, f))]
 
-    def publish_impl(self):  # noqa: C901
-        # type: () -> None
+    def publish_impl(self) -> None:  # noqa: C901
         """
         Publishes Nodes first and then Relations
         :return:
@@ -224,17 +220,15 @@ class Neo4jCsvPublisher(Publisher):
                 tx.rollback()
             raise e
 
-    def get_scope(self):
-        # type: () -> str
+    def get_scope(self) -> str:
         return 'publisher.neo4j'
 
-    def _create_indices(self, node_file):
+    def _create_indices(self, node_file: str) -> None:
         """
         Go over the node file and try creating unique index
         :param node_file:
         :return:
         """
-        # type: (str) -> None
         LOGGER.info('Creating indices. (Existing indices will be ignored)')
 
         with open(node_file, 'r', encoding='utf8') as node_csv:
@@ -246,8 +240,7 @@ class Neo4jCsvPublisher(Publisher):
 
         LOGGER.info('Indices have been created.')
 
-    def _publish_node(self, node_file, tx):
-        # type: (str, Transaction) -> Transaction
+    def _publish_node(self, node_file: str, tx: Transaction) -> Transaction:
         """
         Iterate over the csv records of a file, each csv record transform to Merge statement and will be executed.
         All nodes should have a unique key, and this method will try to create unique index on the LABEL when it sees
@@ -271,8 +264,7 @@ class Neo4jCsvPublisher(Publisher):
                 tx = self._execute_statement(stmt, tx)
         return tx
 
-    def is_create_only_node(self, node_record):
-        # type: (dict) -> bool
+    def is_create_only_node(self, node_record: dict) -> bool:
         """
         Check if node can be updated
         :param node_record:
@@ -283,8 +275,7 @@ class Neo4jCsvPublisher(Publisher):
         else:
             return False
 
-    def create_node_merge_statement(self, node_record):
-        # type: (dict) -> str
+    def create_node_merge_statement(self, node_record: dict) -> str:
         """
         Creates node merge statement
         :param node_record:
@@ -301,8 +292,7 @@ class Neo4jCsvPublisher(Publisher):
 
         return NODE_MERGE_TEMPLATE.substitute(params)
 
-    def _publish_relation(self, relation_file, tx):
-        # type: (str, Transaction) -> Transaction
+    def _publish_relation(self, relation_file: str, tx: Transaction) -> Transaction:
         """
         Creates relation between two nodes.
         (In Amundsen, all relation is bi-directional)
@@ -345,8 +335,7 @@ class Neo4jCsvPublisher(Publisher):
 
         return tx
 
-    def create_relationship_merge_statement(self, rel_record):
-        # type: (dict) -> str
+    def create_relationship_merge_statement(self, rel_record: dict) -> str:
         """
         Creates relationship merge statement
         :param rel_record:
@@ -370,10 +359,9 @@ ON MATCH SET {update_prop_body}""".format(create_prop_body=create_prop_body,
         return RELATION_MERGE_TEMPLATE.substitute(param)
 
     def _create_props_body(self,
-                           record_dict,
-                           excludes,
-                           identifier):
-        # type: (dict, Set, str) -> str
+                           record_dict: dict,
+                           excludes: Set,
+                           identifier: str) -> str:
         """
         Creates properties body with params required for resolving template.
 
@@ -418,11 +406,10 @@ ON MATCH SET {update_prop_body}""".format(create_prop_body=create_prop_body,
         return ', '.join(props)
 
     def _execute_statement(self,
-                           stmt,
-                           tx,
-                           params=None,
-                           expect_result=False):
-        # type: (str, Transaction, bool) -> Transaction
+                           stmt: str,
+                           tx: Transaction,
+                           params: bool=None,
+                           expect_result: bool=False) -> Transaction:
         """
         Executes statement against Neo4j. If execution fails, it rollsback and raise exception.
         If 'expect_result' flag is True, it confirms if result object is not null.
@@ -456,9 +443,7 @@ ON MATCH SET {update_prop_body}""".format(create_prop_body=create_prop_body,
                 tx.rollback()
             raise e
 
-    def _try_create_index(self,
-                          label):
-        # type: (str) -> None
+    def _try_create_index(self, label: str) -> None:
         """
         For any label seen first time for this publisher it will try to create unique index.
         Neo4j ignores a second creation in 3.x, but raises an error in 4.x.

--- a/databuilder/publisher/neo4j_preprocessor.py
+++ b/databuilder/publisher/neo4j_preprocessor.py
@@ -23,13 +23,12 @@ class RelationPreprocessor(object, metaclass=abc.ABCMeta):
     """
 
     def preprocess_cypher(self,
-                          start_label,
-                          end_label,
-                          start_key,
-                          end_key,
-                          relation,
-                          reverse_relation):
-        # type: (str, str, str, str, str, str) -> Tuple[str, Dict[str, str]]
+                          start_label: str,
+                          end_label: str,
+                          start_key: str,
+                          end_key: str,
+                          relation: str,
+                          reverse_relation: str) -> Tuple[str, Dict[str, str]]:
         """
         Provides a Cypher statement that will be executed before publishing relations.
         :param start_label:
@@ -55,13 +54,12 @@ class RelationPreprocessor(object, metaclass=abc.ABCMeta):
 
     @abc.abstractmethod
     def preprocess_cypher_impl(self,
-                               start_label,
-                               end_label,
-                               start_key,
-                               end_key,
-                               relation,
-                               reverse_relation):
-        # type: (str, str, str, str, str, str) -> Tuple[str, Dict[str, str]]
+                               start_label: str,
+                               end_label: str,
+                               start_key: str,
+                               end_key: str,
+                               relation: str,
+                               reverse_relation: str) -> Tuple[str, Dict[str, str]]:
         """
         Provides a Cypher statement that will be executed before publishing relations.
         :param start_label:
@@ -73,13 +71,12 @@ class RelationPreprocessor(object, metaclass=abc.ABCMeta):
         pass
 
     def filter(self,
-               start_label,
-               end_label,
-               start_key,
-               end_key,
-               relation,
-               reverse_relation):
-        # type: (str, str, str, str, str, str) -> bool
+               start_label: str,
+               end_label: str,
+               start_key: str,
+               end_key: str,
+               relation: str,
+               reverse_relation: str) -> bool:
         """
         A method that filters pre-processing in record level. Returns True if it needs preprocessing, otherwise False.
         :param start_label:
@@ -93,8 +90,7 @@ class RelationPreprocessor(object, metaclass=abc.ABCMeta):
         True
 
     @abc.abstractmethod
-    def is_perform_preprocess(self):
-        # type: () -> bool
+    def is_perform_preprocess(self) -> bool:
         """
         A method for Neo4j Publisher to determine whether to perform pre-processing or not. Regard this method as a
         global filter.
@@ -106,17 +102,15 @@ class RelationPreprocessor(object, metaclass=abc.ABCMeta):
 class NoopRelationPreprocessor(RelationPreprocessor):
 
     def preprocess_cypher_impl(self,
-                               start_label,
-                               end_label,
-                               start_key,
-                               end_key,
-                               relation,
-                               reverse_relation):
-        # type: (str, str, str, str, str, str) -> Tuple[str, Dict[str, str]]
+                               start_label: str,
+                               end_label: str,
+                               start_key: str,
+                               end_key: str,
+                               relation: str,
+                               reverse_relation: str) -> Tuple[str, Dict[str, str]]:
         pass
 
-    def is_perform_preprocess(self):
-        # type: () -> bool
+    def is_perform_preprocess(self) -> bool:
         return False
 
 
@@ -145,8 +139,9 @@ class DeleteRelationPreprocessor(RelationPreprocessor):
     RETURN count(*) as count;
     """)
 
-    def __init__(self, label_tuples=None, where_clause=''):
-        # type: (List[Tuple[str, str]], str) -> None
+    def __init__(self,
+                 label_tuples: List[Tuple[str, str]] = None,
+                 where_clause: str = '') -> None:
         super(DeleteRelationPreprocessor, self).__init__()
         self._label_tuples = set(label_tuples) if label_tuples else set()
 
@@ -155,13 +150,12 @@ class DeleteRelationPreprocessor(RelationPreprocessor):
         self._where_clause = where_clause
 
     def preprocess_cypher_impl(self,
-                               start_label,
-                               end_label,
-                               start_key,
-                               end_key,
-                               relation,
-                               reverse_relation):
-        # type: (str, str, str, str, str, str) -> Tuple[str, Dict[str, str]]
+                               start_label: str,
+                               end_label: str,
+                               start_key: str,
+                               end_key: str,
+                               relation: str,
+                               reverse_relation: str) -> Tuple[str, Dict[str, str]]:
         """
         Provides DELETE Relation Cypher query on specific relation.
         :param start_label:
@@ -181,18 +175,16 @@ class DeleteRelationPreprocessor(RelationPreprocessor):
                                                                          end_label=end_label,
                                                                          where_clause=self._where_clause), params
 
-    def is_perform_preprocess(self):
-        # type: () -> bool
+    def is_perform_preprocess(self) -> bool:
         return True
 
     def filter(self,
-               start_label,
-               end_label,
-               start_key,
-               end_key,
-               relation,
-               reverse_relation):
-        # type: (str, str, str, str, str, str) -> bool
+               start_label: str,
+               end_label: str,
+               start_key: str,
+               end_key: str,
+               relation: str,
+               reverse_relation: str) -> bool:
         """
         If pair of labels is what client requested passed through label_tuples, filter will return True meaning that
         it needs to be pre-processed.

--- a/databuilder/publisher/neo4j_preprocessor.py
+++ b/databuilder/publisher/neo4j_preprocessor.py
@@ -4,7 +4,7 @@
 import abc
 
 import logging
-from typing import Dict, List, Tuple
+from typing import Dict, List, Tuple, Optional
 import textwrap
 
 LOGGER = logging.getLogger(__name__)
@@ -29,7 +29,7 @@ class RelationPreprocessor(object, metaclass=abc.ABCMeta):
                           start_key: str,
                           end_key: str,
                           relation: str,
-                          reverse_relation: str) -> Tuple[str, Dict[str, str]]:
+                          reverse_relation: str) -> Optional[Tuple[str, Dict[str, str]]]:
         """
         Provides a Cypher statement that will be executed before publishing relations.
         :param start_label:
@@ -52,6 +52,7 @@ class RelationPreprocessor(object, metaclass=abc.ABCMeta):
                                                end_key=end_key,
                                                relation=relation,
                                                reverse_relation=reverse_relation)
+        return None
 
     @abc.abstractmethod
     def preprocess_cypher_impl(self,
@@ -88,7 +89,7 @@ class RelationPreprocessor(object, metaclass=abc.ABCMeta):
         :param reverse_relation:
         :return: bool. True if it needs preprocessing, otherwise False.
         """
-        True
+        return True
 
     @abc.abstractmethod
     def is_perform_preprocess(self) -> bool:

--- a/databuilder/publisher/neo4j_preprocessor.py
+++ b/databuilder/publisher/neo4j_preprocessor.py
@@ -4,6 +4,7 @@
 import abc
 
 import logging
+from typing import Dict, List, Tuple
 import textwrap
 
 LOGGER = logging.getLogger(__name__)

--- a/databuilder/rest_api/base_rest_api_query.py
+++ b/databuilder/rest_api/base_rest_api_query.py
@@ -12,12 +12,11 @@ LOGGER = logging.getLogger(__name__)
 class BaseRestApiQuery(object, metaclass=abc.ABCMeta):
 
     @abc.abstractmethod
-    def execute(self):
+    def execute(self) -> Iterator[Dict[str, Any]]:
         """
         Provides iterator of the records. It uses iterator so that it can stream the result.
         :return:
         """
-        # type: () -> Iterator[Dict[str, Any]]
 
         return iter([dict()])
 
@@ -33,15 +32,11 @@ class RestApiQuerySeed(BaseRestApiQuery):
     """
 
     def __init__(self,
-                 seed_record  # type: Iterable[Dict[str, Any]]
-                 ):
-        # type: (...) -> None
-
+                 seed_record: Iterable[Dict[str, Any]]
+                 ) -> None:
         self._seed_record = seed_record
 
-    def execute(self):
-        # type: () -> Iterator[Dict[str, Any]]
-
+    def execute(self) -> Iterator[Dict[str, Any]]:
         return iter(self._seed_record)
 
 

--- a/databuilder/rest_api/base_rest_api_query.py
+++ b/databuilder/rest_api/base_rest_api_query.py
@@ -50,7 +50,5 @@ class EmptyRestApiQuerySeed(RestApiQuerySeed):
     Sometimes there simply isn't a record to seed with.
     """
 
-    def __init__(self):
-        # type: () -> None
-
+    def __init__(self) -> None:
         super(EmptyRestApiQuerySeed, self).__init__([{'empty_rest_api_query_seed': 1}])

--- a/databuilder/rest_api/mode_analytics/mode_paginated_rest_api_query.py
+++ b/databuilder/rest_api/mode_analytics/mode_paginated_rest_api_query.py
@@ -5,7 +5,7 @@ import logging
 
 import requests  # noqa: F401
 from jsonpath_rw import parse
-from typing import Any  # noqa: F401
+from typing import Any, Dict  # noqa: F401
 
 from databuilder.rest_api.rest_api_query import RestApiQuery
 

--- a/databuilder/rest_api/mode_analytics/mode_paginated_rest_api_query.py
+++ b/databuilder/rest_api/mode_analytics/mode_paginated_rest_api_query.py
@@ -26,9 +26,9 @@ class ModePaginatedRestApiQuery(RestApiQuery):
     """
 
     def __init__(self,
-                 pagination_json_path=LIST_REPORTS_PAGINATION_JSON_PATH,  # type: str
-                 max_record_size=DEFAULT_MAX_RECORD_SIZE,  # type: int
-                 **kwargs  # type: Any
+                 pagination_json_path: str = LIST_REPORTS_PAGINATION_JSON_PATH,
+                 max_record_size: int = DEFAULT_MAX_RECORD_SIZE,
+                 **kwargs: Any
                  ):
         # type (...) -> None
         super(ModePaginatedRestApiQuery, self).__init__(**kwargs)
@@ -39,9 +39,8 @@ class ModePaginatedRestApiQuery(RestApiQuery):
         self._pagination_jsonpath_expr = parse(pagination_json_path)
 
     def _preprocess_url(self,
-                        record,  # type: Dict[str, Any]
-                        ):
-        # type: (...) -> str
+                        record: Dict[str, Any],
+                        ) -> str:
         """
         Updates URL with page information
         :param record:
@@ -55,9 +54,8 @@ class ModePaginatedRestApiQuery(RestApiQuery):
         return self._url.format(**record)
 
     def _post_process(self,
-                      response,  # type: requests.Response
-                      ):
-        # type: (...) -> None
+                      response: requests.Response,
+                      ) -> None:
         """
         Updates trigger to pagination (self._more_pages) as well as current_page (self._current_page)
         Mode does not have explicit indicator that it just the number of records need to be certain number that

--- a/databuilder/rest_api/mode_analytics/mode_paginated_rest_api_query.py
+++ b/databuilder/rest_api/mode_analytics/mode_paginated_rest_api_query.py
@@ -49,8 +49,7 @@ class ModePaginatedRestApiQuery(RestApiQuery):
         page_suffix = PAGE_SUFFIX_TEMPLATE.format(self._current_page)  # example: ?page=2
 
         # example: http://foo.bar/resources?page=2
-        self._url = self._original_url + '{page_suffix}'.format(original_url=self._original_url,
-                                                                page_suffix=page_suffix)
+        self._url = self._original_url + '{page_suffix}'.format(page_suffix=page_suffix)
         return self._url.format(**record)
 
     def _post_process(self,

--- a/databuilder/rest_api/rest_api_failure_handlers.py
+++ b/databuilder/rest_api/rest_api_failure_handlers.py
@@ -26,12 +26,10 @@ class HttpFailureSkipOnStatus(BaseFailureHandler):
     def can_skip_failure(self,
                          exception: Exception,
                          ) -> bool:
-
-        if isinstance(exception, HTTPError):
-            try:
-                status_code: int = getattr(getattr(exception, 'response'), 'status_code')
-                return status_code in self._status_codes_to_skip
-            except AttributeError:
-                pass
+        try:
+            status_code: int = getattr(getattr(exception, 'response'), 'status_code')
+            return status_code in self._status_codes_to_skip
+        except AttributeError:
+            pass
 
         return False

--- a/databuilder/rest_api/rest_api_failure_handlers.py
+++ b/databuilder/rest_api/rest_api_failure_handlers.py
@@ -11,24 +11,21 @@ class BaseFailureHandler(object, metaclass=abc.ABCMeta):
 
     @abc.abstractmethod
     def can_skip_failure(self,
-                         exception,  # type: Exception
-                         ):
-        # type: (...) -> bool
+                         exception: Exception,
+                         ) -> bool:
         pass
 
 
 class HttpFailureSkipOnStatus(BaseFailureHandler):
 
     def __init__(self,
-                 status_codes_to_skip,  # type: Iterable[int]
-                 ):
-        # type: (...) -> None
+                 status_codes_to_skip: Iterable[int],
+                 ) -> None:
         self._status_codes_to_skip = {v for v in status_codes_to_skip}
 
     def can_skip_failure(self,
-                         exception,  # type: Exception
-                         ):
-        # type: (...) -> bool
+                         exception: Exception,
+                         ) -> bool:
 
         if (isinstance(exception, HTTPError) or hasattr(exception, 'response')) \
                 and exception.response.status_code in self._status_codes_to_skip:

--- a/databuilder/rest_api/rest_api_failure_handlers.py
+++ b/databuilder/rest_api/rest_api_failure_handlers.py
@@ -3,8 +3,7 @@
 
 import abc
 
-from requests.exceptions import HTTPError
-from typing import Iterable, Union, List, Dict, Any, Optional  # noqa: F401
+from typing import Iterable
 
 
 class BaseFailureHandler(object, metaclass=abc.ABCMeta):

--- a/databuilder/rest_api/rest_api_failure_handlers.py
+++ b/databuilder/rest_api/rest_api_failure_handlers.py
@@ -27,8 +27,11 @@ class HttpFailureSkipOnStatus(BaseFailureHandler):
                          exception: Exception,
                          ) -> bool:
 
-        if (isinstance(exception, HTTPError) or hasattr(exception, 'response')) \
-                and exception.response.status_code in self._status_codes_to_skip:
-            return True
+        if isinstance(exception, HTTPError):
+            try:
+                status_code: int = getattr(getattr(exception, 'response'), 'status_code')
+                return status_code in self._status_codes_to_skip
+            except AttributeError:
+                pass
 
         return False

--- a/databuilder/rest_api/rest_api_query.py
+++ b/databuilder/rest_api/rest_api_query.py
@@ -51,20 +51,18 @@ class RestApiQuery(BaseRestApiQuery):
     """
 
     def __init__(self,
-                 query_to_join,  # type: BaseRestApiQuery
-                 url,  # type: str
-                 params,  # type: Dict[str, Any]
-                 json_path,  # type: str
-                 field_names,  # type: List[str]
-                 fail_no_result=False,  # type: bool
-                 skip_no_result=False,  # type: bool
-                 json_path_contains_or=False,  # type: bool
-                 can_skip_failure=None,  # type: Callable,
-                 **kwargs  # type: Any
-                 ):
-        # type: (...) -> None
+                 query_to_join: BaseRestApiQuery,
+                 url: str,
+                 params: Dict[str, Any],
+                 json_path: str,
+                 field_names: List[str],
+                 fail_no_result: bool=False,
+                 skip_no_result: bool=False,
+                 json_path_contains_or: bool=False,
+                 can_skip_failure: Callable=None,
+                 **kwargs
+                 ) -> None:
         """
-
         :param query_to_join: Previous query to JOIN. RestApiQuerySeed can be used for the first query
         :param url: URL string. It will use <str>.format operation using record that comes from previous query to
         substitute any variable that URL has.
@@ -131,8 +129,7 @@ class RestApiQuery(BaseRestApiQuery):
         self._can_skip_failure = can_skip_failure
         self._more_pages = False
 
-    def execute(self):  # noqa: C901
-        # type: () -> Iterator[Dict[str, Any]]
+    def execute(self) -> Iterator[Dict[str, Any]]:  # noqa: C901
         self._authenticate()
 
         for record_dict in self._inner_rest_api_query.execute():
@@ -182,10 +179,7 @@ class RestApiQuery(BaseRestApiQuery):
 
                 self._post_process(response)
 
-    def _preprocess_url(self,
-                        record,  # type: Dict[str, Any]
-                        ):
-        # type: (...) -> str
+    def _preprocess_url(self, record: Dict[str, Any]) -> str:
         """
         Performs variable substitution using a dict comes as a record from previous query.
         :param record:
@@ -210,10 +204,10 @@ class RestApiQuery(BaseRestApiQuery):
 
     @classmethod
     def _compute_sub_records(cls,
-                             result_list,  # type: List
-                             field_names,  # type: List[str]
-                             json_path_contains_or=False,  # type: bool
-                             ):
+                             result_list: List[Any],
+                             field_names: List[str],
+                             json_path_contains_or: bool=False,
+                             ) -> List[List[Any]]:
         """
         The behavior of JSONPATH is different when it's extracting multiple fields using AND(,) vs OR(|)
         If it uses AND(,), first n records will be first record. If it uses OR(|), it will list first field of all
@@ -238,7 +232,6 @@ class RestApiQuery(BaseRestApiQuery):
         :param json_path_contains_or:
         :return:
         """
-        # type: (...) -> List[List[Any]]
 
         if not field_names:
             raise Exception('Field names should not be empty')
@@ -254,18 +247,14 @@ class RestApiQuery(BaseRestApiQuery):
 
         return result
 
-    def _post_process(self,
-                      response,  # type: requests.Response
-                      ):
-        # type: (...) -> None
+    def _post_process(self, response: requests.Response) -> None:
         """
         Extension point for post-processing such thing as pagination
         :return:
         """
         pass
 
-    def _authenticate(self):
-        # type: (...) -> None
+    def _authenticate(self) -> None:
         """
         Extension point to support other authentication mechanism such as Oauth.
         Subclass this class and implement authentication process.

--- a/databuilder/rest_api/rest_api_query.py
+++ b/databuilder/rest_api/rest_api_query.py
@@ -60,7 +60,7 @@ class RestApiQuery(BaseRestApiQuery):
                  skip_no_result: bool=False,
                  json_path_contains_or: bool=False,
                  can_skip_failure: Callable=None,
-                 **kwargs
+                 **kwargs: Any
                  ) -> None:
         """
         :param query_to_join: Previous query to JOIN. RestApiQuerySeed can be used for the first query

--- a/databuilder/task/base_task.py
+++ b/databuilder/task/base_task.py
@@ -13,19 +13,16 @@ class Task(Scoped):
     A Abstract task that can run an abstract task
     """
     @abc.abstractmethod
-    def init(self, conf):
-        # type: (ConfigTree) -> None
+    def init(self, conf: ConfigTree) -> None:
         pass
 
     @abc.abstractmethod
-    def run(self):
-        # type: () -> None
+    def run(self) -> None:
         """
         Runs a task
         :return:
         """
         pass
 
-    def get_scope(self):
-        # type: () -> str
+    def get_scope(self) -> str:
         return 'task'

--- a/databuilder/task/neo4j_staleness_removal_task.py
+++ b/databuilder/task/neo4j_staleness_removal_task.py
@@ -101,8 +101,7 @@ class Neo4jStalenessRemovalTask(Task):
                                  encrypted=conf.get_bool(NEO4J_ENCRYPTED),
                                  trust=trust)
 
-    def run(self):
-        # type: () -> None
+    def run(self) -> None:
         """
         First, performs a safety check to make sure this operation would not delete more than a threshold where
         default threshold is 5%. Once it passes a safety check, it will first delete stale nodes, and then stale
@@ -113,13 +112,12 @@ class Neo4jStalenessRemovalTask(Task):
         self._delete_stale_nodes()
         self._delete_stale_relations()
 
-    def validate(self):
+    def validate(self) -> None:
         """
         Validation method. Focused on limit the risk on deleting nodes and relations.
          - Check if deleted nodes will be within 10% of total nodes.
         :return:
         """
-        # type: () -> None
         self._validate_node_staleness_pct()
         self._validate_relation_staleness_pct()
 

--- a/databuilder/task/neo4j_staleness_removal_task.py
+++ b/databuilder/task/neo4j_staleness_removal_task.py
@@ -63,16 +63,13 @@ class Neo4jStalenessRemovalTask(Task):
 
     """
 
-    def __init__(self):
-        # type: () -> None
+    def __init__(self) -> None:
         pass
 
-    def get_scope(self):
-        # type: () -> str
+    def get_scope(self) -> str:
         return 'task.remove_stale_data'
 
-    def init(self, conf):
-        # type: (ConfigTree) -> None
+    def init(self, conf: ConfigTree) -> None:
         conf = Scoped.get_scoped_conf(conf, self.get_scope()) \
             .with_fallback(conf) \
             .with_fallback(DEFAULT_CONFIG)

--- a/databuilder/task/task.py
+++ b/databuilder/task/task.py
@@ -28,10 +28,9 @@ class DefaultTask(Task):
     PROGRESS_REPORT_FREQUENCY = 'progress_report_frequency'
 
     def __init__(self,
-                 extractor,
-                 loader,
-                 transformer=NoopTransformer()):
-        # type: (Extractor, Loader, Transformer) -> None
+                 extractor: Extractor,
+                 loader: Loader,
+                 transformer: Transformer = NoopTransformer()) -> None:
         self.extractor = extractor
         self.transformer = transformer
         self.loader = loader
@@ -41,8 +40,7 @@ class DefaultTask(Task):
         self._closer.register(self.transformer.close)
         self._closer.register(self.loader.close)
 
-    def init(self, conf):
-        # type: (ConfigTree) -> None
+    def init(self, conf: ConfigTree) -> None:
         self._progress_report_frequency = \
             conf.get_int('{}.{}'.format(self.get_scope(), DefaultTask.PROGRESS_REPORT_FREQUENCY), 500)
 
@@ -50,8 +48,7 @@ class DefaultTask(Task):
         self.transformer.init(Scoped.get_scoped_conf(conf, self.transformer.get_scope()))
         self.loader.init(Scoped.get_scoped_conf(conf, self.loader.get_scope()))
 
-    def run(self):
-        # type: () -> None
+    def run(self) -> None:
         """
         Runs a task
         :return:

--- a/databuilder/transformer/base_transformer.py
+++ b/databuilder/transformer/base_transformer.py
@@ -14,13 +14,11 @@ class Transformer(Scoped):
     A transformer transforms a record
     """
     @abc.abstractmethod
-    def init(self, conf):
-        # type: (ConfigTree) -> None
+    def init(self, conf: ConfigTree) -> None:
         pass
 
     @abc.abstractmethod
-    def transform(self, record):
-        # type: (Any) -> Any
+    def transform(self, record: Any) -> Any:
         pass
 
 
@@ -29,16 +27,13 @@ class NoopTransformer(Transformer):
     A no-op transformer
     """
 
-    def init(self, conf):
-        # type: (ConfigTree) -> None
+    def init(self, conf: ConfigTree) -> None:
         pass
 
-    def transform(self, record):
-        # type: (Any) -> Any
+    def transform(self, record: Any) -> Any:
         return record
 
-    def get_scope(self):
-        # type: () -> str
+    def get_scope(self) -> str:
         pass
 
 
@@ -48,20 +43,17 @@ class ChainedTransformer(Transformer):
     """
 
     def __init__(self,
-                 transformers,
-                 is_init_transformers=False):
-        # type: (Iterable[Transformer], Optional[bool]) -> None
+                 transformers: Iterable[Transformer],
+                 is_init_transformers: Optional[bool] = False) -> None:
         self.transformers = transformers
         self.is_init_transformers = is_init_transformers
 
-    def init(self, conf):
-        # type: (ConfigTree) -> None
+    def init(self, conf: ConfigTree) -> None:
         if self.is_init_transformers:
             for transformer in self.transformers:
                 transformer.init(Scoped.get_scoped_conf(conf, transformer.get_scope()))
 
-    def transform(self, record):
-        # type: (Any) -> Any
+    def transform(self, record: Any) -> Any:
         for t in self.transformers:
             record = t.transform(record)
             # Check filtered record
@@ -70,11 +62,9 @@ class ChainedTransformer(Transformer):
 
         return record
 
-    def get_scope(self):
-        # type: () -> str
+    def get_scope(self) -> str:
         return 'transformer.chained'
 
-    def close(self):
-        # type: () -> None
+    def close(self) -> None:
         for t in self.transformers:
             t.close()

--- a/databuilder/transformer/bigquery_usage_transformer.py
+++ b/databuilder/transformer/bigquery_usage_transformer.py
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 from pyhocon import ConfigTree  # noqa: F401
-from typing import Dict, Optional  # noqa: F401
+from typing import Dict, Optional, Tuple  # noqa: F401
 
 from databuilder.transformer.base_transformer import Transformer
 from databuilder.models.table_column_usage import ColumnReader, TableColumnUsage
@@ -18,7 +18,7 @@ class BigqueryUsageTransformer(Transformer):
         """
         self.conf = conf
 
-    def transform(self, record: Dict) -> Optional[TableColumnUsage]:
+    def transform(self, record: Tuple[TableColumnUsageTuple, int]) -> Optional[TableColumnUsage]:
         if not record:
             return None
 

--- a/databuilder/transformer/bigquery_usage_transformer.py
+++ b/databuilder/transformer/bigquery_usage_transformer.py
@@ -11,16 +11,14 @@ from databuilder.extractor.bigquery_usage_extractor import TableColumnUsageTuple
 
 class BigqueryUsageTransformer(Transformer):
 
-    def init(self, conf):
-        # type: (ConfigTree) -> None
+    def init(self, conf: ConfigTree) -> None:
         """
         Transformer to convert TableColumnUsageTuple data to bigquery usage data
         which can be uploaded to Neo4j
         """
         self.conf = conf
 
-    def transform(self, record):
-        # type: (Dict) -> Optional[TableColumnUsage]
+    def transform(self, record: Dict) -> Optional[TableColumnUsage]:
         if not record:
             return None
 
@@ -40,6 +38,5 @@ class BigqueryUsageTransformer(Transformer):
 
         return TableColumnUsage(col_readers=col_readers)
 
-    def get_scope(self):
-        # type: () -> str
+    def get_scope(self) -> str:
         return 'transformer.bigquery_usage'

--- a/databuilder/transformer/dict_to_model.py
+++ b/databuilder/transformer/dict_to_model.py
@@ -20,14 +20,12 @@ class DictToModel(Transformer):
     """
 
     def init(self, conf: ConfigTree) -> None:
-
         model_class = conf.get_string(MODEL_CLASS)
         module_name, class_name = model_class.rsplit(".", 1)
         mod = importlib.import_module(module_name)
         self._model_class = getattr(mod, class_name)
 
     def transform(self, record: Dict[str, Any]) -> Dict[str, Any]:
-
         return self._model_class(**record)
 
     def get_scope(self) -> str:

--- a/databuilder/transformer/dict_to_model.py
+++ b/databuilder/transformer/dict_to_model.py
@@ -19,19 +19,16 @@ class DictToModel(Transformer):
     Transforms dictionary into model
     """
 
-    def init(self, conf):
-        # type: (ConfigTree) -> None
+    def init(self, conf: ConfigTree) -> None:
 
         model_class = conf.get_string(MODEL_CLASS)
         module_name, class_name = model_class.rsplit(".", 1)
         mod = importlib.import_module(module_name)
         self._model_class = getattr(mod, class_name)
 
-    def transform(self, record):
-        # type: (Dict[str, Any]) -> Dict[str, Any]
+    def transform(self, record: Dict[str, Any]) -> Dict[str, Any]:
 
         return self._model_class(**record)
 
-    def get_scope(self):
-        # type: () -> str
+    def get_scope(self) -> str:
         return 'transformer.dict_to_model'

--- a/databuilder/transformer/generic_transformer.py
+++ b/databuilder/transformer/generic_transformer.py
@@ -19,13 +19,11 @@ class GenericTransformer(Transformer):
     A generic transformer that accepts a callback function that transforms the record on specified field.
     """
 
-    def init(self, conf):
-        # type: (ConfigTree) -> None
+    def init(self, conf: ConfigTree) -> None:
         self._callback_function = conf.get(CALLBACK_FUNCTION)
         self._field_name = conf.get_string(FIELD_NAME)
 
-    def transform(self, record):
-        # type: (Dict[str, Any]) -> Dict[str, Any]
+    def transform(self, record: Dict[str, Any]) -> Dict[str, Any]:
 
         for k, v in record.items():
             if k == self._field_name:
@@ -33,6 +31,5 @@ class GenericTransformer(Transformer):
                 record[k] = new_val
         return record
 
-    def get_scope(self):
-        # type: () -> str
+    def get_scope(self) -> str:
         return 'transformer.generic'

--- a/databuilder/transformer/regex_str_replace_transformer.py
+++ b/databuilder/transformer/regex_str_replace_transformer.py
@@ -24,13 +24,11 @@ class RegexStrReplaceTransformer(Transformer):
     Any non-string values will be ignored.
     """
 
-    def init(self, conf):
-        # type: (ConfigTree) -> None
+    def init(self, conf: ConfigTree) -> None:
         self._regex_replace_tuples = conf.get_list(REGEX_REPLACE_TUPLE_LIST)
         self._attribute_name = conf.get_string(ATTRIBUTE_NAME)
 
-    def transform(self, record):
-        # type: (Any) -> Any
+    def transform(self, record: Any) -> Any:
 
         if isinstance(record, dict):
             val = record.get(self._attribute_name)
@@ -50,6 +48,5 @@ class RegexStrReplaceTransformer(Transformer):
 
         return record
 
-    def get_scope(self):
-        # type: () -> str
+    def get_scope(self) -> str:
         return 'transformer.regex_str_replace'

--- a/databuilder/transformer/remove_field_transformer.py
+++ b/databuilder/transformer/remove_field_transformer.py
@@ -19,12 +19,10 @@ class RemoveFieldTransformer(Transformer):
 
     """
 
-    def init(self, conf):
-        # type: (ConfigTree) -> None
+    def init(self, conf: ConfigTree) -> None:
         self._field_names = conf.get_list(FIELD_NAMES)
 
-    def transform(self, record):
-        # type: (Dict[str, Any]) -> Dict[str, Any]
+    def transform(self, record: Dict[str, Any]) -> Dict[str, Any]:
 
         for k in self._field_names:
             if k in record:
@@ -32,6 +30,5 @@ class RemoveFieldTransformer(Transformer):
 
         return record
 
-    def get_scope(self):
-        # type: () -> str
+    def get_scope(self) -> str:
         return 'transformer.remove_field'

--- a/databuilder/transformer/table_tag_transformer.py
+++ b/databuilder/transformer/table_tag_transformer.py
@@ -1,7 +1,8 @@
 # Copyright Contributors to the Amundsen project.
 # SPDX-License-Identifier: Apache-2.0
 
-from pyhocon import ConfigFactory
+from pyhocon import ConfigFactory, ConfigTree
+from typing import Any
 
 from databuilder.transformer.base_transformer import Transformer
 from databuilder.models.table_metadata import TableMetadata
@@ -13,13 +14,13 @@ class TableTagTransformer(Transformer):
     TAGS = 'tags'
     DEFAULT_CONFIG = ConfigFactory.from_dict({TAGS: None})
 
-    def init(self, conf):
+    def init(self, conf: ConfigTree) -> None:
         conf = conf.with_fallback(TableTagTransformer.DEFAULT_CONFIG)
         tags = conf.get_string(TableTagTransformer.TAGS)
 
         self.tags = TableMetadata.format_tags(tags)
 
-    def transform(self, record):
+    def transform(self, record: Any) -> Any:
         if isinstance(record, TableMetadata):
             if record.tags:
                 record.tags += self.tags

--- a/databuilder/transformer/table_tag_transformer.py
+++ b/databuilder/transformer/table_tag_transformer.py
@@ -27,6 +27,5 @@ class TableTagTransformer(Transformer):
                 record.tags = self.tags
         return record
 
-    def get_scope(self):
-        # type: () -> str
+    def get_scope(self) -> str:
         return 'transformer.table_tag'

--- a/databuilder/transformer/template_variable_substitution_transformer.py
+++ b/databuilder/transformer/template_variable_substitution_transformer.py
@@ -21,19 +21,16 @@ class TemplateVariableSubstitutionTransformer(Transformer):
 
     """
 
-    def init(self, conf):
-        # type: (ConfigTree) -> None
+    def init(self, conf: ConfigTree) -> None:
 
         self._template = conf.get_string(TEMPLATE)
         self._field_name = conf.get_string(FIELD_NAME)
 
-    def transform(self, record):
-        # type: (Dict[str, Any]) -> Dict[str, Any]
+    def transform(self, record: Dict[str, Any]) -> Dict[str, Any]:
 
         val = self._template.format(**record)
         record[self._field_name] = val
         return record
 
-    def get_scope(self):
-        # type: () -> str
+    def get_scope(self) -> str:
         return 'transformer.template_variable_substitution'

--- a/databuilder/transformer/timestamp_string_to_epoch.py
+++ b/databuilder/transformer/timestamp_string_to_epoch.py
@@ -23,14 +23,12 @@ class TimestampStringToEpoch(Transformer):
     Transforms string timestamp into epoch
     """
 
-    def init(self, conf):
-        # type: (ConfigTree) -> None
+    def init(self, conf: ConfigTree) -> None:
         self._conf = conf.with_fallback(DEFAULT_CONFIG)
         self._timestamp_format = self._conf.get_string(TIMESTAMP_FORMAT)
         self._field_name = self._conf.get_string(FIELD_NAME)
 
-    def transform(self, record):
-        # type: (Dict[str, Any]) -> Dict[str, Any]
+    def transform(self, record: Dict[str, Any]) -> Dict[str, Any]:
         timestamp_str = record.get(self._field_name, '')
 
         if not timestamp_str:
@@ -41,6 +39,5 @@ class TimestampStringToEpoch(Transformer):
         record[self._field_name] = int((utc_dt - datetime(1970, 1, 1)).total_seconds())
         return record
 
-    def get_scope(self):
-        # type: () -> str
+    def get_scope(self) -> str:
         return 'transformer.timestamp_str_to_epoch'

--- a/databuilder/utils/closer.py
+++ b/databuilder/utils/closer.py
@@ -16,13 +16,11 @@ class Closer(object):
     as closeable instance can have dependency each other.
     """
 
-    def __init__(self):
-        # type: () -> None
-        self._stack = []  # type: List
+    def __init__(self) -> None:
+        self._stack: List = []
         atexit.register(self.close)
 
-    def register(self, close_callable):
-        # type: (Callable) -> None
+    def register(self, close_callable: Callable) -> None:
         """
         Register closeable callable.
         :param close_callable:
@@ -34,8 +32,7 @@ class Closer(object):
 
         self._stack.append(close_callable)
 
-    def close(self):
-        # type: () -> None
+    def close(self) -> None:
         """
         Execute all closeable callable in LIFO order.
         All registered callable will be guaranteed to be executed. If there

--- a/requirements.txt
+++ b/requirements.txt
@@ -49,6 +49,7 @@ sqlalchemy>=1.3.0,<2.0
 wheel==0.31.1
 neo4j-driver==1.7.2
 neotime==1.7.1
+mypy==0.782
 pytz==2018.4
 statsd==3.2.1
 retrying==1.3.3

--- a/setup.cfg
+++ b/setup.cfg
@@ -22,8 +22,5 @@ output = build/coverage.xml
 directory = build/coverage_html
 
 [mypy]
-python_version = 2.7
+python_version = 3.6
 disallow_untyped_defs = True
-ignore_missing_imports = True
-strict_optional = True
-warn_no_return = True

--- a/setup.cfg
+++ b/setup.cfg
@@ -24,3 +24,4 @@ directory = build/coverage_html
 [mypy]
 python_version = 3.6
 disallow_untyped_defs = True
+ignore_missing_imports = True

--- a/tests/unit/callback/test_call_back.py
+++ b/tests/unit/callback/test_call_back.py
@@ -10,8 +10,7 @@ from databuilder.callback import call_back
 
 class TestCallBack(unittest.TestCase):
 
-    def test_success_notify(self):
-        # type: () -> None
+    def test_success_notify(self) -> None:
         callback1 = MagicMock()
         callback2 = MagicMock()
         callbacks = [callback1, callback2]
@@ -23,8 +22,7 @@ class TestCallBack(unittest.TestCase):
         self.assertTrue(callback2.on_success.called)
         self.assertTrue(not callback2.on_failure.called)
 
-    def test_failure_notify(self):
-        # type: () -> None
+    def test_failure_notify(self) -> None:
         callback1 = MagicMock()
         callback2 = MagicMock()
         callbacks = [callback1, callback2]
@@ -36,8 +34,7 @@ class TestCallBack(unittest.TestCase):
         self.assertTrue(not callback2.on_success.called)
         self.assertTrue(callback2.on_failure.called)
 
-    def test_notify_failure(self):
-        # type: () -> None
+    def test_notify_failure(self) -> None:
         callback1 = MagicMock()
         callback2 = MagicMock()
         callback2.on_success.side_effect = Exception('Boom')

--- a/tests/unit/callback/test_call_back.py
+++ b/tests/unit/callback/test_call_back.py
@@ -4,8 +4,9 @@
 import unittest
 
 from mock import MagicMock
+from typings import List
 
-from databuilder.callback import call_back
+from databuilder.callback.call_back import Callback, notify_callbacks
 
 
 class TestCallBack(unittest.TestCase):
@@ -13,9 +14,9 @@ class TestCallBack(unittest.TestCase):
     def test_success_notify(self) -> None:
         callback1 = MagicMock()
         callback2 = MagicMock()
-        callbacks = [callback1, callback2]
+        callbacks: List[Callback] = [callback1, callback2]
 
-        call_back.notify_callbacks(callbacks, is_success=True)
+        notify_callbacks(callbacks, is_success=True)
 
         self.assertTrue(callback1.on_success.called)
         self.assertTrue(not callback1.on_failure.called)
@@ -25,9 +26,9 @@ class TestCallBack(unittest.TestCase):
     def test_failure_notify(self) -> None:
         callback1 = MagicMock()
         callback2 = MagicMock()
-        callbacks = [callback1, callback2]
+        callbacks: List[Callback] = [callback1, callback2]
 
-        call_back.notify_callbacks(callbacks, is_success=False)
+        notify_callbacks(callbacks, is_success=False)
 
         self.assertTrue(not callback1.on_success.called)
         self.assertTrue(callback1.on_failure.called)
@@ -39,10 +40,10 @@ class TestCallBack(unittest.TestCase):
         callback2 = MagicMock()
         callback2.on_success.side_effect = Exception('Boom')
         callback3 = MagicMock()
-        callbacks = [callback1, callback2, callback3]
+        callbacks: List[Callback] = [callback1, callback2, callback3]
 
         try:
-            call_back.notify_callbacks(callbacks, is_success=True)
+            notify_callbacks(callbacks, is_success=True)
             self.assertTrue(False)
         except Exception:
             self.assertTrue(True)

--- a/tests/unit/callback/test_call_back.py
+++ b/tests/unit/callback/test_call_back.py
@@ -4,7 +4,7 @@
 import unittest
 
 from mock import MagicMock
-from typings import List
+from typing import List
 
 from databuilder.callback.call_back import Callback, notify_callbacks
 

--- a/tests/unit/extractor/dashboard/redash/test_redash_dashboard_extractor.py
+++ b/tests/unit/extractor/dashboard/redash/test_redash_dashboard_extractor.py
@@ -6,6 +6,7 @@ import unittest
 
 from mock import patch
 from pyhocon import ConfigFactory  # noqa: F401
+from typing import Any, Dict, List
 
 from databuilder import Scoped
 from databuilder.extractor.dashboard.redash.redash_dashboard_extractor import \
@@ -19,30 +20,29 @@ from databuilder.models.dashboard.dashboard_table import DashboardTable
 logging.basicConfig(level=logging.INFO)
 
 
-def dummy_tables(*args):
+def dummy_tables(*args: Any) -> List[TableRelationData]:
     return [TableRelationData('some_db', 'prod', 'public', 'users')]
 
 
 class MockApiResponse:
-    def __init__(self, data):
+    def __init__(self, data: Any) -> None:
         self.json_data = data
         self.status_code = 200
 
-    def json(self):
+    def json(self) -> Any:
         return self.json_data
 
-    def raise_for_status(self):
+    def raise_for_status(self) -> None:
         pass
 
 
 class TestRedashDashboardExtractor(unittest.TestCase):
-    def test_table_relation_data(self):
+    def test_table_relation_data(self) -> None:
         tr = TableRelationData('db', 'cluster', 'schema', 'tbl')
         self.assertEqual(tr.key, 'db://cluster.schema/tbl')
 
-    def test_with_one_dashboard(self):
-
-        def mock_api_get(url, *args, **kwargs):
+    def test_with_one_dashboard(self) -> None:
+        def mock_api_get(url: str, *args: Any, **kwargs: Any) -> MockApiResponse:
             if 'test-dash' in url:
                 return MockApiResponse({
                     'id': 123,
@@ -108,41 +108,41 @@ class TestRedashDashboardExtractor(unittest.TestCase):
 
             # DashboardLastModified
             record = extractor.extract()
-            identity = {
+            identity: Dict[str, Any] = {
                 'dashboard_id': 123,
                 'dashboard_group_id': RedashDashboardExtractor.DASHBOARD_GROUP_ID,
                 'product': RedashDashboardExtractor.PRODUCT,
                 'cluster': u'prod'
             }
-            expected = DashboardLastModifiedTimestamp(
+            expected_timestamp = DashboardLastModifiedTimestamp(
                 last_modified_timestamp=1577923200,
                 **identity
             )
-            self.assertEqual(record.__repr__(), expected.__repr__())
+            self.assertEqual(record.__repr__(), expected_timestamp.__repr__())
 
             # DashboardOwner
             record = extractor.extract()
-            expected = DashboardOwner(email='asdf@example.com', **identity)
-            self.assertEqual(record.__repr__(), expected.__repr__())
+            expected_owner = DashboardOwner(email='asdf@example.com', **identity)
+            self.assertEqual(record.__repr__(), expected_owner.__repr__())
 
             # DashboardQuery
             record = extractor.extract()
-            expected = DashboardQuery(
-                query_id=1234,
+            expected_query = DashboardQuery(
+                query_id='1234',
                 query_name='Test Query',
                 url=u'{base}/queries/1234'.format(base=redash_base_url),
                 query_text='SELECT id FROM users',
                 **identity
             )
-            self.assertEqual(record.__repr__(), expected.__repr__())
+            self.assertEqual(record.__repr__(), expected_query.__repr__())
 
             # DashboardTable
             record = extractor.extract()
-            expected = DashboardTable(
+            expected_table = DashboardTable(
                 table_ids=[TableRelationData('some_db', 'prod', 'public', 'users').key],
                 **identity
             )
-            self.assertEqual(record.__repr__(), expected.__repr__())
+            self.assertEqual(record.__repr__(), expected_table.__repr__())
 
 
 if __name__ == '__main__':

--- a/tests/unit/extractor/dashboard/redash/test_redash_dashboard_extractor.py
+++ b/tests/unit/extractor/dashboard/redash/test_redash_dashboard_extractor.py
@@ -51,7 +51,7 @@ class TestRedashDashboardExtractor(unittest.TestCase):
                             'visualization': {
                                 'query': {
                                     'data_source_id': 1,
-                                    'id': 1234,
+                                    'id': '1234',
                                     'name': 'Test Query',
                                     'query': 'SELECT id FROM users'
                                 }

--- a/tests/unit/extractor/dashboard/redash/test_redash_dashboard_utils.py
+++ b/tests/unit/extractor/dashboard/redash/test_redash_dashboard_utils.py
@@ -6,6 +6,7 @@ import random
 import unittest
 
 from mock import patch
+from typing import Any, Dict, List
 
 from databuilder.rest_api.base_rest_api_query import EmptyRestApiQuerySeed
 from databuilder.extractor.dashboard.redash.redash_dashboard_utils import \
@@ -40,7 +41,7 @@ class TestRedashDashboardUtils(unittest.TestCase):
         self.assertListEqual([widget['text'] for widget in sorted_widgets], ['a', 'b', 'c', 'd'])
 
     def test_widget_filters(self) -> None:
-        widgets = [
+        widgets: List[Dict[str, Any]] = [
             {'text': 'asdf', 'options': {'ex': 1}},
             {'text': 'asdf', 'options': {'ex': 2}},
             {'visualization': {}, 'options': {'ex': 1}},

--- a/tests/unit/extractor/dashboard/redash/test_redash_dashboard_utils.py
+++ b/tests/unit/extractor/dashboard/redash/test_redash_dashboard_utils.py
@@ -16,7 +16,7 @@ logging.basicConfig(level=logging.INFO)
 
 
 class TestRedashDashboardUtils(unittest.TestCase):
-    def test_sort_widgets(self):
+    def test_sort_widgets(self) -> None:
         widgets = [
             {
                 'text': 'a',
@@ -39,7 +39,7 @@ class TestRedashDashboardUtils(unittest.TestCase):
         sorted_widgets = sort_widgets(widgets)
         self.assertListEqual([widget['text'] for widget in sorted_widgets], ['a', 'b', 'c', 'd'])
 
-    def test_widget_filters(self):
+    def test_widget_filters(self) -> None:
         widgets = [
             {'text': 'asdf', 'options': {'ex': 1}},
             {'text': 'asdf', 'options': {'ex': 2}},
@@ -50,14 +50,14 @@ class TestRedashDashboardUtils(unittest.TestCase):
         self.assertEqual(len(get_text_widgets(widgets)), 2)
         self.assertEqual(len(get_visualization_widgets(widgets)), 3)
 
-    def test_text_widget_props(self):
+    def test_text_widget_props(self) -> None:
         widget_data = {
             'text': 'asdf'
         }
         widget = get_text_widgets([widget_data])[0]
         self.assertEqual(widget.text, 'asdf')
 
-    def test_visualization_widget_props(self):
+    def test_visualization_widget_props(self) -> None:
         widget_data = {
             'visualization': {
                 'query': {
@@ -75,7 +75,7 @@ class TestRedashDashboardUtils(unittest.TestCase):
         self.assertEqual(widget.raw_query, 'SELECT 2+2 FROM DUAL')
         self.assertEqual(widget.query_name, 'Test')
 
-    def test_descriptions_from_text(self):
+    def test_descriptions_from_text(self) -> None:
         text_widgets = get_text_widgets([
             {'text': 'T1'},
             {'text': 'T2'}
@@ -122,11 +122,11 @@ class TestRedashDashboardUtils(unittest.TestCase):
         desc4 = generate_dashboard_description([], [])
         self.assertTrue('empty' in desc4)
 
-    def test_auth_headers(self):
+    def test_auth_headers(self) -> None:
         headers = get_auth_headers('testkey')
         self.assertTrue('testkey' in headers['Authorization'])
 
-    def test_paginated_rest_api_query(self):
+    def test_paginated_rest_api_query(self) -> None:
         paged_content = [
             {
                 'page': 1,

--- a/tests/unit/extractor/restapi/test_rest_api_extractor.py
+++ b/tests/unit/extractor/restapi/test_rest_api_extractor.py
@@ -29,7 +29,7 @@ class TestRestAPIExtractor(unittest.TestCase):
 
         self.assertDictEqual(expected, record)
 
-    def test_model_construction(self):
+    def test_model_construction(self) -> None:
         conf = ConfigFactory.from_dict(
             {
                 REST_API_QUERY: RestApiQuerySeed(

--- a/tests/unit/extractor/restapi/test_rest_api_extractor.py
+++ b/tests/unit/extractor/restapi/test_rest_api_extractor.py
@@ -13,8 +13,7 @@ from databuilder.rest_api.base_rest_api_query import RestApiQuerySeed
 
 class TestRestAPIExtractor(unittest.TestCase):
 
-    def test_static_data(self):
-        # type: (...) -> None
+    def test_static_data(self) -> None:
 
         conf = ConfigFactory.from_dict(
             {

--- a/tests/unit/extractor/test_athena_metadata_extractor.py
+++ b/tests/unit/extractor/test_athena_metadata_extractor.py
@@ -14,8 +14,7 @@ from databuilder.models.table_metadata import TableMetadata, ColumnMetadata
 
 
 class TestAthenaMetadataExtractor(unittest.TestCase):
-    def setUp(self):
-        # type: () -> None
+    def setUp(self) -> None:
         logging.basicConfig(level=logging.INFO)
 
         config_dict = {
@@ -27,8 +26,7 @@ class TestAthenaMetadataExtractor(unittest.TestCase):
         }
         self.conf = ConfigFactory.from_dict(config_dict)
 
-    def test_extraction_with_empty_query_result(self):
-        # type: () -> None
+    def test_extraction_with_empty_query_result(self) -> None:
         """
         Test Extraction with empty result from query
         """
@@ -39,8 +37,7 @@ class TestAthenaMetadataExtractor(unittest.TestCase):
             results = extractor.extract()
             self.assertEqual(results, None)
 
-    def test_extraction_with_single_result(self):
-        # type: () -> None
+    def test_extraction_with_single_result(self) -> None:
         with patch.object(SQLAlchemyExtractor, '_get_connection') as mock_connection:
             connection = MagicMock()
             mock_connection.return_value = connection
@@ -106,8 +103,7 @@ class TestAthenaMetadataExtractor(unittest.TestCase):
             self.assertEqual(expected.__repr__(), actual.__repr__())
             self.assertIsNone(extractor.extract())
 
-    def test_extraction_with_multiple_result(self):
-        # type: () -> None
+    def test_extraction_with_multiple_result(self) -> None:
         with patch.object(SQLAlchemyExtractor, '_get_connection') as mock_connection:
             connection = MagicMock()
             mock_connection.return_value = connection
@@ -229,15 +225,15 @@ class TestAthenaMetadataExtractor(unittest.TestCase):
             self.assertIsNone(extractor.extract())
             self.assertIsNone(extractor.extract())
 
-    def _union(self, target, extra):
-        # type: (Dict[Any, Any], Dict[Any, Any]) -> Dict[Any, Any]
+    def _union(self,
+               target: Dict[Any, Any],
+               extra: Dict[Any, Any]) -> Dict[Any, Any]:
         target.update(extra)
         return target
 
 
 class TestAthenaMetadataExtractorWithWhereClause(unittest.TestCase):
-    def setUp(self):
-        # type: () -> None
+    def setUp(self) -> None:
         logging.basicConfig(level=logging.INFO)
         self.where_clause_suffix = """
         where table_schema in ('public') and table_name = 'movies'
@@ -249,8 +245,7 @@ class TestAthenaMetadataExtractorWithWhereClause(unittest.TestCase):
         }
         self.conf = ConfigFactory.from_dict(config_dict)
 
-    def test_sql_statement(self):
-        # type: () -> None
+    def test_sql_statement(self) -> None:
         """
         Test Extraction with empty result from query
         """

--- a/tests/unit/extractor/test_bigquery_metadata_extractor.py
+++ b/tests/unit/extractor/test_bigquery_metadata_extractor.py
@@ -140,8 +140,7 @@ class MockBigQueryClient():
 # Patch fallback auth method to avoid actually calling google API
 @patch('google.auth.default', lambda scopes: ['dummy', 'dummy'])
 class TestBigQueryMetadataExtractor(unittest.TestCase):
-    def setUp(self):
-        # type: () -> None
+    def setUp(self) -> None:
         config_dict = {
             'extractor.bigquery_table_metadata.{}'.format(BigQueryMetadataExtractor.PROJECT_ID_KEY):
                 'your-project-here'}

--- a/tests/unit/extractor/test_bigquery_metadata_extractor.py
+++ b/tests/unit/extractor/test_bigquery_metadata_extractor.py
@@ -117,7 +117,7 @@ except NameError:
 
 
 class MockBigQueryClient():
-    def __init__(self, dataset_list_data, table_list_data, table_data):
+    def __init__(self, dataset_list_data, table_list_data, table_data) -> None:
         self.ds_execute = Mock()
         self.ds_execute.execute.return_value = dataset_list_data
         self.ds_list = Mock()

--- a/tests/unit/extractor/test_bigquery_metadata_extractor.py
+++ b/tests/unit/extractor/test_bigquery_metadata_extractor.py
@@ -6,6 +6,7 @@ import unittest
 
 from mock import patch, Mock
 from pyhocon import ConfigFactory
+from typing import Any
 
 from databuilder import Scoped
 from databuilder.extractor.bigquery_metadata_extractor import BigQueryMetadataExtractor
@@ -117,7 +118,11 @@ except NameError:
 
 
 class MockBigQueryClient():
-    def __init__(self, dataset_list_data, table_list_data, table_data) -> None:
+    def __init__(self,
+                 dataset_list_data: Any,
+                 table_list_data: Any,
+                 table_data: Any
+                 ) -> None:
         self.ds_execute = Mock()
         self.ds_execute.execute.return_value = dataset_list_data
         self.ds_list = Mock()
@@ -130,10 +135,10 @@ class MockBigQueryClient():
         self.tables_method.list.return_value = self.list_execute
         self.tables_method.get.return_value = self.get_execute
 
-    def datasets(self):
+    def datasets(self) -> Any:
         return self.ds_list
 
-    def tables(self):
+    def tables(self) -> Any:
         return self.tables_method
 
 
@@ -147,7 +152,7 @@ class TestBigQueryMetadataExtractor(unittest.TestCase):
         self.conf = ConfigFactory.from_dict(config_dict)
 
     @patch('databuilder.extractor.base_bigquery_extractor.build')
-    def test_can_handle_datasets(self, mock_build):
+    def test_can_handle_datasets(self, mock_build: Any) -> None:
         mock_build.return_value = MockBigQueryClient(NO_DATASETS, None, None)
         extractor = BigQueryMetadataExtractor()
         extractor.init(Scoped.get_scoped_conf(conf=self.conf,
@@ -156,7 +161,7 @@ class TestBigQueryMetadataExtractor(unittest.TestCase):
         self.assertIsNone(result)
 
     @patch('databuilder.extractor.base_bigquery_extractor.build')
-    def test_empty_dataset(self, mock_build):
+    def test_empty_dataset(self, mock_build: Any) -> None:
         mock_build.return_value = MockBigQueryClient(ONE_DATASET, NO_TABLES, None)
         extractor = BigQueryMetadataExtractor()
         extractor.init(Scoped.get_scoped_conf(conf=self.conf,
@@ -165,7 +170,7 @@ class TestBigQueryMetadataExtractor(unittest.TestCase):
         self.assertIsNone(result)
 
     @patch('databuilder.extractor.base_bigquery_extractor.build')
-    def test_accepts_dataset_filter_by_label(self, mock_build):
+    def test_accepts_dataset_filter_by_label(self, mock_build: Any) -> None:
         config_dict = {
             'extractor.bigquery_table_metadata.{}'.format(BigQueryMetadataExtractor.PROJECT_ID_KEY):
                 'your-project-here',
@@ -182,7 +187,7 @@ class TestBigQueryMetadataExtractor(unittest.TestCase):
         self.assertIsInstance(result, TableMetadata)
 
     @patch('databuilder.extractor.base_bigquery_extractor.build')
-    def test_table_without_schema(self, mock_build):
+    def test_table_without_schema(self, mock_build: Any) -> None:
         mock_build.return_value = MockBigQueryClient(ONE_DATASET, ONE_TABLE, NO_SCHEMA)
         extractor = BigQueryMetadataExtractor()
         extractor.init(Scoped.get_scoped_conf(conf=self.conf,
@@ -198,7 +203,7 @@ class TestBigQueryMetadataExtractor(unittest.TestCase):
         self.assertEquals(result.is_view, False)
 
     @patch('databuilder.extractor.base_bigquery_extractor.build')
-    def test_table_without_columns(self, mock_build):
+    def test_table_without_columns(self, mock_build: Any) -> None:
         mock_build.return_value = MockBigQueryClient(ONE_DATASET, ONE_TABLE, NO_COLS)
         extractor = BigQueryMetadataExtractor()
         extractor.init(Scoped.get_scoped_conf(conf=self.conf,
@@ -214,7 +219,7 @@ class TestBigQueryMetadataExtractor(unittest.TestCase):
         self.assertEquals(result.is_view, False)
 
     @patch('databuilder.extractor.base_bigquery_extractor.build')
-    def test_view(self, mock_build):
+    def test_view(self, mock_build: Any) -> None:
         mock_build.return_value = MockBigQueryClient(ONE_DATASET, ONE_VIEW, VIEW_DATA)
         extractor = BigQueryMetadataExtractor()
         extractor.init(Scoped.get_scoped_conf(conf=self.conf,
@@ -224,7 +229,7 @@ class TestBigQueryMetadataExtractor(unittest.TestCase):
         self.assertEquals(result.is_view, True)
 
     @patch('databuilder.extractor.base_bigquery_extractor.build')
-    def test_normal_table(self, mock_build):
+    def test_normal_table(self, mock_build: Any) -> None:
         mock_build.return_value = MockBigQueryClient(ONE_DATASET, ONE_TABLE, TABLE_DATA)
         extractor = BigQueryMetadataExtractor()
         extractor.init(Scoped.get_scoped_conf(conf=self.conf,
@@ -244,7 +249,7 @@ class TestBigQueryMetadataExtractor(unittest.TestCase):
         self.assertEquals(result.is_view, False)
 
     @patch('databuilder.extractor.base_bigquery_extractor.build')
-    def test_table_with_nested_records(self, mock_build):
+    def test_table_with_nested_records(self, mock_build: Any) -> None:
         mock_build.return_value = MockBigQueryClient(ONE_DATASET, ONE_TABLE, NESTED_DATA)
         extractor = BigQueryMetadataExtractor()
         extractor.init(Scoped.get_scoped_conf(conf=self.conf,
@@ -262,7 +267,7 @@ class TestBigQueryMetadataExtractor(unittest.TestCase):
         self.assertEquals(third_col.type, 'STRING')
 
     @patch('databuilder.extractor.base_bigquery_extractor.build')
-    def test_keypath_and_pagesize_can_be_set(self, mock_build):
+    def test_keypath_and_pagesize_can_be_set(self, mock_build: Any) -> None:
         config_dict = {
             'extractor.bigquery_table_metadata.{}'.format(BigQueryMetadataExtractor.PROJECT_ID_KEY):
                 'your-project-here',
@@ -281,7 +286,7 @@ class TestBigQueryMetadataExtractor(unittest.TestCase):
                                                   scope=extractor.get_scope()))
 
     @patch('databuilder.extractor.base_bigquery_extractor.build')
-    def test_table_part_of_table_date_range(self, mock_build):
+    def test_table_part_of_table_date_range(self, mock_build: Any) -> None:
         mock_build.return_value = MockBigQueryClient(ONE_DATASET, TABLE_DATE_RANGE, TABLE_DATA)
         extractor = BigQueryMetadataExtractor()
         extractor.init(Scoped.get_scoped_conf(conf=self.conf,

--- a/tests/unit/extractor/test_bigquery_usage_extractor.py
+++ b/tests/unit/extractor/test_bigquery_usage_extractor.py
@@ -7,6 +7,7 @@ import tempfile
 import unittest
 
 from pyhocon import ConfigFactory
+from typing import Any
 
 from databuilder import Scoped
 from databuilder.extractor.bigquery_usage_extractor import BigQueryTableUsageExtractor
@@ -178,14 +179,14 @@ ci1wcm9qZWN0LWhlcmUuaWFtLmdzZXJ2aWNlYWNjb3VudC5jb20iCn0KCgo=
 
 
 class MockLoggingClient():
-    def __init__(self, data) -> None:
+    def __init__(self, data: Any) -> None:
         self.data = data
         self.a = Mock()
         self.a.execute.return_value = self.data
         self.b = Mock()
         self.b.list.return_value = self.a
 
-    def entries(self):
+    def entries(self) -> Any:
         return self.b
 
 
@@ -194,7 +195,7 @@ class MockLoggingClient():
 class TestBigqueryUsageExtractor(unittest.TestCase):
 
     @patch('databuilder.extractor.base_bigquery_extractor.build')
-    def test_basic_extraction(self, mock_build):
+    def test_basic_extraction(self, mock_build: Any) -> None:
         """
         Test Extraction using mock class
         """
@@ -209,6 +210,7 @@ class TestBigqueryUsageExtractor(unittest.TestCase):
         extractor.init(Scoped.get_scoped_conf(conf=conf,
                                               scope=extractor.get_scope()))
         result = extractor.extract()
+        assert result is not None
         self.assertIsInstance(result, tuple)
 
         (key, value) = result
@@ -223,7 +225,7 @@ class TestBigqueryUsageExtractor(unittest.TestCase):
         self.assertEqual(value, 1)
 
     @patch('databuilder.extractor.base_bigquery_extractor.build')
-    def test_no_entries(self, mock_build):
+    def test_no_entries(self, mock_build: Any) -> None:
         config_dict = {
             'extractor.bigquery_table_usage.{}'.format(BigQueryTableUsageExtractor.PROJECT_ID_KEY):
                 'your-project-here',
@@ -238,7 +240,7 @@ class TestBigqueryUsageExtractor(unittest.TestCase):
         self.assertIsNone(result)
 
     @patch('databuilder.extractor.base_bigquery_extractor.build')
-    def test_key_path(self, mock_build):
+    def test_key_path(self, mock_build: Any) -> None:
         """
         Test key_path can be used
         """
@@ -268,7 +270,7 @@ class TestBigqueryUsageExtractor(unittest.TestCase):
             self.assertEqual(creds.service_account_email, 'test-162@your-project-here.iam.gserviceaccount.com')
 
     @patch('databuilder.extractor.base_bigquery_extractor.build')
-    def test_timestamp_pagesize_settings(self, mock_build):
+    def test_timestamp_pagesize_settings(self, mock_build: Any) -> None:
         """
         Test timestamp and pagesize can be set
         """
@@ -298,7 +300,7 @@ class TestBigqueryUsageExtractor(unittest.TestCase):
         self.assertEqual(TIMESTAMP in body['filter'], True)
 
     @patch('databuilder.extractor.base_bigquery_extractor.build')
-    def test_failed_jobs_should_not_be_counted(self, mock_build):
+    def test_failed_jobs_should_not_be_counted(self, mock_build: Any) -> None:
 
         config_dict = {
             'extractor.bigquery_table_usage.{}'.format(BigQueryTableUsageExtractor.PROJECT_ID_KEY):
@@ -316,7 +318,7 @@ class TestBigqueryUsageExtractor(unittest.TestCase):
         self.assertIsNone(result)
 
     @patch('databuilder.extractor.base_bigquery_extractor.build')
-    def test_email_filter_not_counted(self, mock_build):
+    def test_email_filter_not_counted(self, mock_build: Any) -> None:
         config_dict = {
             'extractor.bigquery_table_usage.{}'.format(BigQueryTableUsageExtractor.PROJECT_ID_KEY):
                 'your-project-here',
@@ -333,7 +335,7 @@ class TestBigqueryUsageExtractor(unittest.TestCase):
         self.assertIsNone(result)
 
     @patch('databuilder.extractor.base_bigquery_extractor.build')
-    def test_email_filter_counted(self, mock_build):
+    def test_email_filter_counted(self, mock_build: Any) -> None:
         config_dict = {
             'extractor.bigquery_table_usage.{}'.format(BigQueryTableUsageExtractor.PROJECT_ID_KEY):
                 'your-project-here',
@@ -347,6 +349,7 @@ class TestBigqueryUsageExtractor(unittest.TestCase):
         extractor.init(Scoped.get_scoped_conf(conf=conf,
                                               scope=extractor.get_scope()))
         result = extractor.extract()
+        assert result is not None
         self.assertIsInstance(result, tuple)
 
         (key, value) = result

--- a/tests/unit/extractor/test_bigquery_usage_extractor.py
+++ b/tests/unit/extractor/test_bigquery_usage_extractor.py
@@ -178,7 +178,7 @@ ci1wcm9qZWN0LWhlcmUuaWFtLmdzZXJ2aWNlYWNjb3VudC5jb20iCn0KCgo=
 
 
 class MockLoggingClient():
-    def __init__(self, data):
+    def __init__(self, data) -> None:
         self.data = data
         self.a = Mock()
         self.a.execute.return_value = self.data

--- a/tests/unit/extractor/test_bigquery_watermark_extractor.py
+++ b/tests/unit/extractor/test_bigquery_watermark_extractor.py
@@ -86,8 +86,7 @@ class MockBigQueryClient():
 # Patch fallback auth method to avoid actually calling google API
 @patch('google.auth.default', lambda scopes: ['dummy', 'dummy'])
 class TestBigQueryWatermarkExtractor(unittest.TestCase):
-    def setUp(self):
-        # type: () -> None
+    def setUp(self) -> None:
         config_dict = {
             'extractor.bigquery_watermarks.{}'.format(BigQueryWatermarkExtractor.PROJECT_ID_KEY):
                 'your-project-here'}

--- a/tests/unit/extractor/test_bigquery_watermark_extractor.py
+++ b/tests/unit/extractor/test_bigquery_watermark_extractor.py
@@ -7,6 +7,7 @@ from datetime import datetime
 
 from mock import patch, Mock
 from pyhocon import ConfigFactory
+from typing import Any
 
 from databuilder import Scoped
 from databuilder.extractor.bigquery_watermark_extractor import BigQueryWatermarkExtractor
@@ -59,7 +60,11 @@ except NameError:
 
 
 class MockBigQueryClient():
-    def __init__(self, dataset_list_data, table_list_data, partition_data) -> None:
+    def __init__(self,
+                 dataset_list_data: Any,
+                 table_list_data: Any,
+                 partition_data: Any
+                 ) -> None:
         self.list_execute = Mock()
         self.list_execute.execute.return_value = table_list_data
         self.tables_method = Mock()
@@ -73,13 +78,13 @@ class MockBigQueryClient():
         self.jobs_query = Mock()
         self.jobs_query.query.return_value = self.query_execute
 
-    def datasets(self):
+    def datasets(self) -> Any:
         return self.ds_list
 
-    def tables(self):
+    def tables(self) -> Any:
         return self.tables_method
 
-    def jobs(self):
+    def jobs(self) -> Any:
         return self.jobs_query
 
 
@@ -93,7 +98,7 @@ class TestBigQueryWatermarkExtractor(unittest.TestCase):
         self.conf = ConfigFactory.from_dict(config_dict)
 
     @patch('databuilder.extractor.base_bigquery_extractor.build')
-    def test_can_handle_no_datasets(self, mock_build):
+    def test_can_handle_no_datasets(self, mock_build: Any) -> None:
         mock_build.return_value = MockBigQueryClient(NO_DATASETS, None, None)
         extractor = BigQueryWatermarkExtractor()
         extractor.init(Scoped.get_scoped_conf(conf=self.conf,
@@ -102,7 +107,7 @@ class TestBigQueryWatermarkExtractor(unittest.TestCase):
         self.assertIsNone(result)
 
     @patch('databuilder.extractor.base_bigquery_extractor.build')
-    def test_empty_dataset(self, mock_build):
+    def test_empty_dataset(self, mock_build: Any) -> None:
         mock_build.return_value = MockBigQueryClient(ONE_DATASET, NO_TABLES, None)
         extractor = BigQueryWatermarkExtractor()
         extractor.init(Scoped.get_scoped_conf(conf=self.conf,
@@ -111,7 +116,7 @@ class TestBigQueryWatermarkExtractor(unittest.TestCase):
         self.assertIsNone(result)
 
     @patch('databuilder.extractor.base_bigquery_extractor.build')
-    def test_table_without_partitions(self, mock_build):
+    def test_table_without_partitions(self, mock_build: Any) -> None:
         mock_build.return_value = MockBigQueryClient(ONE_DATASET, ONE_TABLE, None)
         extractor = BigQueryWatermarkExtractor()
         extractor.init(Scoped.get_scoped_conf(conf=self.conf,
@@ -120,7 +125,7 @@ class TestBigQueryWatermarkExtractor(unittest.TestCase):
         self.assertIsNone(result)
 
     @patch('databuilder.extractor.base_bigquery_extractor.build')
-    def test_table_with_default_partitions(self, mock_build):
+    def test_table_with_default_partitions(self, mock_build: Any) -> None:
         mock_build.return_value = MockBigQueryClient(ONE_DATASET, TIME_PARTITIONED, PARTITION_DATA)
         extractor = BigQueryWatermarkExtractor()
         extractor.init(Scoped.get_scoped_conf(conf=self.conf,
@@ -144,12 +149,13 @@ class TestBigQueryWatermarkExtractor(unittest.TestCase):
         self.assertEquals(result.parts, [('_partitiontime', '20180804')])
 
     @patch('databuilder.extractor.base_bigquery_extractor.build')
-    def test_table_with_field_partitions(self, mock_build):
+    def test_table_with_field_partitions(self, mock_build: Any) -> None:
         mock_build.return_value = MockBigQueryClient(ONE_DATASET, TIME_PARTITIONED_WITH_FIELD, PARTITION_DATA)
         extractor = BigQueryWatermarkExtractor()
         extractor.init(Scoped.get_scoped_conf(conf=self.conf,
                                               scope=extractor.get_scope()))
         result = extractor.extract()
+        assert result is not None
         self.assertEquals(result.part_type, 'low_watermark')
         self.assertEquals(result.database, 'bigquery')
         self.assertEquals(result.schema, 'fdgdfgh')
@@ -159,6 +165,7 @@ class TestBigQueryWatermarkExtractor(unittest.TestCase):
         self.assertEquals(result.parts, [('processed_date', '20180802')])
 
         result = extractor.extract()
+        assert result is not None
         self.assertEquals(result.part_type, 'high_watermark')
         self.assertEquals(result.database, 'bigquery')
         self.assertEquals(result.schema, 'fdgdfgh')
@@ -168,7 +175,7 @@ class TestBigQueryWatermarkExtractor(unittest.TestCase):
         self.assertEquals(result.parts, [('processed_date', '20180804')])
 
     @patch('databuilder.extractor.base_bigquery_extractor.build')
-    def test_keypath_can_be_set(self, mock_build):
+    def test_keypath_can_be_set(self, mock_build: Any) -> None:
         config_dict = {
             'extractor.bigquery_watermarks.{}'.format(BigQueryWatermarkExtractor.PROJECT_ID_KEY):
                 'your-project-here',
@@ -185,13 +192,14 @@ class TestBigQueryWatermarkExtractor(unittest.TestCase):
                                                   scope=extractor.get_scope()))
 
     @patch('databuilder.extractor.base_bigquery_extractor.build')
-    def test_table_part_of_table_date_range(self, mock_build):
+    def test_table_part_of_table_date_range(self, mock_build: Any) -> None:
         mock_build.return_value = MockBigQueryClient(ONE_DATASET, TABLE_DATE_RANGE, None)
         extractor = BigQueryWatermarkExtractor()
         extractor.init(Scoped.get_scoped_conf(conf=self.conf,
                                               scope=extractor.get_scope()))
 
         result = extractor.extract()
+        assert result is not None
         self.assertEquals(result.part_type, 'low_watermark')
         self.assertEquals(result.database, 'bigquery')
         self.assertEquals(result.schema, 'fdgdfgh')
@@ -201,6 +209,7 @@ class TestBigQueryWatermarkExtractor(unittest.TestCase):
         self.assertEquals(result.parts, [('__table__', '20190101')])
 
         result = extractor.extract()
+        assert result is not None
         self.assertEquals(result.part_type, 'high_watermark')
         self.assertEquals(result.database, 'bigquery')
         self.assertEquals(result.schema, 'fdgdfgh')

--- a/tests/unit/extractor/test_bigquery_watermark_extractor.py
+++ b/tests/unit/extractor/test_bigquery_watermark_extractor.py
@@ -59,7 +59,7 @@ except NameError:
 
 
 class MockBigQueryClient():
-    def __init__(self, dataset_list_data, table_list_data, partition_data):
+    def __init__(self, dataset_list_data, table_list_data, partition_data) -> None:
         self.list_execute = Mock()
         self.list_execute.execute.return_value = table_list_data
         self.tables_method = Mock()

--- a/tests/unit/extractor/test_cassandra_extractor.py
+++ b/tests/unit/extractor/test_cassandra_extractor.py
@@ -36,9 +36,10 @@ class TestCassandraExtractor(unittest.TestCase):
     @patch('databuilder.extractor.cassandra_extractor.CassandraExtractor._get_tables')
     @patch('databuilder.extractor.cassandra_extractor.CassandraExtractor._get_columns')
     def test_extraction_with_default_conf(self,
-                                          mock_columns,
-                                          mock_tables,
-                                          mock_keyspaces) -> None:
+                                          mock_columns: Any,
+                                          mock_tables: Any,
+                                          mock_keyspaces: Any
+                                          ) -> None:
         mock_keyspaces.return_value = {'test_schema': None}
         mock_tables.return_value = {'test_table': None}
         columns_dict = OrderedDict()
@@ -59,9 +60,10 @@ class TestCassandraExtractor(unittest.TestCase):
     @patch('databuilder.extractor.cassandra_extractor.CassandraExtractor._get_tables')
     @patch('databuilder.extractor.cassandra_extractor.CassandraExtractor._get_columns')
     def test_extraction_with_filter_conf(self,
-                                         mock_columns,
-                                         mock_tables,
-                                         mock_keyspaces) -> None:
+                                         mock_columns: Any,
+                                         mock_tables: Any,
+                                         mock_keyspaces: Any
+                                         ) -> None:
         mock_keyspaces.return_value = {'test_schema': None}
         mock_tables.return_value = {'test_table': None}
         columns_dict = OrderedDict()
@@ -69,7 +71,7 @@ class TestCassandraExtractor(unittest.TestCase):
         columns_dict['txt'] = CassandraColumnMetadata(None, 'txt', 'text')
         mock_columns.return_value = columns_dict
 
-        def filter_function(k, t):
+        def filter_function(k: str, t: str) -> bool:
             return False if 'test' in k or 'test' in t else False
 
         conf = ConfigFactory.from_dict({

--- a/tests/unit/extractor/test_cassandra_extractor.py
+++ b/tests/unit/extractor/test_cassandra_extractor.py
@@ -17,14 +17,12 @@ from databuilder.models.table_metadata import TableMetadata, ColumnMetadata
 # patch whole class to avoid actually calling for boto3.client during tests
 @patch('cassandra.cluster.Cluster.connect', lambda x: None)
 class TestCassandraExtractor(unittest.TestCase):
-    def setUp(self):
-        # type: () -> None
+    def setUp(self) -> None:
         logging.basicConfig(level=logging.INFO)
 
         self.default_conf = ConfigFactory.from_dict({})
 
-    def test_extraction_with_empty_query_result(self):
-        # type: () -> None
+    def test_extraction_with_empty_query_result(self) -> None:
         """
         Test Extraction with empty result from query
         """
@@ -37,8 +35,10 @@ class TestCassandraExtractor(unittest.TestCase):
     @patch('databuilder.extractor.cassandra_extractor.CassandraExtractor._get_keyspaces')
     @patch('databuilder.extractor.cassandra_extractor.CassandraExtractor._get_tables')
     @patch('databuilder.extractor.cassandra_extractor.CassandraExtractor._get_columns')
-    def test_extraction_with_default_conf(self, mock_columns, mock_tables, mock_keyspaces):
-        # type: () -> None
+    def test_extraction_with_default_conf(self,
+                                          mock_columns,
+                                          mock_tables,
+                                          mock_keyspaces) -> None:
         mock_keyspaces.return_value = {'test_schema': None}
         mock_tables.return_value = {'test_table': None}
         columns_dict = OrderedDict()
@@ -58,8 +58,10 @@ class TestCassandraExtractor(unittest.TestCase):
     @patch('databuilder.extractor.cassandra_extractor.CassandraExtractor._get_keyspaces')
     @patch('databuilder.extractor.cassandra_extractor.CassandraExtractor._get_tables')
     @patch('databuilder.extractor.cassandra_extractor.CassandraExtractor._get_columns')
-    def test_extraction_with_filter_conf(self, mock_columns, mock_tables, mock_keyspaces):
-        # type: () -> None
+    def test_extraction_with_filter_conf(self,
+                                         mock_columns,
+                                         mock_tables,
+                                         mock_keyspaces) -> None:
         mock_keyspaces.return_value = {'test_schema': None}
         mock_tables.return_value = {'test_table': None}
         columns_dict = OrderedDict()

--- a/tests/unit/extractor/test_csv_extractor.py
+++ b/tests/unit/extractor/test_csv_extractor.py
@@ -11,16 +11,14 @@ from databuilder.extractor.csv_extractor import CsvExtractor
 
 class TestCsvExtractor(unittest.TestCase):
 
-    def setUp(self):
-        # type: () -> None
+    def setUp(self) -> None:
         config_dict = {
             'extractor.csv.{}'.format(CsvExtractor.FILE_LOCATION): 'example/sample_data/sample_table.csv',
             'extractor.csv.model_class': 'databuilder.models.table_metadata.TableMetadata',
         }
         self.conf = ConfigFactory.from_dict(config_dict)
 
-    def test_extraction_with_model_class(self):
-        # type: () -> None
+    def test_extraction_with_model_class(self) -> None:
         """
         Test Extraction using model class
         """

--- a/tests/unit/extractor/test_generic_extractor.py
+++ b/tests/unit/extractor/test_generic_extractor.py
@@ -11,8 +11,7 @@ from databuilder.extractor.generic_extractor import GenericExtractor
 
 class TestGenericExtractor(unittest.TestCase):
 
-    def test_extraction_with_model_class(self):
-        # type: () -> None
+    def test_extraction_with_model_class(self) -> None:
         """
         Test Extraction using model class
         """
@@ -31,8 +30,7 @@ class TestGenericExtractor(unittest.TestCase):
         result = extractor.extract()
         self.assertEquals(result.timestamp, 10000000)
 
-    def test_extraction_without_model_class(self):
-        # type: () -> None
+    def test_extraction_without_model_class(self) -> None:
         """
         Test Extraction using model class
         """

--- a/tests/unit/extractor/test_glue_extractor.py
+++ b/tests/unit/extractor/test_glue_extractor.py
@@ -15,14 +15,12 @@ from databuilder.models.table_metadata import TableMetadata, ColumnMetadata
 # patch whole class to avoid actually calling for boto3.client during tests
 @patch('databuilder.extractor.glue_extractor.boto3.client', lambda x: None)
 class TestGlueExtractor(unittest.TestCase):
-    def setUp(self):
-        # type: () -> None
+    def setUp(self) -> None:
         logging.basicConfig(level=logging.INFO)
 
         self.conf = ConfigFactory.from_dict({})
 
-    def test_extraction_with_empty_query_result(self):
-        # type: () -> None
+    def test_extraction_with_empty_query_result(self) -> None:
         """
         Test Extraction with empty result from query
         """
@@ -33,8 +31,7 @@ class TestGlueExtractor(unittest.TestCase):
             results = extractor.extract()
             self.assertEqual(results, None)
 
-    def test_extraction_with_single_result(self):
-        # type: () -> None
+    def test_extraction_with_single_result(self) -> None:
         with patch.object(GlueExtractor, '_search_tables') as mock_search:
             mock_search.return_value = [
                 {
@@ -99,8 +96,7 @@ class TestGlueExtractor(unittest.TestCase):
             self.assertEqual(expected.__repr__(), actual.__repr__())
             self.assertIsNone(extractor.extract())
 
-    def test_extraction_with_multiple_result(self):
-        # type: () -> None
+    def test_extraction_with_multiple_result(self) -> None:
         with patch.object(GlueExtractor, '_search_tables') as mock_search:
             mock_search.return_value = [
                 {

--- a/tests/unit/extractor/test_hive_table_last_updated_extractor.py
+++ b/tests/unit/extractor/test_hive_table_last_updated_extractor.py
@@ -29,12 +29,10 @@ def null_iterator(items):
 
 class TestHiveTableLastUpdatedExtractor(unittest.TestCase):
 
-    def setUp(self):
-        # type: () -> None
+    def setUp(self) -> None:
         logging.basicConfig(level=logging.INFO)
 
-    def test_extraction_with_empty_query_result(self):
-        # type: () -> None
+    def test_extraction_with_empty_query_result(self) -> None:
 
         config_dict = {
             'extractor.sqlalchemy.{}'.format(SQLAlchemyExtractor.CONN_STRING):
@@ -49,8 +47,7 @@ class TestHiveTableLastUpdatedExtractor(unittest.TestCase):
             result = extractor.extract()
             self.assertEqual(result, None)
 
-    def test_extraction_with_partition_table_result(self):
-        # type: () -> None
+    def test_extraction_with_partition_table_result(self) -> None:
         config_dict = {
             'filesystem.{}'.format(FileSystem.DASK_FILE_SYSTEM): MagicMock()
         }
@@ -87,8 +84,7 @@ class TestHiveTableLastUpdatedExtractor(unittest.TestCase):
 
             self.assertIsNone(extractor.extract())
 
-    def test_extraction(self):
-        # type: () -> None
+    def test_extraction(self) -> None:
         old_datetime = datetime(2018, 8, 14, 4, 12, 3, tzinfo=UTC)
         new_datetime = datetime(2018, 11, 14, 4, 12, 3, tzinfo=UTC)
 

--- a/tests/unit/extractor/test_hive_table_last_updated_extractor.py
+++ b/tests/unit/extractor/test_hive_table_last_updated_extractor.py
@@ -9,7 +9,7 @@ from pytz import UTC
 
 from mock import patch, MagicMock
 from pyhocon import ConfigFactory
-from typing import Any, Dict  # noqa: F401
+from typing import Any, Iterable, Iterator, Dict, Optional, TypeVar  # noqa: F401
 
 from databuilder.extractor.hive_table_last_updated_extractor import HiveTableLastUpdatedExtractor
 from databuilder.extractor.sql_alchemy_extractor import SQLAlchemyExtractor
@@ -18,11 +18,14 @@ from databuilder.filesystem.filesystem import FileSystem
 from databuilder.filesystem.metadata import FileMetadata
 
 
-def null_iterator(items):
+T = TypeVar('T')
+
+
+def null_iterator(items: Iterable[T]) -> Iterator[Optional[T]]:
     """
-        Returns an infinite iterator that returns the items from items,
-        then infinite Nones. Required because Extractor.extract is expected
-        to return None when it is exhausted, not terminate.
+    Returns an infinite iterator that returns the items from items,
+    then infinite Nones. Required because Extractor.extract is expected
+    to return None when it is exhausted, not terminate.
     """
     return itertools.chain(iter(items), itertools.repeat(None))
 

--- a/tests/unit/extractor/test_hive_table_metadata_extractor.py
+++ b/tests/unit/extractor/test_hive_table_metadata_extractor.py
@@ -14,8 +14,7 @@ from databuilder.models.table_metadata import TableMetadata, ColumnMetadata
 
 
 class TestHiveTableMetadataExtractor(unittest.TestCase):
-    def setUp(self):
-        # type: () -> None
+    def setUp(self) -> None:
         logging.basicConfig(level=logging.INFO)
 
         config_dict = {
@@ -24,8 +23,7 @@ class TestHiveTableMetadataExtractor(unittest.TestCase):
         }
         self.conf = ConfigFactory.from_dict(config_dict)
 
-    def test_extraction_with_empty_query_result(self):
-        # type: () -> None
+    def test_extraction_with_empty_query_result(self) -> None:
         """
         Test Extraction with empty result from query
         """
@@ -36,8 +34,7 @@ class TestHiveTableMetadataExtractor(unittest.TestCase):
             results = extractor.extract()
             self.assertEqual(results, None)
 
-    def test_extraction_with_single_result(self):
-        # type: () -> None
+    def test_extraction_with_single_result(self) -> None:
         with patch.object(SQLAlchemyExtractor, '_get_connection') as mock_connection:
             connection = MagicMock()
             mock_connection.return_value = connection
@@ -95,8 +92,7 @@ class TestHiveTableMetadataExtractor(unittest.TestCase):
             self.assertEqual(expected.__repr__(), actual.__repr__())
             self.assertIsNone(extractor.extract())
 
-    def test_extraction_with_multiple_result(self):
-        # type: () -> None
+    def test_extraction_with_multiple_result(self) -> None:
         with patch.object(SQLAlchemyExtractor, '_get_connection') as mock_connection:
             connection = MagicMock()
             mock_connection.return_value = connection
@@ -199,15 +195,15 @@ class TestHiveTableMetadataExtractor(unittest.TestCase):
             self.assertIsNone(extractor.extract())
             self.assertIsNone(extractor.extract())
 
-    def _union(self, target, extra):
-        # type: (Dict[Any, Any], Dict[Any, Any]) -> Dict[Any, Any]
+    def _union(self,
+               target: Dict[Any, Any],
+               extra: Dict[Any, Any]) -> Dict[Any, Any]:
         target.update(extra)
         return target
 
 
 class TestHiveTableMetadataExtractorWithWhereClause(unittest.TestCase):
-    def setUp(self):
-        # type: () -> None
+    def setUp(self) -> None:
         logging.basicConfig(level=logging.INFO)
         self.where_clause_suffix = """
         AND d.NAME IN ('test_schema1', 'test_schema2')
@@ -220,8 +216,7 @@ class TestHiveTableMetadataExtractorWithWhereClause(unittest.TestCase):
         }
         self.conf = ConfigFactory.from_dict(config_dict)
 
-    def test_sql_statement(self):
-        # type: () -> None
+    def test_sql_statement(self) -> None:
         """
         Test Extraction with empty result from query
         """

--- a/tests/unit/extractor/test_kafka_source_extractor.py
+++ b/tests/unit/extractor/test_kafka_source_extractor.py
@@ -5,7 +5,7 @@ import logging
 from mock import patch, MagicMock
 import unittest
 
-from pyhocon import ConfigFactory
+from pyhocon import ConfigFactory, ConfigTree
 
 from databuilder import Scoped
 from databuilder.extractor.kafka_source_extractor import KafkaSourceExtractor

--- a/tests/unit/extractor/test_kafka_source_extractor.py
+++ b/tests/unit/extractor/test_kafka_source_extractor.py
@@ -5,7 +5,7 @@ import logging
 from mock import patch, MagicMock
 import unittest
 
-from pyhocon import ConfigFactory, ConfigTree
+from pyhocon import ConfigFactory
 
 from databuilder import Scoped
 from databuilder.extractor.kafka_source_extractor import KafkaSourceExtractor

--- a/tests/unit/extractor/test_kafka_source_extractor.py
+++ b/tests/unit/extractor/test_kafka_source_extractor.py
@@ -25,7 +25,7 @@ class TestKafkaSourceExtractor(unittest.TestCase):
         }
         self.conf = ConfigFactory.from_dict(config_dict)
 
-    def test_consume_success(self):
+    def test_consume_success(self) -> None:
         kafka_extractor = KafkaSourceExtractor()
         kafka_extractor.init(Scoped.get_scoped_conf(conf=self.conf,
                                                     scope=kafka_extractor.get_scope()))
@@ -41,7 +41,7 @@ class TestKafkaSourceExtractor(unittest.TestCase):
             records = kafka_extractor.consume()
             self.assertEqual(len(records), 1)
 
-    def test_consume_fail(self):
+    def test_consume_fail(self) -> None:
         kafka_extractor = KafkaSourceExtractor()
         kafka_extractor.init(Scoped.get_scoped_conf(conf=self.conf,
                                                     scope=kafka_extractor.get_scope()))

--- a/tests/unit/extractor/test_kafka_source_extractor.py
+++ b/tests/unit/extractor/test_kafka_source_extractor.py
@@ -12,8 +12,7 @@ from databuilder.extractor.kafka_source_extractor import KafkaSourceExtractor
 
 
 class TestKafkaSourceExtractor(unittest.TestCase):
-    def setUp(self):
-        # type: () -> None
+    def setUp(self) -> None:
         logging.basicConfig(level=logging.INFO)
         config_dict = {
             'extractor.kafka_source.consumer_config': {'"group.id"': 'consumer-group',

--- a/tests/unit/extractor/test_mssql_metadata_extractor.py
+++ b/tests/unit/extractor/test_mssql_metadata_extractor.py
@@ -14,8 +14,7 @@ from databuilder.models.table_metadata import TableMetadata, ColumnMetadata
 
 
 class TestMSSQLMetadataExtractor(unittest.TestCase):
-    def setUp(self):
-        # type: () -> None
+    def setUp(self) -> None:
         logging.basicConfig(level=logging.INFO)
 
         config_dict = {
@@ -31,8 +30,7 @@ class TestMSSQLMetadataExtractor(unittest.TestCase):
         }
         self.conf = ConfigFactory.from_dict(config_dict)
 
-    def test_extraction_with_empty_query_result(self):
-        # type: () -> None
+    def test_extraction_with_empty_query_result(self) -> None:
         """
         Test Extraction with empty result from query
         """
@@ -43,8 +41,7 @@ class TestMSSQLMetadataExtractor(unittest.TestCase):
             results = extractor.extract()
             self.assertEqual(results, None)
 
-    def test_extraction_with_single_result(self):
-        # type: () -> None
+    def test_extraction_with_single_result(self) -> None:
         with patch.object(SQLAlchemyExtractor, '_get_connection') as mock_connection:
             connection = MagicMock()
             mock_connection.return_value = connection
@@ -104,8 +101,7 @@ class TestMSSQLMetadataExtractor(unittest.TestCase):
             self.assertEqual(expected.__repr__(), actual.__repr__())
             self.assertIsNone(extractor.extract())
 
-    def test_extraction_with_multiple_result(self):
-        # type: () -> None
+    def test_extraction_with_multiple_result(self) -> None:
         with patch.object(SQLAlchemyExtractor, '_get_connection') as mock_connection:
             connection = MagicMock()
             mock_connection.return_value = connection
@@ -221,15 +217,15 @@ class TestMSSQLMetadataExtractor(unittest.TestCase):
             self.assertIsNone(extractor.extract())
             self.assertIsNone(extractor.extract())
 
-    def _union(self, target, extra):
-        # type: (Dict[Any, Any], Dict[Any, Any]) -> Dict[Any, Any]
+    def _union(self,
+               target: Dict[Any, Any],
+               extra: Dict[Any, Any]) -> Dict[Any, Any]:
         target.update(extra)
         return target
 
 
 class TestMSSQLMetadataExtractorWithWhereClause(unittest.TestCase):
-    def setUp(self):
-        # type: () -> None
+    def setUp(self) -> None:
         logging.basicConfig(level=logging.INFO)
         self.where_clause_suffix = """
             ('dbo', 'sys')
@@ -242,8 +238,7 @@ class TestMSSQLMetadataExtractorWithWhereClause(unittest.TestCase):
         }
         self.conf = ConfigFactory.from_dict(config_dict)
 
-    def test_sql_statement(self):
-        # type: () -> None
+    def test_sql_statement(self) -> None:
         """
         Test Extraction with empty result from query
         """
@@ -255,8 +250,7 @@ class TestMSSQLMetadataExtractorWithWhereClause(unittest.TestCase):
 
 class TestMSSQLMetadataExtractorClusterKeyNoTableCatalog(unittest.TestCase):
     # test when USE_CATALOG_AS_CLUSTER_NAME is false and CLUSTER_KEY is specified
-    def setUp(self):
-        # type: () -> None
+    def setUp(self) -> None:
         logging.basicConfig(level=logging.INFO)
         self.cluster_key = "not_master"
 
@@ -268,8 +262,7 @@ class TestMSSQLMetadataExtractorClusterKeyNoTableCatalog(unittest.TestCase):
         }
         self.conf = ConfigFactory.from_dict(config_dict)
 
-    def test_sql_statement(self):
-        # type: () -> None
+    def test_sql_statement(self) -> None:
         """
         Test Extraction with empty result from query
         """
@@ -281,8 +274,7 @@ class TestMSSQLMetadataExtractorClusterKeyNoTableCatalog(unittest.TestCase):
 
 class TestMSSQLMetadataExtractorNoClusterKeyNoTableCatalog(unittest.TestCase):
     # test when USE_CATALOG_AS_CLUSTER_NAME is false and CLUSTER_KEY is NOT specified
-    def setUp(self):
-        # type: () -> None
+    def setUp(self) -> None:
         logging.basicConfig(level=logging.INFO)
 
         config_dict = {
@@ -292,8 +284,7 @@ class TestMSSQLMetadataExtractorNoClusterKeyNoTableCatalog(unittest.TestCase):
         }
         self.conf = ConfigFactory.from_dict(config_dict)
 
-    def test_sql_statement(self):
-        # type: () -> None
+    def test_sql_statement(self) -> None:
         """
         Test Extraction with empty result from query
         """
@@ -305,8 +296,7 @@ class TestMSSQLMetadataExtractorNoClusterKeyNoTableCatalog(unittest.TestCase):
 
 class TestMSSQLMetadataExtractorTableCatalogEnabled(unittest.TestCase):
     # test when USE_CATALOG_AS_CLUSTER_NAME is true (CLUSTER_KEY should be ignored)
-    def setUp(self):
-        # type: () -> None
+    def setUp(self) -> None:
         logging.basicConfig(level=logging.INFO)
         self.cluster_key = "not_master"
 
@@ -318,8 +308,7 @@ class TestMSSQLMetadataExtractorTableCatalogEnabled(unittest.TestCase):
         }
         self.conf = ConfigFactory.from_dict(config_dict)
 
-    def test_sql_statement(self):
-        # type: () -> None
+    def test_sql_statement(self) -> None:
         """
         Test Extraction with empty result from query
         """

--- a/tests/unit/extractor/test_neo4j_es_last_updated_extractor.py
+++ b/tests/unit/extractor/test_neo4j_es_last_updated_extractor.py
@@ -13,8 +13,7 @@ from databuilder.extractor.neo4j_es_last_updated_extractor import Neo4jEsLastUpd
 
 class TestNeo4jEsLastUpdatedExtractor(unittest.TestCase):
 
-    def setUp(self):
-        # type: () -> None
+    def setUp(self) -> None:
         config_dict = {
             'extractor.neo4j_es_last_updated.model_class':
                 'databuilder.models.neo4j_es_last_updated.Neo4jESLastUpdated',
@@ -22,8 +21,7 @@ class TestNeo4jEsLastUpdatedExtractor(unittest.TestCase):
         self.conf = ConfigFactory.from_dict(config_dict)
 
     @patch('time.time')
-    def test_extraction_with_model_class(self, mock_time):
-        # type: (Any) -> None
+    def test_extraction_with_model_class(self, mock_time: Any) -> None:
         """
         Test Extraction using model class
         """

--- a/tests/unit/extractor/test_neo4j_extractor.py
+++ b/tests/unit/extractor/test_neo4j_extractor.py
@@ -14,8 +14,7 @@ from databuilder.models.table_elasticsearch_document import TableESDocument
 
 class TestNeo4jExtractor(unittest.TestCase):
 
-    def setUp(self):
-        # type: () -> None
+    def setUp(self) -> None:
         config_dict = {
             'extractor.neo4j.{}'.format(Neo4jExtractor.GRAPH_URL_CONFIG_KEY): 'TEST_GRAPH_URL',
             'extractor.neo4j.{}'.format(Neo4jExtractor.CYPHER_QUERY_CONFIG_KEY): 'TEST_QUERY',
@@ -25,8 +24,7 @@ class TestNeo4jExtractor(unittest.TestCase):
 
         self.conf = ConfigFactory.from_dict(config_dict)
 
-    def text_extraction_with_empty_query_result(self):
-        # type: (Any) -> None
+    def text_extraction_with_empty_query_result(self: Any) -> None:
         """
         Test Extraction with empty results from query
         """
@@ -39,8 +37,7 @@ class TestNeo4jExtractor(unittest.TestCase):
             result = extractor.extract()
             self.assertIsNone(result)
 
-    def test_extraction_with_single_query_result(self):
-        # type: (Any) -> None
+    def test_extraction_with_single_query_result(self: Any) -> None:
         """
         Test Extraction with single result from query
         """
@@ -57,8 +54,7 @@ class TestNeo4jExtractor(unittest.TestCase):
             result = extractor.extract()
             self.assertIsNone(result)
 
-    def test_extraction_with_multiple_query_result(self):
-        # type: (Any) -> None
+    def test_extraction_with_multiple_query_result(self: Any) -> None:
         """
         Test Extraction with multiple result from query
         """
@@ -82,8 +78,7 @@ class TestNeo4jExtractor(unittest.TestCase):
             result = extractor.extract()
             self.assertIsNone(result)
 
-    def test_extraction_with_model_class(self):
-        # type: (Any) -> None
+    def test_extraction_with_model_class(self: Any) -> None:
         """
         Test Extraction using model class
         """

--- a/tests/unit/extractor/test_neo4j_search_data_extractor.py
+++ b/tests/unit/extractor/test_neo4j_search_data_extractor.py
@@ -3,6 +3,7 @@
 
 import unittest
 from mock import patch
+from typing import Any
 
 from pyhocon import ConfigFactory
 from databuilder import Scoped

--- a/tests/unit/extractor/test_neo4j_search_data_extractor.py
+++ b/tests/unit/extractor/test_neo4j_search_data_extractor.py
@@ -13,22 +13,19 @@ from databuilder.publisher.neo4j_csv_publisher import JOB_PUBLISH_TAG
 
 class TestNeo4jExtractor(unittest.TestCase):
 
-    def test_adding_filter(self):
-        # type: (Any) -> None
+    def test_adding_filter(self: Any) -> None:
         extractor = Neo4jSearchDataExtractor()
         actual = extractor._add_publish_tag_filter('foo', 'MATCH (table:Table) {publish_tag_filter} RETURN table')
 
         self.assertEqual(actual, """MATCH (table:Table) WHERE table.published_tag = 'foo' RETURN table""")
 
-    def test_not_adding_filter(self):
-        # type: (Any) -> None
+    def test_not_adding_filter(self: Any) -> None:
         extractor = Neo4jSearchDataExtractor()
         actual = extractor._add_publish_tag_filter('', 'MATCH (table:Table) {publish_tag_filter} RETURN table')
 
         self.assertEqual(actual, """MATCH (table:Table)  RETURN table""")
 
-    def test_default_search_query(self):
-        # type: (Any) -> None
+    def test_default_search_query(self: Any) -> None:
         with patch.object(Neo4jExtractor, '_get_driver'):
             extractor = Neo4jSearchDataExtractor()
             conf = ConfigFactory.from_dict({
@@ -46,8 +43,7 @@ class TestNeo4jExtractor(unittest.TestCase):
             self.assertEqual(extractor.cypher_query, Neo4jSearchDataExtractor
                              .DEFAULT_NEO4J_DASHBOARD_CYPHER_QUERY.format(publish_tag_filter=''))
 
-    def test_default_search_query_with_tag(self):
-        # type: (Any) -> None
+    def test_default_search_query_with_tag(self: Any) -> None:
         with patch.object(Neo4jExtractor, '_get_driver'):
             extractor = Neo4jSearchDataExtractor()
             conf = ConfigFactory.from_dict({

--- a/tests/unit/extractor/test_postgres_metadata_extractor.py
+++ b/tests/unit/extractor/test_postgres_metadata_extractor.py
@@ -14,8 +14,7 @@ from databuilder.models.table_metadata import TableMetadata, ColumnMetadata
 
 
 class TestPostgresMetadataExtractor(unittest.TestCase):
-    def setUp(self):
-        # type: () -> None
+    def setUp(self) -> None:
         logging.basicConfig(level=logging.INFO)
 
         config_dict = {
@@ -30,8 +29,7 @@ class TestPostgresMetadataExtractor(unittest.TestCase):
         }
         self.conf = ConfigFactory.from_dict(config_dict)
 
-    def test_extraction_with_empty_query_result(self):
-        # type: () -> None
+    def test_extraction_with_empty_query_result(self) -> None:
         """
         Test Extraction with empty result from query
         """
@@ -42,8 +40,7 @@ class TestPostgresMetadataExtractor(unittest.TestCase):
             results = extractor.extract()
             self.assertEqual(results, None)
 
-    def test_extraction_with_single_result(self):
-        # type: () -> None
+    def test_extraction_with_single_result(self) -> None:
         with patch.object(SQLAlchemyExtractor, '_get_connection') as mock_connection:
             connection = MagicMock()
             mock_connection.return_value = connection
@@ -103,8 +100,7 @@ class TestPostgresMetadataExtractor(unittest.TestCase):
             self.assertEqual(expected.__repr__(), actual.__repr__())
             self.assertIsNone(extractor.extract())
 
-    def test_extraction_with_multiple_result(self):
-        # type: () -> None
+    def test_extraction_with_multiple_result(self) -> None:
         with patch.object(SQLAlchemyExtractor, '_get_connection') as mock_connection:
             connection = MagicMock()
             mock_connection.return_value = connection
@@ -219,15 +215,15 @@ class TestPostgresMetadataExtractor(unittest.TestCase):
             self.assertIsNone(extractor.extract())
             self.assertIsNone(extractor.extract())
 
-    def _union(self, target, extra):
-        # type: (Dict[Any, Any], Dict[Any, Any]) -> Dict[Any, Any]
+    def _union(self,
+               target: Dict[Any, Any],
+               extra: Dict[Any, Any]) -> Dict[Any, Any]:
         target.update(extra)
         return target
 
 
 class TestPostgresMetadataExtractorWithWhereClause(unittest.TestCase):
-    def setUp(self):
-        # type: () -> None
+    def setUp(self) -> None:
         logging.basicConfig(level=logging.INFO)
         self.where_clause_suffix = """
         where table_schema in ('public') and table_name = 'movies'
@@ -240,8 +236,7 @@ class TestPostgresMetadataExtractorWithWhereClause(unittest.TestCase):
         }
         self.conf = ConfigFactory.from_dict(config_dict)
 
-    def test_sql_statement(self):
-        # type: () -> None
+    def test_sql_statement(self) -> None:
         """
         Test Extraction with empty result from query
         """
@@ -253,8 +248,7 @@ class TestPostgresMetadataExtractorWithWhereClause(unittest.TestCase):
 
 class TestPostgresMetadataExtractorClusterKeyNoTableCatalog(unittest.TestCase):
     # test when USE_CATALOG_AS_CLUSTER_NAME is false and CLUSTER_KEY is specified
-    def setUp(self):
-        # type: () -> None
+    def setUp(self) -> None:
         logging.basicConfig(level=logging.INFO)
         self.cluster_key = "not_master"
 
@@ -266,8 +260,7 @@ class TestPostgresMetadataExtractorClusterKeyNoTableCatalog(unittest.TestCase):
         }
         self.conf = ConfigFactory.from_dict(config_dict)
 
-    def test_sql_statement(self):
-        # type: () -> None
+    def test_sql_statement(self) -> None:
         """
         Test Extraction with empty result from query
         """
@@ -279,8 +272,7 @@ class TestPostgresMetadataExtractorClusterKeyNoTableCatalog(unittest.TestCase):
 
 class TestPostgresMetadataExtractorNoClusterKeyNoTableCatalog(unittest.TestCase):
     # test when USE_CATALOG_AS_CLUSTER_NAME is false and CLUSTER_KEY is NOT specified
-    def setUp(self):
-        # type: () -> None
+    def setUp(self) -> None:
         logging.basicConfig(level=logging.INFO)
 
         config_dict = {
@@ -290,8 +282,7 @@ class TestPostgresMetadataExtractorNoClusterKeyNoTableCatalog(unittest.TestCase)
         }
         self.conf = ConfigFactory.from_dict(config_dict)
 
-    def test_sql_statement(self):
-        # type: () -> None
+    def test_sql_statement(self) -> None:
         """
         Test Extraction with empty result from query
         """
@@ -303,8 +294,7 @@ class TestPostgresMetadataExtractorNoClusterKeyNoTableCatalog(unittest.TestCase)
 
 class TestPostgresMetadataExtractorTableCatalogEnabled(unittest.TestCase):
     # test when USE_CATALOG_AS_CLUSTER_NAME is true (CLUSTER_KEY should be ignored)
-    def setUp(self):
-        # type: () -> None
+    def setUp(self) -> None:
         logging.basicConfig(level=logging.INFO)
         self.cluster_key = "not_master"
 
@@ -316,8 +306,7 @@ class TestPostgresMetadataExtractorTableCatalogEnabled(unittest.TestCase):
         }
         self.conf = ConfigFactory.from_dict(config_dict)
 
-    def test_sql_statement(self):
-        # type: () -> None
+    def test_sql_statement(self) -> None:
         """
         Test Extraction with empty result from query
         """

--- a/tests/unit/extractor/test_presto_view_metadata_extractor.py
+++ b/tests/unit/extractor/test_presto_view_metadata_extractor.py
@@ -15,8 +15,7 @@ from databuilder.models.table_metadata import TableMetadata, ColumnMetadata
 
 
 class TestPrestoViewMetadataExtractor(unittest.TestCase):
-    def setUp(self):
-        # type: () -> None
+    def setUp(self) -> None:
         logging.basicConfig(level=logging.INFO)
 
         config_dict = {
@@ -25,8 +24,7 @@ class TestPrestoViewMetadataExtractor(unittest.TestCase):
         }
         self.conf = ConfigFactory.from_dict(config_dict)
 
-    def test_extraction_with_empty_result(self):
-        # type: () -> None
+    def test_extraction_with_empty_result(self) -> None:
         """
         Test Extraction with empty result from query
         """
@@ -37,8 +35,7 @@ class TestPrestoViewMetadataExtractor(unittest.TestCase):
             results = extractor.extract()
             self.assertEqual(results, None)
 
-    def test_extraction_with_multiple_views(self):
-        # type: () -> None
+    def test_extraction_with_multiple_views(self) -> None:
         with patch.object(SQLAlchemyExtractor, '_get_connection') as mock_connection:
             connection = MagicMock()
             mock_connection.return_value = connection

--- a/tests/unit/extractor/test_snowflake_metadata_extractor.py
+++ b/tests/unit/extractor/test_snowflake_metadata_extractor.py
@@ -14,8 +14,7 @@ from databuilder.models.table_metadata import TableMetadata, ColumnMetadata
 
 
 class TestSnowflakeMetadataExtractor(unittest.TestCase):
-    def setUp(self):
-        # type: () -> None
+    def setUp(self) -> None:
         logging.basicConfig(level=logging.INFO)
 
         config_dict = {
@@ -30,8 +29,7 @@ class TestSnowflakeMetadataExtractor(unittest.TestCase):
         }
         self.conf = ConfigFactory.from_dict(config_dict)
 
-    def test_extraction_with_empty_query_result(self):
-        # type: () -> None
+    def test_extraction_with_empty_query_result(self) -> None:
         """
         Test Extraction with empty result from query
         """
@@ -42,8 +40,7 @@ class TestSnowflakeMetadataExtractor(unittest.TestCase):
             results = extractor.extract()
             self.assertEqual(results, None)
 
-    def test_extraction_with_single_result(self):
-        # type: () -> None
+    def test_extraction_with_single_result(self) -> None:
         with patch.object(SQLAlchemyExtractor, '_get_connection') as mock_connection:
             connection = MagicMock()
             mock_connection.return_value = connection
@@ -105,8 +102,7 @@ class TestSnowflakeMetadataExtractor(unittest.TestCase):
             self.assertEqual(expected.__repr__(), actual.__repr__())
             self.assertIsNone(extractor.extract())
 
-    def test_extraction_with_multiple_result(self):
-        # type: () -> None
+    def test_extraction_with_multiple_result(self) -> None:
         with patch.object(SQLAlchemyExtractor, '_get_connection') as mock_connection:
             connection = MagicMock()
             mock_connection.return_value = connection
@@ -226,15 +222,15 @@ class TestSnowflakeMetadataExtractor(unittest.TestCase):
             self.assertIsNone(extractor.extract())
             self.assertIsNone(extractor.extract())
 
-    def _union(self, target, extra):
-        # type: (Dict[Any, Any], Dict[Any, Any]) -> Dict[Any, Any]
+    def _union(self,
+               target: Dict[Any, Any],
+               extra: Dict[Any, Any]) -> Dict[Any, Any]:
         target.update(extra)
         return target
 
 
 class TestSnowflakeMetadataExtractorWithWhereClause(unittest.TestCase):
-    def setUp(self):
-        # type: () -> None
+    def setUp(self) -> None:
         logging.basicConfig(level=logging.INFO)
         self.where_clause_suffix = """
         where table_schema in ('public') and table_name = 'movies'
@@ -247,8 +243,7 @@ class TestSnowflakeMetadataExtractorWithWhereClause(unittest.TestCase):
         }
         self.conf = ConfigFactory.from_dict(config_dict)
 
-    def test_sql_statement(self):
-        # type: () -> None
+    def test_sql_statement(self) -> None:
         """
         Test Extraction with empty result from query
         """
@@ -260,8 +255,7 @@ class TestSnowflakeMetadataExtractorWithWhereClause(unittest.TestCase):
 
 class TestSnowflakeMetadataExtractorClusterKeyNoTableCatalog(unittest.TestCase):
     # test when USE_CATALOG_AS_CLUSTER_NAME is false and CLUSTER_KEY is specified
-    def setUp(self):
-        # type: () -> None
+    def setUp(self) -> None:
         logging.basicConfig(level=logging.INFO)
         self.cluster_key = "not_master"
 
@@ -273,8 +267,7 @@ class TestSnowflakeMetadataExtractorClusterKeyNoTableCatalog(unittest.TestCase):
         }
         self.conf = ConfigFactory.from_dict(config_dict)
 
-    def test_sql_statement(self):
-        # type: () -> None
+    def test_sql_statement(self) -> None:
         """
         Test Extraction with empty result from query
         """
@@ -286,8 +279,7 @@ class TestSnowflakeMetadataExtractorClusterKeyNoTableCatalog(unittest.TestCase):
 
 class TestSnowflakeMetadataExtractorDefaultSnowflakeDatabaseKey(unittest.TestCase):
     # test when SNOWFLAKE_DATABASE_KEY is specified
-    def setUp(self):
-        # type: () -> None
+    def setUp(self) -> None:
         logging.basicConfig(level=logging.INFO)
         self.snowflake_database_key = "not_prod"
 
@@ -298,8 +290,7 @@ class TestSnowflakeMetadataExtractorDefaultSnowflakeDatabaseKey(unittest.TestCas
         }
         self.conf = ConfigFactory.from_dict(config_dict)
 
-    def test_sql_statement(self):
-        # type: () -> None
+    def test_sql_statement(self) -> None:
         """
         Test Extraction with empty result from query
         """
@@ -311,8 +302,7 @@ class TestSnowflakeMetadataExtractorDefaultSnowflakeDatabaseKey(unittest.TestCas
 
 class TestSnowflakeMetadataExtractorDefaultDatabaseKey(unittest.TestCase):
     # test when DATABASE_KEY is specified
-    def setUp(self):
-        # type: () -> None
+    def setUp(self) -> None:
         logging.basicConfig(level=logging.INFO)
         self.database_key = 'not_snowflake'
 
@@ -323,8 +313,7 @@ class TestSnowflakeMetadataExtractorDefaultDatabaseKey(unittest.TestCase):
         }
         self.conf = ConfigFactory.from_dict(config_dict)
 
-    def test_sql_statement(self):
-        # type: () -> None
+    def test_sql_statement(self) -> None:
         """
         Test Extraction with empty result from query
         """
@@ -333,8 +322,7 @@ class TestSnowflakeMetadataExtractorDefaultDatabaseKey(unittest.TestCase):
             extractor.init(self.conf)
             self.assertFalse(self.database_key in extractor.sql_stmt)
 
-    def test_extraction_with_database_specified(self):
-        # type: () -> None
+    def test_extraction_with_database_specified(self) -> None:
         with patch.object(SQLAlchemyExtractor, '_get_connection') as mock_connection:
             connection = MagicMock()
             mock_connection.return_value = connection
@@ -367,8 +355,7 @@ class TestSnowflakeMetadataExtractorDefaultDatabaseKey(unittest.TestCase):
 
 class TestSnowflakeMetadataExtractorNoClusterKeyNoTableCatalog(unittest.TestCase):
     # test when USE_CATALOG_AS_CLUSTER_NAME is false and CLUSTER_KEY is NOT specified
-    def setUp(self):
-        # type: () -> None
+    def setUp(self) -> None:
         logging.basicConfig(level=logging.INFO)
 
         config_dict = {
@@ -378,8 +365,7 @@ class TestSnowflakeMetadataExtractorNoClusterKeyNoTableCatalog(unittest.TestCase
         }
         self.conf = ConfigFactory.from_dict(config_dict)
 
-    def test_sql_statement(self):
-        # type: () -> None
+    def test_sql_statement(self) -> None:
         """
         Test Extraction with empty result from query
         """
@@ -391,8 +377,7 @@ class TestSnowflakeMetadataExtractorNoClusterKeyNoTableCatalog(unittest.TestCase
 
 class TestSnowflakeMetadataExtractorTableCatalogEnabled(unittest.TestCase):
     # test when USE_CATALOG_AS_CLUSTER_NAME is true (CLUSTER_KEY should be ignored)
-    def setUp(self):
-        # type: () -> None
+    def setUp(self) -> None:
         logging.basicConfig(level=logging.INFO)
         self.cluster_key = "not_master"
 
@@ -404,8 +389,7 @@ class TestSnowflakeMetadataExtractorTableCatalogEnabled(unittest.TestCase):
         }
         self.conf = ConfigFactory.from_dict(config_dict)
 
-    def test_sql_statement(self):
-        # type: () -> None
+    def test_sql_statement(self) -> None:
         """
         Test Extraction with empty result from query
         """

--- a/tests/unit/extractor/test_sql_alchemy_extractor.py
+++ b/tests/unit/extractor/test_sql_alchemy_extractor.py
@@ -41,7 +41,7 @@ class TestSqlAlchemyExtractor(unittest.TestCase):
         Test Extraction from single result from query
         """
         extractor = SQLAlchemyExtractor()
-        extractor.results = [('test_result'), ]
+        extractor.results = [('test_result')]
         extractor.init(Scoped.get_scoped_conf(conf=self.conf,
                                               scope=extractor.get_scope()))
         results = extractor.extract()

--- a/tests/unit/extractor/test_sql_alchemy_extractor.py
+++ b/tests/unit/extractor/test_sql_alchemy_extractor.py
@@ -13,8 +13,7 @@ from databuilder.extractor.sql_alchemy_extractor import SQLAlchemyExtractor
 
 class TestSqlAlchemyExtractor(unittest.TestCase):
 
-    def setUp(self):
-        # type: () -> None
+    def setUp(self) -> None:
         config_dict = {
             'extractor.sqlalchemy.conn_string': 'TEST_CONNECTION',
             'extractor.sqlalchemy.extract_sql': 'SELECT 1 FROM TEST_TABLE;'
@@ -22,8 +21,8 @@ class TestSqlAlchemyExtractor(unittest.TestCase):
         self.conf = ConfigFactory.from_dict(config_dict)
 
     @patch.object(SQLAlchemyExtractor, '_get_connection')
-    def test_extraction_with_empty_query_result(self, mock_method):
-        # type: (Any, Any) -> None
+    def test_extraction_with_empty_query_result(self: Any,
+                                                mock_method: Any) -> None:
         """
         Test Extraction with empty result from query
         """
@@ -36,8 +35,8 @@ class TestSqlAlchemyExtractor(unittest.TestCase):
         self.assertEqual(results, '')
 
     @patch.object(SQLAlchemyExtractor, '_get_connection')
-    def test_extraction_with_single_query_result(self, mock_method):
-        # type: (Any, Any) -> None
+    def test_extraction_with_single_query_result(self: Any,
+                                                 mock_method: Any) -> None:
         """
         Test Extraction from single result from query
         """
@@ -49,8 +48,8 @@ class TestSqlAlchemyExtractor(unittest.TestCase):
         self.assertEqual(results, 'test_result')
 
     @patch.object(SQLAlchemyExtractor, '_get_connection')
-    def test_extraction_with_multiple_query_result(self, mock_method):
-        # type: (Any, Any) -> None
+    def test_extraction_with_multiple_query_result(self: Any,
+                                                   mock_method: Any) -> None:
         """
         Test Extraction from list of results from query
         """
@@ -65,8 +64,7 @@ class TestSqlAlchemyExtractor(unittest.TestCase):
                          ['test_result', 'test_result2', 'test_result3'])
 
     @patch.object(SQLAlchemyExtractor, '_get_connection')
-    def test_extraction_with_model_class(self, mock_method):
-        # type: (Any, Any) -> None
+    def test_extraction_with_model_class(self: Any, mock_method: Any) -> None:
         """
         Test Extraction using model class
         """
@@ -104,16 +102,15 @@ class TableMetadataResult:
     """
 
     def __init__(self,
-                 database,  # type: str
-                 schema,  # type: str
-                 name,  # type: str
-                 description,  # type: str
-                 column_name,  # type: str
-                 column_type,  # type: str
-                 column_comment,  # type: str
-                 owner  # type: str
-                 ):
-        # type: (...) -> None
+                 database: str,
+                 schema: str,
+                 name: str,
+                 description: str,
+                 column_name: str,
+                 column_type: str,
+                 column_comment: str,
+                 owner: str
+                 ) -> None:
         self.database = database
         self.schema = schema
         self.name = name

--- a/tests/unit/extractor/test_sql_server_metadata_extractor.py
+++ b/tests/unit/extractor/test_sql_server_metadata_extractor.py
@@ -14,8 +14,7 @@ from databuilder.models.table_metadata import TableMetadata, ColumnMetadata
 
 
 class TestMSSQLMetadataExtractor(unittest.TestCase):
-    def setUp(self):
-        # type: () -> None
+    def setUp(self) -> None:
         logging.basicConfig(level=logging.INFO)
 
         config_dict = {
@@ -30,8 +29,7 @@ class TestMSSQLMetadataExtractor(unittest.TestCase):
         }
         self.conf = ConfigFactory.from_dict(config_dict)
 
-    def test_extraction_with_empty_query_result(self):
-        # type: () -> None
+    def test_extraction_with_empty_query_result(self) -> None:
         """
         Test Extraction with empty result from query
         """
@@ -42,8 +40,7 @@ class TestMSSQLMetadataExtractor(unittest.TestCase):
             results = extractor.extract()
             self.assertEqual(results, None)
 
-    def test_extraction_with_single_result(self):
-        # type: () -> None
+    def test_extraction_with_single_result(self) -> None:
         with patch.object(SQLAlchemyExtractor, '_get_connection') as mock_connection:
             connection = MagicMock()
             mock_connection.return_value = connection
@@ -105,8 +102,7 @@ class TestMSSQLMetadataExtractor(unittest.TestCase):
             self.assertEqual(expected.__repr__(), actual.__repr__())
             self.assertIsNone(extractor.extract())
 
-    def test_extraction_with_multiple_result(self):
-        # type: () -> None
+    def test_extraction_with_multiple_result(self) -> None:
         with patch.object(SQLAlchemyExtractor, '_get_connection') as mock_connection:
             connection = MagicMock()
             mock_connection.return_value = connection
@@ -235,15 +231,15 @@ class TestMSSQLMetadataExtractor(unittest.TestCase):
             self.assertIsNone(extractor.extract())
             self.assertIsNone(extractor.extract())
 
-    def _union(self, target, extra):
-        # type: (Dict[Any, Any], Dict[Any, Any]) -> Dict[Any, Any]
+    def _union(self,
+               target: Dict[Any, Any],
+               extra: Dict[Any, Any]) -> Dict[Any, Any]:
         target.update(extra)
         return target
 
 
 class TestMSSQLMetadataExtractorWithWhereClause(unittest.TestCase):
-    def setUp(self):
-        # type: () -> None
+    def setUp(self) -> None:
         logging.basicConfig(level=logging.INFO)
         self.where_clause_suffix = """
         where table_schema in ('public') and table_name = 'movies'
@@ -256,8 +252,7 @@ class TestMSSQLMetadataExtractorWithWhereClause(unittest.TestCase):
         }
         self.conf = ConfigFactory.from_dict(config_dict)
 
-    def test_sql_statement(self):
-        # type: () -> None
+    def test_sql_statement(self) -> None:
         """
         Test Extraction with empty result from query
         """
@@ -269,8 +264,7 @@ class TestMSSQLMetadataExtractorWithWhereClause(unittest.TestCase):
 
 class TestMSSQLMetadataExtractorClusterKeyNoTableCatalog(unittest.TestCase):
     # test when USE_CATALOG_AS_CLUSTER_NAME is false and CLUSTER_KEY is specified
-    def setUp(self):
-        # type: () -> None
+    def setUp(self) -> None:
         logging.basicConfig(level=logging.INFO)
         self.cluster_key = "not_master"
 
@@ -282,8 +276,7 @@ class TestMSSQLMetadataExtractorClusterKeyNoTableCatalog(unittest.TestCase):
         }
         self.conf = ConfigFactory.from_dict(config_dict)
 
-    def test_sql_statement(self):
-        # type: () -> None
+    def test_sql_statement(self) -> None:
         """
         Test Extraction with empty result from query
         """
@@ -295,8 +288,7 @@ class TestMSSQLMetadataExtractorClusterKeyNoTableCatalog(unittest.TestCase):
 
 class TestMSSQLMetadataExtractorNoClusterKeyNoTableCatalog(unittest.TestCase):
     # test when USE_CATALOG_AS_CLUSTER_NAME is false and CLUSTER_KEY is NOT specified
-    def setUp(self):
-        # type: () -> None
+    def setUp(self) -> None:
         logging.basicConfig(level=logging.INFO)
 
         config_dict = {
@@ -306,8 +298,7 @@ class TestMSSQLMetadataExtractorNoClusterKeyNoTableCatalog(unittest.TestCase):
         }
         self.conf = ConfigFactory.from_dict(config_dict)
 
-    def test_sql_statement(self):
-        # type: () -> None
+    def test_sql_statement(self) -> None:
         """
         Test Extraction with empty result from query
         """
@@ -319,8 +310,7 @@ class TestMSSQLMetadataExtractorNoClusterKeyNoTableCatalog(unittest.TestCase):
 
 class TestMSSQLMetadataExtractorTableCatalogEnabled(unittest.TestCase):
     # test when USE_CATALOG_AS_CLUSTER_NAME is true (CLUSTER_KEY should be ignored)
-    def setUp(self):
-        # type: () -> None
+    def setUp(self) -> None:
         logging.basicConfig(level=logging.INFO)
         self.cluster_key = "not_master"
 
@@ -332,8 +322,7 @@ class TestMSSQLMetadataExtractorTableCatalogEnabled(unittest.TestCase):
         }
         self.conf = ConfigFactory.from_dict(config_dict)
 
-    def test_sql_statement(self):
-        # type: () -> None
+    def test_sql_statement(self) -> None:
         """
         Test Extraction with empty result from query
         """

--- a/tests/unit/filesystem/test_filesystem.py
+++ b/tests/unit/filesystem/test_filesystem.py
@@ -14,8 +14,7 @@ from databuilder.filesystem.metadata import FileMetadata
 
 class TestFileSystem(unittest.TestCase):
 
-    def test_is_file(self):
-        # type: () -> None
+    def test_is_file(self) -> None:
         dask_fs = MagicMock()
         dask_fs.ls = MagicMock(return_value=['/foo/bar'])
 
@@ -33,8 +32,7 @@ class TestFileSystem(unittest.TestCase):
 
         self.assertFalse(fs.is_file('foo'))
 
-    def test_info(self):
-        # type: () -> None
+    def test_info(self) -> None:
         dask_fs = MagicMock()
         dask_fs.info = MagicMock(return_value={'LastModified': datetime(2018, 8, 14, 4, 12, 3, tzinfo=UTC),
                                                'Size': 15093})

--- a/tests/unit/loader/test_file_system_csv_loader.py
+++ b/tests/unit/loader/test_file_system_csv_loader.py
@@ -15,8 +15,7 @@ from tests.unit.extractor.test_sql_alchemy_extractor import TableMetadataResult
 
 class TestFileSystemCSVLoader(unittest.TestCase):
 
-    def setUp(self):
-        # type: () -> None
+    def setUp(self) -> None:
         self.temp_dir_path = tempfile.mkdtemp()
         self.dest_file_name = '{}/test_file.csv'.format(self.temp_dir_path)
         self.file_mode = 'w'
@@ -24,12 +23,10 @@ class TestFileSystemCSVLoader(unittest.TestCase):
                        'loader.filesystem.csv.mode': self.file_mode}
         self.conf = ConfigFactory.from_dict(config_dict)
 
-    def tearDown(self):
-        # type: () -> None
+    def tearDown(self) -> None:
         shutil.rmtree(self.temp_dir_path)
 
-    def _check_results_helper(self, expected):
-        # type: (List[str]) -> None
+    def _check_results_helper(self, expected: List[str]) -> None:
         """
         Helper function to compare results with expected outcome
         :param expected: expected result
@@ -40,8 +37,7 @@ class TestFileSystemCSVLoader(unittest.TestCase):
                 self.assertEqual(set(e.split(',')), set(actual.split(',')))
             self.assertFalse(file.readline())
 
-    def test_empty_loading(self):
-        # type: () -> None
+    def test_empty_loading(self) -> None:
         """
         Test loading functionality with no data
         """
@@ -54,8 +50,7 @@ class TestFileSystemCSVLoader(unittest.TestCase):
 
         self._check_results_helper(expected=[])
 
-    def test_loading_with_single_object(self):
-        # type: () -> None
+    def test_loading_with_single_object(self) -> None:
         """
         Test Loading functionality with single python object
         """
@@ -86,8 +81,7 @@ class TestFileSystemCSVLoader(unittest.TestCase):
 
         self._check_results_helper(expected=expected)
 
-    def test_loading_with_list_of_objects(self):
-        # type: () -> None
+    def test_loading_with_list_of_objects(self) -> None:
         """
         Test Loading functionality with list of objects.
         Check to ensure all objects are added to file

--- a/tests/unit/loader/test_file_system_elasticsearch_json_loader.py
+++ b/tests/unit/loader/test_file_system_elasticsearch_json_loader.py
@@ -16,8 +16,7 @@ from databuilder.models.table_elasticsearch_document import TableESDocument
 
 class TestFSElasticsearchJSONLoader(unittest.TestCase):
 
-    def setUp(self):
-        # type: () -> None
+    def setUp(self) -> None:
         self.temp_dir_path = tempfile.mkdtemp()
         self.dest_file_name = '{}/test_file.json'.format(self.temp_dir_path)
         self.file_mode = 'w'
@@ -25,12 +24,10 @@ class TestFSElasticsearchJSONLoader(unittest.TestCase):
                        'loader.filesystem.elasticsearch.mode': self.file_mode}
         self.conf = ConfigFactory.from_dict(config_dict)
 
-    def tearDown(self):
-        # type: () -> None
+    def tearDown(self) -> None:
         shutil.rmtree(self.temp_dir_path)
 
-    def _check_results_helper(self, expected):
-        # type: (List[str]) -> None
+    def _check_results_helper(self, expected: List[str]) -> None:
         """
         Helper function to compare results with expected outcome
         :param expected: expected result
@@ -41,8 +38,7 @@ class TestFSElasticsearchJSONLoader(unittest.TestCase):
                 self.assertDictEqual(json.loads(e), json.loads(actual))
             self.assertFalse(file.readline())
 
-    def test_empty_loading(self):
-        # type: () -> None
+    def test_empty_loading(self) -> None:
         """
         Test loading functionality with no data
         """
@@ -55,8 +51,7 @@ class TestFSElasticsearchJSONLoader(unittest.TestCase):
 
         self._check_results_helper(expected=[])
 
-    def test_loading_with_different_object(self):
-        # type: () -> None
+    def test_loading_with_different_object(self) -> None:
         """
         Test Loading functionality with a python Dict object
         """
@@ -84,8 +79,7 @@ class TestFSElasticsearchJSONLoader(unittest.TestCase):
 
         loader.close()
 
-    def test_loading_with_single_object(self):
-        # type: () -> None
+    def test_loading_with_single_object(self) -> None:
         """
         Test Loading functionality with single python object
         """
@@ -124,8 +118,7 @@ class TestFSElasticsearchJSONLoader(unittest.TestCase):
 
         self._check_results_helper(expected=expected)
 
-    def test_loading_with_list_of_objects(self):
-        # type: () -> None
+    def test_loading_with_list_of_objects(self) -> None:
         """
         Test Loading functionality with list of objects.
         Check to ensure all objects are added to file

--- a/tests/unit/loader/test_fs_neo4j_csv_loader.py
+++ b/tests/unit/loader/test_fs_neo4j_csv_loader.py
@@ -19,8 +19,7 @@ from operator import itemgetter
 
 
 class TestFsNeo4jCSVLoader(unittest.TestCase):
-    def setUp(self):
-        # type: () -> None
+    def setUp(self) -> None:
         logging.basicConfig(level=logging.INFO)
         prefix = '/var/tmp/TestFsNeo4jCSVLoader'
         self._conf = ConfigFactory.from_dict(
@@ -29,12 +28,10 @@ class TestFsNeo4jCSVLoader(unittest.TestCase):
              .format(prefix, 'relationships'),
              FsNeo4jCSVLoader.SHOULD_DELETE_CREATED_DIR: True})
 
-    def tearDown(self):
-        # type: () -> None
+    def tearDown(self) -> None:
         Job.closer.close()
 
-    def test_load(self):
-        # type: () -> None
+    def test_load(self) -> None:
         actors = [Actor('Tom Cruise'), Actor('Meg Ryan')]
         cities = [City('San Diego'), City('Oakland')]
         movie = Movie('Top Gun', actors, cities)
@@ -59,8 +56,9 @@ class TestFsNeo4jCSVLoader(unittest.TestCase):
                                               itemgetter('START_KEY', 'END_KEY'))
         self.assertEqual(expected_relations, actual_relations)
 
-    def _get_csv_rows(self, path, sorting_key_getter):
-        # type: (str, Callable) -> Iterable[Dict[str, Any]]
+    def _get_csv_rows(self,
+                      path: str,
+                      sorting_key_getter: Callable) -> Iterable[Dict[str, Any]]:
         files = [join(path, f) for f in listdir(path) if isfile(join(path, f))]
 
         result = []

--- a/tests/unit/loader/test_generic_loader.py
+++ b/tests/unit/loader/test_generic_loader.py
@@ -11,8 +11,7 @@ from databuilder.loader.generic_loader import GenericLoader, CALLBACK_FUNCTION
 
 class TestGenericLoader(unittest.TestCase):
 
-    def test_loading(self):
-        # type: () -> None
+    def test_loading(self) -> None:
 
         loader = GenericLoader()
         callback_func = MagicMock()
@@ -25,8 +24,7 @@ class TestGenericLoader(unittest.TestCase):
 
         callback_func.assert_called_once()
 
-    def test_none_loading(self):
-        # type: () -> None
+    def test_none_loading(self) -> None:
 
         loader = GenericLoader()
         callback_func = MagicMock()

--- a/tests/unit/models/dashboard/test_dashboard_chart.py
+++ b/tests/unit/models/dashboard/test_dashboard_chart.py
@@ -3,7 +3,7 @@
 
 import unittest
 
-from typing import Any, Dict, Optional
+from typing import Any, Dict
 
 from databuilder.models.dashboard.dashboard_chart import DashboardChart
 from databuilder.models.neo4j_csv_serde import RELATION_START_KEY, RELATION_START_LABEL, RELATION_END_KEY, \

--- a/tests/unit/models/dashboard/test_dashboard_chart.py
+++ b/tests/unit/models/dashboard/test_dashboard_chart.py
@@ -3,7 +3,7 @@
 
 import unittest
 
-from typings import Any, Dict, Optional
+from typing import Any, Dict, Optional
 
 from databuilder.models.dashboard.dashboard_chart import DashboardChart
 from databuilder.models.neo4j_csv_serde import RELATION_START_KEY, RELATION_START_LABEL, RELATION_END_KEY, \

--- a/tests/unit/models/dashboard/test_dashboard_chart.py
+++ b/tests/unit/models/dashboard/test_dashboard_chart.py
@@ -3,6 +3,8 @@
 
 import unittest
 
+from typings import Any, Dict, Optional
+
 from databuilder.models.dashboard.dashboard_chart import DashboardChart
 from databuilder.models.neo4j_csv_serde import RELATION_START_KEY, RELATION_START_LABEL, RELATION_END_KEY, \
     RELATION_END_LABEL, RELATION_TYPE, RELATION_REVERSE_TYPE
@@ -22,9 +24,16 @@ class TestDashboardChart(unittest.TestCase):
                                          )
 
         actual = dashboard_chart.create_next_node()
-        expected = {'name': 'c_name', 'type': 'bar', 'id': 'c_id', 'url': 'http://gold.foo/chart',
-                    'KEY': '_dashboard://gold.dg_id/d_id/query/q_id/chart/c_id', 'LABEL': 'Chart'}
+        expected: Dict[str, Any] = {
+            'name': 'c_name',
+            'type': 'bar',
+            'id': 'c_id',
+            'url': 'http://gold.foo/chart',
+            'KEY': '_dashboard://gold.dg_id/d_id/query/q_id/chart/c_id',
+            'LABEL': 'Chart'
+        }
 
+        assert actual is not None
         self.assertDictEqual(expected, actual)
         self.assertIsNone(dashboard_chart.create_next_node())
 
@@ -36,8 +45,13 @@ class TestDashboardChart(unittest.TestCase):
                                          )
 
         actual2 = dashboard_chart.create_next_node()
-        expected2 = {'id': 'c_id', 'KEY': '_dashboard://gold.dg_id/d_id/query/q_id/chart/c_id', 'LABEL': 'Chart',
-                     'url': 'http://gold.foo.bar/'}
+        expected2: Dict[str, Any] = {
+            'id': 'c_id',
+            'KEY': '_dashboard://gold.dg_id/d_id/query/q_id/chart/c_id',
+            'LABEL': 'Chart',
+            'url': 'http://gold.foo.bar/'
+        }
+        assert actual2 is not None
         self.assertDictEqual(expected2, actual2)
 
     def test_create_relation(self) -> None:
@@ -50,10 +64,13 @@ class TestDashboardChart(unittest.TestCase):
                                          )
 
         actual = dashboard_chart.create_next_relation()
-        expected = {RELATION_END_KEY: '_dashboard://gold.dg_id/d_id/query/q_id/chart/c_id',
-                    RELATION_START_LABEL: 'Query', RELATION_END_LABEL: 'Chart',
-                    RELATION_START_KEY: '_dashboard://gold.dg_id/d_id/query/q_id', RELATION_TYPE: 'HAS_CHART',
-                    RELATION_REVERSE_TYPE: 'CHART_OF'}
+        expected: Dict[str, Any] = {
+            RELATION_END_KEY: '_dashboard://gold.dg_id/d_id/query/q_id/chart/c_id',
+            RELATION_START_LABEL: 'Query', RELATION_END_LABEL: 'Chart',
+            RELATION_START_KEY: '_dashboard://gold.dg_id/d_id/query/q_id', RELATION_TYPE: 'HAS_CHART',
+            RELATION_REVERSE_TYPE: 'CHART_OF'
+        }
 
+        assert actual is not None
         self.assertEqual(expected, actual)
         self.assertIsNone(dashboard_chart.create_next_relation())

--- a/tests/unit/models/dashboard/test_dashboard_chart.py
+++ b/tests/unit/models/dashboard/test_dashboard_chart.py
@@ -10,8 +10,7 @@ from databuilder.models.neo4j_csv_serde import RELATION_START_KEY, RELATION_STAR
 
 class TestDashboardChart(unittest.TestCase):
 
-    def test_create_nodes(self):
-        # type: () -> None
+    def test_create_nodes(self) -> None:
 
         dashboard_chart = DashboardChart(dashboard_group_id='dg_id',
                                          dashboard_id='d_id',
@@ -41,8 +40,7 @@ class TestDashboardChart(unittest.TestCase):
                      'url': 'http://gold.foo.bar/'}
         self.assertDictEqual(expected2, actual2)
 
-    def test_create_relation(self):
-        # type: () -> None
+    def test_create_relation(self) -> None:
         dashboard_chart = DashboardChart(dashboard_group_id='dg_id',
                                          dashboard_id='d_id',
                                          query_id='q_id',

--- a/tests/unit/models/dashboard/test_dashboard_last_modified.py
+++ b/tests/unit/models/dashboard/test_dashboard_last_modified.py
@@ -20,10 +20,12 @@ class TestDashboardLastModifiedTimestamp(unittest.TestCase):
                                                                  dashboard_group_id='dashboard_group_id')
 
         actual = dashboard_last_modified.create_next_node()
-        expected: Dict[str, Any] = {'timestamp': 123456789,
-                    'name': 'last_updated_timestamp',
-                    'KEY': 'product_id_dashboard://cluster_id.dashboard_group_id/dashboard_id/_last_modified_timestamp',
-                    'LABEL': 'Timestamp'}
+        expected: Dict[str, Any] = {
+            'timestamp': 123456789,
+            'name': 'last_updated_timestamp',
+            'KEY': 'product_id_dashboard://cluster_id.dashboard_group_id/dashboard_id/_last_modified_timestamp',
+            'LABEL': 'Timestamp'
+        }
 
         assert actual is not None
         self.assertDictEqual(actual, expected)

--- a/tests/unit/models/dashboard/test_dashboard_last_modified.py
+++ b/tests/unit/models/dashboard/test_dashboard_last_modified.py
@@ -3,6 +3,8 @@
 
 import unittest
 
+from typing import Any, Dict
+
 from databuilder.models.dashboard.dashboard_last_modified import DashboardLastModifiedTimestamp
 from databuilder.models.neo4j_csv_serde import RELATION_START_KEY, RELATION_START_LABEL, RELATION_END_KEY, \
     RELATION_END_LABEL, RELATION_TYPE, RELATION_REVERSE_TYPE
@@ -18,11 +20,12 @@ class TestDashboardLastModifiedTimestamp(unittest.TestCase):
                                                                  dashboard_group_id='dashboard_group_id')
 
         actual = dashboard_last_modified.create_next_node()
-        expected = {'timestamp': 123456789,
+        expected: Dict[str, Any] = {'timestamp': 123456789,
                     'name': 'last_updated_timestamp',
                     'KEY': 'product_id_dashboard://cluster_id.dashboard_group_id/dashboard_id/_last_modified_timestamp',
                     'LABEL': 'Timestamp'}
 
+        assert actual is not None
         self.assertDictEqual(actual, expected)
         self.assertIsNone(dashboard_last_modified.create_next_node())
 
@@ -34,8 +37,7 @@ class TestDashboardLastModifiedTimestamp(unittest.TestCase):
                                                                  dashboard_group_id='dashboard_group_id')
 
         actual = dashboard_last_modified.create_next_relation()
-        print(actual)
-        expected = {
+        expected: Dict[str, Any] = {
             RELATION_END_KEY: 'product_id_dashboard://cluster_id.dashboard_group_id/dashboard_id'
                               '/_last_modified_timestamp',
             RELATION_START_LABEL: 'Dashboard',
@@ -45,5 +47,6 @@ class TestDashboardLastModifiedTimestamp(unittest.TestCase):
             RELATION_REVERSE_TYPE: 'LAST_UPDATED_TIME_OF'
         }
 
+        assert actual is not None
         self.assertDictEqual(actual, expected)
         self.assertIsNone(dashboard_last_modified.create_next_relation())

--- a/tests/unit/models/dashboard/test_dashboard_last_modified.py
+++ b/tests/unit/models/dashboard/test_dashboard_last_modified.py
@@ -10,8 +10,7 @@ from databuilder.models.neo4j_csv_serde import RELATION_START_KEY, RELATION_STAR
 
 class TestDashboardLastModifiedTimestamp(unittest.TestCase):
 
-    def test_dashboard_timestamp_nodes(self):
-        # type: () -> None
+    def test_dashboard_timestamp_nodes(self) -> None:
         dashboard_last_modified = DashboardLastModifiedTimestamp(last_modified_timestamp=123456789,
                                                                  cluster='cluster_id',
                                                                  product='product_id',
@@ -27,8 +26,7 @@ class TestDashboardLastModifiedTimestamp(unittest.TestCase):
         self.assertDictEqual(actual, expected)
         self.assertIsNone(dashboard_last_modified.create_next_node())
 
-    def test_dashboard_owner_relations(self):
-        # type: () -> None
+    def test_dashboard_owner_relations(self) -> None:
         dashboard_last_modified = DashboardLastModifiedTimestamp(last_modified_timestamp=123456789,
                                                                  cluster='cluster_id',
                                                                  product='product_id',

--- a/tests/unit/models/dashboard/test_dashboard_metadata.py
+++ b/tests/unit/models/dashboard/test_dashboard_metadata.py
@@ -8,8 +8,7 @@ from databuilder.models.dashboard.dashboard_metadata import DashboardMetadata
 
 
 class TestDashboardMetadata(unittest.TestCase):
-    def setUp(self):
-        # type: () -> None
+    def setUp(self) -> None:
         # Full exammple
         self.dashboard_metadata = DashboardMetadata('Product - Jobs.cz',
                                                     'Agent',
@@ -134,8 +133,7 @@ class TestDashboardMetadata(unittest.TestCase):
 
         self.expected_rels3 = copy.deepcopy(self.expected_rels_deduped3)
 
-    def test_serialize(self):
-        # type: () -> None
+    def test_serialize(self) -> None:
         # First test
         node_row = self.dashboard_metadata.next_node()
         actual = []

--- a/tests/unit/models/dashboard/test_dashboard_owner.py
+++ b/tests/unit/models/dashboard/test_dashboard_owner.py
@@ -10,16 +10,14 @@ from databuilder.models.neo4j_csv_serde import RELATION_START_KEY, RELATION_STAR
 
 class TestDashboardOwner(unittest.TestCase):
 
-    def test_dashboard_owner_nodes(self):
-        # type: () -> None
+    def test_dashboard_owner_nodes(self) -> None:
         dashboard_owner = DashboardOwner(email='foo@bar.com', cluster='cluster_id', product='product_id',
                                          dashboard_id='dashboard_id', dashboard_group_id='dashboard_group_id')
 
         actual = dashboard_owner.create_next_node()
         self.assertIsNone(actual)
 
-    def test_dashboard_owner_relations(self):
-        # type: () -> None
+    def test_dashboard_owner_relations(self) -> None:
         dashboard_owner = DashboardOwner(email='foo@bar.com', cluster='cluster_id', product='product_id',
                                          dashboard_id='dashboard_id', dashboard_group_id='dashboard_group_id')
 

--- a/tests/unit/models/dashboard/test_dashboard_owner.py
+++ b/tests/unit/models/dashboard/test_dashboard_owner.py
@@ -26,4 +26,5 @@ class TestDashboardOwner(unittest.TestCase):
                     RELATION_START_KEY: 'product_id_dashboard://cluster_id.dashboard_group_id/dashboard_id',
                     RELATION_TYPE: 'OWNER',
                     RELATION_REVERSE_TYPE: 'OWNER_OF'}
+        assert actual is not None
         self.assertDictEqual(actual, expected)

--- a/tests/unit/models/dashboard/test_dashboard_query.py
+++ b/tests/unit/models/dashboard/test_dashboard_query.py
@@ -11,8 +11,7 @@ from databuilder.models.neo4j_csv_serde import NODE_KEY, \
 
 class TestDashboardQuery(unittest.TestCase):
 
-    def test_create_nodes(self):
-        # type: () -> None
+    def test_create_nodes(self) -> None:
 
         dashboard_query = DashboardQuery(dashboard_group_id='dg_id',
                                          dashboard_id='d_id',
@@ -29,8 +28,7 @@ class TestDashboardQuery(unittest.TestCase):
 
         self.assertEqual(expected, actual)
 
-    def test_create_relation(self):
-        # type: () -> None
+    def test_create_relation(self) -> None:
         dashboard_query = DashboardQuery(dashboard_group_id='dg_id',
                                          dashboard_id='d_id',
                                          query_id='q_id',

--- a/tests/unit/models/dashboard/test_dashboard_table.py
+++ b/tests/unit/models/dashboard/test_dashboard_table.py
@@ -29,4 +29,5 @@ class TestDashboardTable(unittest.TestCase):
                     RELATION_START_KEY: 'product_id_dashboard://cluster_id.dashboard_group_id/dashboard_id',
                     RELATION_TYPE: 'DASHBOARD_WITH_TABLE',
                     RELATION_REVERSE_TYPE: 'TABLE_OF_DASHBOARD'}
+        assert actual is not None
         self.assertDictEqual(actual, expected)

--- a/tests/unit/models/dashboard/test_dashboard_table.py
+++ b/tests/unit/models/dashboard/test_dashboard_table.py
@@ -10,8 +10,7 @@ from databuilder.models.neo4j_csv_serde import RELATION_START_KEY, RELATION_STAR
 
 class TestDashboardTable(unittest.TestCase):
 
-    def test_dashboard_table_nodes(self):
-        # type: () -> None
+    def test_dashboard_table_nodes(self) -> None:
         dashboard_table = DashboardTable(table_ids=['hive://gold.schema/table1', 'hive://gold.schema/table2'],
                                          cluster='cluster_id', product='product_id',
                                          dashboard_id='dashboard_id', dashboard_group_id='dashboard_group_id')
@@ -19,8 +18,7 @@ class TestDashboardTable(unittest.TestCase):
         actual = dashboard_table.create_next_node()
         self.assertIsNone(actual)
 
-    def test_dashboard_table_relations(self):
-        # type: () -> None
+    def test_dashboard_table_relations(self) -> None:
         dashboard_table = DashboardTable(table_ids=['hive://gold.schema/table1'],
                                          cluster='cluster_id', product='product_id',
                                          dashboard_id='dashboard_id', dashboard_group_id='dashboard_group_id')

--- a/tests/unit/models/dashboard/test_dashboard_usage.py
+++ b/tests/unit/models/dashboard/test_dashboard_usage.py
@@ -10,8 +10,7 @@ from databuilder.models.neo4j_csv_serde import RELATION_START_KEY, RELATION_STAR
 
 class TestDashboardOwner(unittest.TestCase):
 
-    def test_dashboard_usage_user_nodes(self):
-        # type: () -> None
+    def test_dashboard_usage_user_nodes(self) -> None:
         dashboard_usage = DashboardUsage(dashboard_group_id='dashboard_group_id', dashboard_id='dashboard_id',
                                          email='foo@bar.com', view_count=123, cluster='cluster_id',
                                          product='product_id', should_create_user_node=True)
@@ -34,8 +33,7 @@ class TestDashboardOwner(unittest.TestCase):
         self.assertDictEqual(expected, actual)
         self.assertIsNone(dashboard_usage.create_next_node())
 
-    def test_dashboard_usage_no_user_nodes(self):
-        # type: () -> None
+    def test_dashboard_usage_no_user_nodes(self) -> None:
         dashboard_usage = DashboardUsage(dashboard_group_id='dashboard_group_id', dashboard_id='dashboard_id',
                                          email='foo@bar.com', view_count=123,
                                          should_create_user_node=False, cluster='cluster_id',
@@ -43,8 +41,7 @@ class TestDashboardOwner(unittest.TestCase):
 
         self.assertIsNone(dashboard_usage.create_next_node())
 
-    def test_dashboard_owner_relations(self):
-        # type: () -> None
+    def test_dashboard_owner_relations(self) -> None:
         dashboard_usage = DashboardUsage(dashboard_group_id='dashboard_group_id', dashboard_id='dashboard_id',
                                          email='foo@bar.com', view_count=123, cluster='cluster_id',
                                          product='product_id')

--- a/tests/unit/models/dashboard/test_dashboard_usage.py
+++ b/tests/unit/models/dashboard/test_dashboard_usage.py
@@ -3,6 +3,8 @@
 
 import unittest
 
+from typing import Any, Dict
+
 from databuilder.models.dashboard.dashboard_usage import DashboardUsage
 from databuilder.models.neo4j_csv_serde import RELATION_START_KEY, RELATION_START_LABEL, RELATION_END_KEY, \
     RELATION_END_LABEL, RELATION_TYPE, RELATION_REVERSE_TYPE
@@ -16,7 +18,7 @@ class TestDashboardOwner(unittest.TestCase):
                                          product='product_id', should_create_user_node=True)
 
         actual = dashboard_usage.create_next_node()
-        expected = {'is_active:UNQUOTED': True,
+        expected: Dict[str, Any] = {'is_active:UNQUOTED': True,
                     'last_name': '',
                     'full_name': '',
                     'employee_type': '',
@@ -30,6 +32,7 @@ class TestDashboardOwner(unittest.TestCase):
                     'email': 'foo@bar.com',
                     'role_name': ''}
 
+        assert actual is not None
         self.assertDictEqual(expected, actual)
         self.assertIsNone(dashboard_usage.create_next_node())
 
@@ -47,7 +50,7 @@ class TestDashboardOwner(unittest.TestCase):
                                          product='product_id')
 
         actual = dashboard_usage.create_next_relation()
-        expected = {'read_count:UNQUOTED': 123,
+        expected: Dict[str, Any] = {'read_count:UNQUOTED': 123,
                     RELATION_END_KEY: 'foo@bar.com',
                     RELATION_START_LABEL: 'Dashboard',
                     RELATION_END_LABEL: 'User',
@@ -55,5 +58,6 @@ class TestDashboardOwner(unittest.TestCase):
                     RELATION_TYPE: 'READ_BY',
                     RELATION_REVERSE_TYPE: 'READ'}
 
+        assert actual is not None
         self.assertDictEqual(expected, actual)
         self.assertIsNone(dashboard_usage.create_next_relation())

--- a/tests/unit/models/dashboard/test_dashboard_usage.py
+++ b/tests/unit/models/dashboard/test_dashboard_usage.py
@@ -18,19 +18,21 @@ class TestDashboardOwner(unittest.TestCase):
                                          product='product_id', should_create_user_node=True)
 
         actual = dashboard_usage.create_next_node()
-        expected: Dict[str, Any] = {'is_active:UNQUOTED': True,
-                    'last_name': '',
-                    'full_name': '',
-                    'employee_type': '',
-                    'first_name': '',
-                    'updated_at': 0,
-                    'LABEL': 'User',
-                    'slack_id': '',
-                    'KEY': 'foo@bar.com',
-                    'github_username': '',
-                    'team_name': '',
-                    'email': 'foo@bar.com',
-                    'role_name': ''}
+        expected: Dict[str, Any] = {
+            'is_active:UNQUOTED': True,
+            'last_name': '',
+            'full_name': '',
+            'employee_type': '',
+            'first_name': '',
+            'updated_at': 0,
+            'LABEL': 'User',
+            'slack_id': '',
+            'KEY': 'foo@bar.com',
+            'github_username': '',
+            'team_name': '',
+            'email': 'foo@bar.com',
+            'role_name': ''
+        }
 
         assert actual is not None
         self.assertDictEqual(expected, actual)
@@ -50,13 +52,15 @@ class TestDashboardOwner(unittest.TestCase):
                                          product='product_id')
 
         actual = dashboard_usage.create_next_relation()
-        expected: Dict[str, Any] = {'read_count:UNQUOTED': 123,
-                    RELATION_END_KEY: 'foo@bar.com',
-                    RELATION_START_LABEL: 'Dashboard',
-                    RELATION_END_LABEL: 'User',
-                    RELATION_START_KEY: 'product_id_dashboard://cluster_id.dashboard_group_id/dashboard_id',
-                    RELATION_TYPE: 'READ_BY',
-                    RELATION_REVERSE_TYPE: 'READ'}
+        expected: Dict[str, Any] = {
+            'read_count:UNQUOTED': 123,
+            RELATION_END_KEY: 'foo@bar.com',
+            RELATION_START_LABEL: 'Dashboard',
+            RELATION_END_LABEL: 'User',
+            RELATION_START_KEY: 'product_id_dashboard://cluster_id.dashboard_group_id/dashboard_id',
+            RELATION_TYPE: 'READ_BY',
+            RELATION_REVERSE_TYPE: 'READ'
+        }
 
         assert actual is not None
         self.assertDictEqual(expected, actual)

--- a/tests/unit/models/schema/test_schema.py
+++ b/tests/unit/models/schema/test_schema.py
@@ -14,9 +14,9 @@ class TestSchemaDescription(unittest.TestCase):
                              schema='schema_name',
                              description='foo')
 
-        self.assertDictEqual(schema.create_next_node(),
+        self.assertDictEqual(schema.create_next_node() or {},
                              {'name': 'schema_name', 'KEY': 'db://cluster.schema', 'LABEL': 'Schema'})
-        self.assertDictEqual(schema.create_next_node(),
+        self.assertDictEqual(schema.create_next_node() or {},
                              {'description_source': 'description', 'description': 'foo',
                               'KEY': 'db://cluster.schema/_description', 'LABEL': 'Description'})
         self.assertIsNone(schema.create_next_node())
@@ -26,7 +26,7 @@ class TestSchemaDescription(unittest.TestCase):
         schema = SchemaModel(schema_key='db://cluster.schema',
                              schema='schema_name')
 
-        self.assertDictEqual(schema.create_next_node(),
+        self.assertDictEqual(schema.create_next_node() or {},
                              {'name': 'schema_name', 'KEY': 'db://cluster.schema', 'LABEL': 'Schema'})
         self.assertIsNone(schema.create_next_node())
 
@@ -37,9 +37,9 @@ class TestSchemaDescription(unittest.TestCase):
                              description='foo',
                              description_source='bar')
 
-        self.assertDictEqual(schema.create_next_node(),
+        self.assertDictEqual(schema.create_next_node() or {},
                              {'name': 'schema_name', 'KEY': 'db://cluster.schema', 'LABEL': 'Schema'})
-        self.assertDictEqual(schema.create_next_node(),
+        self.assertDictEqual(schema.create_next_node() or {},
                              {'description_source': 'bar', 'description': 'foo',
                               'KEY': 'db://cluster.schema/_bar_description', 'LABEL': 'Programmatic_Description'})
         self.assertIsNone(schema.create_next_node())

--- a/tests/unit/models/schema/test_schema.py
+++ b/tests/unit/models/schema/test_schema.py
@@ -8,8 +8,7 @@ from databuilder.models.schema.schema import SchemaModel
 
 class TestSchemaDescription(unittest.TestCase):
 
-    def test_create_nodes(self):
-        # type: () -> None
+    def test_create_nodes(self) -> None:
 
         schema = SchemaModel(schema_key='db://cluster.schema',
                              schema='schema_name',
@@ -22,8 +21,7 @@ class TestSchemaDescription(unittest.TestCase):
                               'KEY': 'db://cluster.schema/_description', 'LABEL': 'Description'})
         self.assertIsNone(schema.create_next_node())
 
-    def test_create_nodes_no_description(self):
-        # type: () -> None
+    def test_create_nodes_no_description(self) -> None:
 
         schema = SchemaModel(schema_key='db://cluster.schema',
                              schema='schema_name')
@@ -32,8 +30,7 @@ class TestSchemaDescription(unittest.TestCase):
                              {'name': 'schema_name', 'KEY': 'db://cluster.schema', 'LABEL': 'Schema'})
         self.assertIsNone(schema.create_next_node())
 
-    def test_create_nodes_programmatic_description(self):
-        # type: () -> None
+    def test_create_nodes_programmatic_description(self) -> None:
 
         schema = SchemaModel(schema_key='db://cluster.schema',
                              schema='schema_name',
@@ -47,8 +44,7 @@ class TestSchemaDescription(unittest.TestCase):
                               'KEY': 'db://cluster.schema/_bar_description', 'LABEL': 'Programmatic_Description'})
         self.assertIsNone(schema.create_next_node())
 
-    def test_create_relation(self):
-        # type: () -> None
+    def test_create_relation(self) -> None:
         schema = SchemaModel(schema_key='db://cluster.schema',
                              schema='schema_name',
                              description='foo')
@@ -60,15 +56,13 @@ class TestSchemaDescription(unittest.TestCase):
         self.assertEqual(expected, actual)
         self.assertIsNone(schema.create_next_relation())
 
-    def test_create_relation_no_description(self):
-        # type: () -> None
+    def test_create_relation_no_description(self) -> None:
         schema = SchemaModel(schema_key='db://cluster.schema',
                              schema='schema_name')
 
         self.assertIsNone(schema.create_next_relation())
 
-    def test_create_relation_programmatic_description(self):
-        # type: () -> None
+    def test_create_relation_programmatic_description(self) -> None:
         schema = SchemaModel(schema_key='db://cluster.schema',
                              schema='schema_name',
                              description='foo',

--- a/tests/unit/models/test_application.py
+++ b/tests/unit/models/test_application.py
@@ -13,8 +13,7 @@ from databuilder.models.table_metadata import TableMetadata
 
 class TestApplication(unittest.TestCase):
 
-    def setUp(self):
-        # type: () -> None
+    def setUp(self) -> None:
         super(TestApplication, self).setUp()
 
         self.application = Application(task_id='hive.default.test_table',
@@ -41,34 +40,28 @@ class TestApplication(unittest.TestCase):
             RELATION_REVERSE_TYPE: 'GENERATES'
         }
 
-    def test_create_next_node(self):
-        # type: () -> None
+    def test_create_next_node(self) -> None:
         next_node = self.application.create_next_node()
         self.assertEquals(next_node, self.expected_node_result)
 
-    def test_create_next_relation(self):
-        # type: () -> None
+    def test_create_next_relation(self) -> None:
         next_relation = self.application.create_next_relation()
         self.assertEquals(next_relation, self.expected_relation_result)
 
-    def test_get_table_model_key(self):
-        # type: () -> None
+    def test_get_table_model_key(self) -> None:
         table = self.application.get_table_model_key()
         self.assertEquals(table, 'hive://gold.default/test_table')
 
-    def test_get_application_model_key(self):
-        # type: () -> None
+    def test_get_application_model_key(self) -> None:
         application = self.application.get_application_model_key()
         self.assertEquals(application, self.expected_node_result[NODE_KEY])
 
-    def test_create_nodes(self):
-        # type: () -> None
+    def test_create_nodes(self) -> None:
         nodes = self.application.create_nodes()
         self.assertEquals(len(nodes), 1)
         self.assertEquals(nodes[0], self.expected_node_result)
 
-    def test_create_relation(self):
-        # type: () -> None
+    def test_create_relation(self) -> None:
         relation = self.application.create_relation()
         self.assertEquals(len(relation), 1)
         self.assertEquals(relation[0], self.expected_relation_result)

--- a/tests/unit/models/test_dashboard_elasticsearch_document.py
+++ b/tests/unit/models/test_dashboard_elasticsearch_document.py
@@ -9,8 +9,7 @@ from databuilder.models.dashboard_elasticsearch_document import DashboardESDocum
 
 class TestDashboardElasticsearchDocument(unittest.TestCase):
 
-    def test_to_json(self):
-        # type: () -> None
+    def test_to_json(self) -> None:
         """
         Test string generated from to_json method
         """

--- a/tests/unit/models/test_metric_elasticsearch_document.py
+++ b/tests/unit/models/test_metric_elasticsearch_document.py
@@ -9,8 +9,7 @@ from databuilder.models.metric_elasticsearch_document import MetricESDocument
 
 class TestMetricElasticsearchDocument(unittest.TestCase):
 
-    def test_to_json(self):
-        # type: () -> None
+    def test_to_json(self) -> None:
         """
         Test string generated from to_json method
         """

--- a/tests/unit/models/test_metric_metadata.py
+++ b/tests/unit/models/test_metric_metadata.py
@@ -8,8 +8,7 @@ from databuilder.models.metric_metadata import MetricMetadata
 
 
 class TestMetricMetadata(unittest.TestCase):
-    def setUp(self):
-        # type: () -> None
+    def setUp(self) -> None:
 
         self.metric_metadata = MetricMetadata('Product - Jobs.cz',
                                               'Agent',
@@ -104,8 +103,7 @@ class TestMetricMetadata(unittest.TestCase):
 
         self.expected_rels3 = copy.deepcopy(self.expected_rels_deduped3)
 
-    def test_serialize(self):
-        # type: () -> None
+    def test_serialize(self) -> None:
         # First test
         node_row = self.metric_metadata.next_node()
         actual = []

--- a/tests/unit/models/test_neo4j_csv_serde.py
+++ b/tests/unit/models/test_neo4j_csv_serde.py
@@ -57,6 +57,22 @@ class TestSerialize(unittest.TestCase):
         self.assertEqual(expected, actual)
 
 
+class Actor(object):
+    LABEL = 'Actor'
+    KEY_FORMAT = 'actor://{}'
+
+    def __init__(self, name: str) -> None:
+        self.name = name
+
+
+class City(object):
+    LABEL = 'City'
+    KEY_FORMAT = 'city://{}'
+
+    def __init__(self, name: str) -> None:
+        self.name = name
+
+
 class Movie(Neo4jCsvSerializable):
     LABEL = 'Movie'
     KEY_FORMAT = 'movie://{}'
@@ -129,22 +145,6 @@ class Movie(Neo4jCsvSerializable):
                            Movie.CITY_MOVIE_RELATION_TYPE
                            })
         return result
-
-
-class Actor(object):
-    LABEL = 'Actor'
-    KEY_FORMAT = 'actor://{}'
-
-    def __init__(self, name: str) -> None:
-        self.name = name
-
-
-class City(object):
-    LABEL = 'City'
-    KEY_FORMAT = 'city://{}'
-
-    def __init__(self, name: str) -> None:
-        self.name = name
 
 
 if __name__ == '__main__':

--- a/tests/unit/models/test_neo4j_csv_serde.py
+++ b/tests/unit/models/test_neo4j_csv_serde.py
@@ -14,8 +14,7 @@ from databuilder.models.neo4j_csv_serde import Neo4jCsvSerializable
 
 class TestSerialize(unittest.TestCase):
 
-    def test_serialize(self):
-        # type: () -> None
+    def test_serialize(self) -> None:
         actors = [Actor('Tom Cruise'), Actor('Meg Ryan')]
         cities = [City('San Diego'), City('Oakland')]
         movie = Movie('Top Gun', actors, cities)
@@ -66,30 +65,29 @@ class Movie(Neo4jCsvSerializable):
     MOVIE_CITY_RELATION_TYPE = 'FILMED_AT'
     CITY_MOVIE_RELATION_TYPE = 'APPEARS_IN'
 
-    def __init__(self, name, actors, cities):
-        # type: (str, Iterable[Actor], Iterable[City]) -> None
+    def __init__(self,
+                 name: str,
+                 actors: Iterable[Actor],
+                 cities: Iterable[City]) -> None:
         self._name = name
         self._actors = actors
         self._cities = cities
         self._node_iter = iter(self.create_nodes())
         self._relation_iter = iter(self.create_relation())
 
-    def create_next_node(self):
-        # type: () -> Union[Dict[str, Any], None]
+    def create_next_node(self) -> Union[Dict[str, Any], None]:
         try:
             return next(self._node_iter)
         except StopIteration:
             return None
 
-    def create_next_relation(self):
-        # type: () -> Union[Dict[str, Any], None]
+    def create_next_relation(self) -> Union[Dict[str, Any], None]:
         try:
             return next(self._relation_iter)
         except StopIteration:
             return None
 
-    def create_nodes(self):
-        # type: () -> Iterable[Dict[str, Any]]
+    def create_nodes(self) -> Iterable[Dict[str, Any]]:
         result = [{NODE_KEY: Movie.KEY_FORMAT.format(self._name),
                    NODE_LABEL: Movie.LABEL,
                    'name': self._name}]
@@ -105,8 +103,7 @@ class Movie(Neo4jCsvSerializable):
                            'name': self._name})
         return result
 
-    def create_relation(self):
-        # type: () -> Iterable[Dict[str, Any]]
+    def create_relation(self) -> Iterable[Dict[str, Any]]:
         result = []
         for actor in self._actors:
             result.append({RELATION_START_KEY:
@@ -138,8 +135,7 @@ class Actor(object):
     LABEL = 'Actor'
     KEY_FORMAT = 'actor://{}'
 
-    def __init__(self, name):
-        # type: (str) -> None
+    def __init__(self, name: str) -> None:
         self.name = name
 
 
@@ -147,8 +143,7 @@ class City(object):
     LABEL = 'City'
     KEY_FORMAT = 'city://{}'
 
-    def __init__(self, name):
-        # type: (str) -> None
+    def __init__(self, name: str) -> None:
         self.name = name
 
 

--- a/tests/unit/models/test_neo4j_es_last_updated.py
+++ b/tests/unit/models/test_neo4j_es_last_updated.py
@@ -10,8 +10,7 @@ from databuilder.models.neo4j_csv_serde import NODE_KEY, \
 
 class TestNeo4jESLastUpdated(unittest.TestCase):
 
-    def setUp(self):
-        # type: () -> None
+    def setUp(self) -> None:
         super(TestNeo4jESLastUpdated, self).setUp()
         self.neo4j_es_last_updated = Neo4jESLastUpdated(timestamp=100)
 
@@ -21,17 +20,14 @@ class TestNeo4jESLastUpdated(unittest.TestCase):
             'latest_timestmap': 100,
         }
 
-    def test_create_nodes(self):
-        # type: () -> None
+    def test_create_nodes(self) -> None:
         nodes = self.neo4j_es_last_updated.create_nodes()
         self.assertEquals(len(nodes), 1)
         self.assertEquals(nodes[0], self.expected_node_result)
 
-    def test_create_next_node(self):
-        # type: () -> None
+    def test_create_next_node(self) -> None:
         next_node = self.neo4j_es_last_updated.create_next_node()
         self.assertEquals(next_node, self.expected_node_result)
 
-    def test_create_next_relation(self):
-        # type: () -> None
+    def test_create_next_relation(self) -> None:
         self.assertIs(self.neo4j_es_last_updated.create_next_relation(), None)

--- a/tests/unit/models/test_table_column_usage.py
+++ b/tests/unit/models/test_table_column_usage.py
@@ -10,8 +10,7 @@ from typing import no_type_check
 class TestTableColumnUsage(unittest.TestCase):
 
     @no_type_check  # mypy is somehow complaining on assignment on expected dict.
-    def test_serialize(self):
-        # type: () -> None
+    def test_serialize(self) -> None:
 
         col_readers = [ColumnReader(database='db', cluster='gold', schema='scm', table='foo', column='*',
                                     user_email='john@example.com')]

--- a/tests/unit/models/test_table_elasticsearch_document.py
+++ b/tests/unit/models/test_table_elasticsearch_document.py
@@ -9,8 +9,7 @@ from databuilder.models.table_elasticsearch_document import TableESDocument
 
 class TestTableElasticsearchDocument(unittest.TestCase):
 
-    def test_to_json(self):
-        # type: () -> None
+    def test_to_json(self) -> None:
         """
         Test string generated from to_json method
         """

--- a/tests/unit/models/test_table_last_updated.py
+++ b/tests/unit/models/test_table_last_updated.py
@@ -12,8 +12,7 @@ from databuilder.models.timestamp import timestamp_constants
 
 class TestTableLastUpdated(unittest.TestCase):
 
-    def setUp(self):
-        # type: () -> None
+    def setUp(self) -> None:
         super(TestTableLastUpdated, self).setUp()
 
         self.tableLastUpdated = TableLastUpdated(table_name='test_table',
@@ -37,34 +36,28 @@ class TestTableLastUpdated(unittest.TestCase):
             RELATION_REVERSE_TYPE: 'LAST_UPDATED_TIME_OF'
         }
 
-    def test_create_next_node(self):
-        # type: () -> None
+    def test_create_next_node(self) -> None:
         next_node = self.tableLastUpdated.create_next_node()
         self.assertEqual(next_node, self.expected_node_result)
 
-    def test_create_next_relation(self):
-        # type: () -> None
+    def test_create_next_relation(self) -> None:
         next_relation = self.tableLastUpdated.create_next_relation()
         self.assertEqual(next_relation, self.expected_relation_result)
 
-    def test_get_table_model_key(self):
-        # type: () -> None
+    def test_get_table_model_key(self) -> None:
         table = self.tableLastUpdated.get_table_model_key()
         self.assertEquals(table, 'hive://gold.default/test_table')
 
-    def test_get_last_updated_model_key(self):
-        # type: () -> None
+    def test_get_last_updated_model_key(self) -> None:
         last_updated = self.tableLastUpdated.get_last_updated_model_key()
         self.assertEquals(last_updated, 'hive://gold.default/test_table/timestamp')
 
-    def test_create_nodes(self):
-        # type: () -> None
+    def test_create_nodes(self) -> None:
         nodes = self.tableLastUpdated.create_nodes()
         self.assertEquals(len(nodes), 1)
         self.assertEquals(nodes[0], self.expected_node_result)
 
-    def test_create_relation(self):
-        # type: () -> None
+    def test_create_relation(self) -> None:
         relation = self.tableLastUpdated.create_relation()
         self.assertEquals(len(relation), 1)
         self.assertEquals(relation[0], self.expected_relation_result)

--- a/tests/unit/models/test_table_lineage.py
+++ b/tests/unit/models/test_table_lineage.py
@@ -16,8 +16,7 @@ CLUSTER = 'default'
 
 class TestTableLineage(unittest.TestCase):
 
-    def setUp(self):
-        # type: () -> None
+    def setUp(self) -> None:
         super(TestTableLineage, self).setUp()
         self.table_lineage = TableLineage(db_name='hive',
                                           schema=SCHEMA,
@@ -26,21 +25,18 @@ class TestTableLineage(unittest.TestCase):
                                           downstream_deps=['hive://default.test_schema/test_table1',
                                                            'hive://default.test_schema/test_table2'])
 
-    def test_get_table_model_key(self):
-        # type: () -> None
+    def test_get_table_model_key(self) -> None:
         metadata = self.table_lineage.get_table_model_key(db=DB,
                                                           cluster=CLUSTER,
                                                           schema=SCHEMA,
                                                           table=TABLE)
         self.assertEquals(metadata, 'hive://default.base/test')
 
-    def test_create_nodes(self):
-        # type: () -> None
+    def test_create_nodes(self) -> None:
         nodes = self.table_lineage.create_nodes()
         self.assertEquals(len(nodes), 0)
 
-    def test_create_relation(self):
-        # type: () -> None
+    def test_create_relation(self) -> None:
         relations = self.table_lineage.create_relation()
         self.assertEquals(len(relations), 2)
 

--- a/tests/unit/models/test_table_metadata.py
+++ b/tests/unit/models/test_table_metadata.py
@@ -8,12 +8,10 @@ from databuilder.models.table_metadata import ColumnMetadata, TableMetadata
 
 
 class TestTableMetadata(unittest.TestCase):
-    def setUp(self):
-        # type: () -> None
+    def setUp(self) -> None:
         super(TestTableMetadata, self).setUp()
 
-    def test_serialize(self):
-        # type: () -> None
+    def test_serialize(self) -> None:
         self.table_metadata = TableMetadata('hive', 'gold', 'test_schema1', 'test_table1', 'test_table1', [
             ColumnMetadata('test_id1', 'description of test_table1', 'bigint', 0),
             ColumnMetadata('test_id2', 'description of test_id2', 'bigint', 1),
@@ -142,8 +140,7 @@ class TestTableMetadata(unittest.TestCase):
 
         self.assertEqual(self.expected_rels_deduped, actual)
 
-    def test_table_attributes(self):
-        # type: () -> None
+    def test_table_attributes(self) -> None:
         self.table_metadata3 = TableMetadata('hive', 'gold', 'test_schema3', 'test_table3', 'test_table3', [
             ColumnMetadata('test_id1', 'description of test_table1', 'bigint', 0),
             ColumnMetadata('test_id2', 'description of test_id2', 'bigint', 1),
@@ -162,8 +159,7 @@ class TestTableMetadata(unittest.TestCase):
         self.assertEqual(actual[0].get('attr2'), 'attr2')
 
     # TODO NO test can run before serialiable... need to fix
-    def test_z_custom_sources(self):
-        # type: () -> None
+    def test_z_custom_sources(self) -> None:
         self.custom_source = TableMetadata('hive', 'gold', 'test_schema3', 'test_table4', 'test_table4', [
             ColumnMetadata('test_id1', 'description of test_table1', 'bigint', 0),
             ColumnMetadata('test_id2', 'description of test_id2', 'bigint', 1),
@@ -182,8 +178,7 @@ class TestTableMetadata(unittest.TestCase):
                     'description_source': 'custom', 'description': 'test_table4'}
         self.assertEqual(actual[1], expected)
 
-    def test_tags_field(self):
-        # type: () -> None
+    def test_tags_field(self) -> None:
         self.table_metadata4 = TableMetadata('hive', 'gold', 'test_schema4', 'test_table4', 'test_table4', [
             ColumnMetadata('test_id1', 'description of test_table1', 'bigint', 0, ['col-tag1', 'col-tag2'])],
             is_view=False, tags=['tag1', 'tag2'], attr1='uri', attr2='attr2')
@@ -229,8 +224,7 @@ class TestTableMetadata(unittest.TestCase):
         self.assertEqual(actual[6], expected_col_tag_rel1)
         self.assertEqual(actual[7], expected_col_tag_rel2)
 
-    def test_tags_populated_from_str(self):
-        # type: () -> None
+    def test_tags_populated_from_str(self) -> None:
         self.table_metadata5 = TableMetadata('hive', 'gold', 'test_schema5', 'test_table5', 'test_table5', [
             ColumnMetadata('test_id1', 'description of test_table1', 'bigint', 0)], tags="tag3, tag4")
 
@@ -261,8 +255,7 @@ class TestTableMetadata(unittest.TestCase):
         self.assertEqual(actual[2], expected_tab_tag_rel3)
         self.assertEqual(actual[3], expected_tab_tag_rel4)
 
-    def test_tags_arent_populated_from_empty_list_and_str(self):
-        # type: () -> None
+    def test_tags_arent_populated_from_empty_list_and_str(self) -> None:
         self.table_metadata6 = TableMetadata('hive', 'gold', 'test_schema6', 'test_table6', 'test_table6', [
             ColumnMetadata('test_id1', 'description of test_table1', 'bigint', 0)], tags=[])
 

--- a/tests/unit/models/test_table_owner.py
+++ b/tests/unit/models/test_table_owner.py
@@ -21,8 +21,7 @@ owner2 = 'user2@2'
 
 class TestTableOwner(unittest.TestCase):
 
-    def setUp(self):
-        # type: () -> None
+    def setUp(self) -> None:
         super(TestTableOwner, self).setUp()
         self.table_owner = TableOwner(db_name='hive',
                                       schema=SCHEMA,
@@ -30,18 +29,15 @@ class TestTableOwner(unittest.TestCase):
                                       cluster=CLUSTER,
                                       owners="user1@1, UsER2@2 ")
 
-    def test_get_owner_model_key(self):
-        # type: () -> None
+    def test_get_owner_model_key(self) -> None:
         owner = self.table_owner.get_owner_model_key(owner1)
         self.assertEquals(owner, owner1)
 
-    def test_get_metadata_model_key(self):
-        # type: () -> None
+    def test_get_metadata_model_key(self) -> None:
         metadata = self.table_owner.get_metadata_model_key()
         self.assertEquals(metadata, 'hive://default.base/test')
 
-    def test_create_nodes(self):
-        # type: () -> None
+    def test_create_nodes(self) -> None:
         nodes = self.table_owner.create_nodes()
         self.assertEquals(len(nodes), 2)
 
@@ -59,8 +55,7 @@ class TestTableOwner(unittest.TestCase):
         self.assertTrue(node1 in nodes)
         self.assertTrue(node2 in nodes)
 
-    def test_create_relation(self):
-        # type: () -> None
+    def test_create_relation(self) -> None:
         relations = self.table_owner.create_relation()
         self.assertEquals(len(relations), 2)
 
@@ -84,8 +79,7 @@ class TestTableOwner(unittest.TestCase):
         self.assertTrue(relation1 in relations)
         self.assertTrue(relation2 in relations)
 
-    def test_create_nodes_with_owners_list(self):
-        # type: () -> None
+    def test_create_nodes_with_owners_list(self) -> None:
         self.table_owner_list = TableOwner(db_name='hive',
                                            schema=SCHEMA,
                                            table_name=TABLE,

--- a/tests/unit/models/test_table_source.py
+++ b/tests/unit/models/test_table_source.py
@@ -17,8 +17,7 @@ SOURCE = '/etl/sql/file.py'
 
 class TestTableSource(unittest.TestCase):
 
-    def setUp(self):
-        # type: () -> None
+    def setUp(self) -> None:
         super(TestTableSource, self).setUp()
         self.table_source = TableSource(db_name='hive',
                                         schema=SCHEMA,
@@ -26,8 +25,7 @@ class TestTableSource(unittest.TestCase):
                                         cluster=CLUSTER,
                                         source=SOURCE)
 
-    def test_get_source_model_key(self):
-        # type: () -> None
+    def test_get_source_model_key(self) -> None:
         source = self.table_source.get_source_model_key()
         self.assertEquals(source, '{db}://{cluster}.{schema}/{tbl}/_source'.format(db=DB,
                                                                                    schema=SCHEMA,
@@ -35,18 +33,15 @@ class TestTableSource(unittest.TestCase):
                                                                                    cluster=CLUSTER,
                                                                                    ))
 
-    def test_get_metadata_model_key(self):
-        # type: () -> None
+    def test_get_metadata_model_key(self) -> None:
         metadata = self.table_source.get_metadata_model_key()
         self.assertEquals(metadata, 'hive://default.base/test')
 
-    def test_create_nodes(self):
-        # type: () -> None
+    def test_create_nodes(self) -> None:
         nodes = self.table_source.create_nodes()
         self.assertEquals(len(nodes), 1)
 
-    def test_create_relation(self):
-        # type: () -> None
+    def test_create_relation(self) -> None:
         relations = self.table_source.create_relation()
         self.assertEquals(len(relations), 1)
 

--- a/tests/unit/models/test_table_stats.py
+++ b/tests/unit/models/test_table_stats.py
@@ -11,8 +11,7 @@ from databuilder.models.neo4j_csv_serde import NODE_KEY, \
 
 class TestTableStats(unittest.TestCase):
 
-    def setUp(self):
-        # type: () -> None
+    def setUp(self) -> None:
         super(TestTableStats, self).setUp()
         self.table_stats = TableColumnStats(table_name='base.test',
                                             col_name='col',
@@ -39,34 +38,28 @@ class TestTableStats(unittest.TestCase):
             RELATION_REVERSE_TYPE: 'STAT'
         }
 
-    def test_get_table_stat_model_key(self):
-        # type: () -> None
+    def test_get_table_stat_model_key(self) -> None:
         table_stats = self.table_stats.get_table_stat_model_key()
         self.assertEquals(table_stats, 'hive://gold.base/test/col/avg/')
 
-    def test_get_col_key(self):
-        # type: () -> None
+    def test_get_col_key(self) -> None:
         metadata = self.table_stats.get_col_key()
         self.assertEquals(metadata, 'hive://gold.base/test/col')
 
-    def test_create_nodes(self):
-        # type: () -> None
+    def test_create_nodes(self) -> None:
         nodes = self.table_stats.create_nodes()
         self.assertEquals(len(nodes), 1)
         self.assertEquals(nodes[0], self.expected_node_result)
 
-    def test_create_relation(self):
-        # type: () -> None
+    def test_create_relation(self) -> None:
         relation = self.table_stats.create_relation()
         self.assertEquals(len(relation), 1)
         self.assertEquals(relation[0], self.expected_relation_result)
 
-    def test_create_next_node(self):
-        # type: () -> None
+    def test_create_next_node(self) -> None:
         next_node = self.table_stats.create_next_node()
         self.assertEquals(next_node, self.expected_node_result)
 
-    def test_create_next_relation(self):
-        # type: () -> None
+    def test_create_next_relation(self) -> None:
         next_relation = self.table_stats.create_next_relation()
         self.assertEquals(next_relation, self.expected_relation_result)

--- a/tests/unit/models/test_user.py
+++ b/tests/unit/models/test_user.py
@@ -10,8 +10,7 @@ from databuilder.models.user import User
 
 class TestUser(unittest.TestCase):
 
-    def setUp(self):
-        # type: () -> None
+    def setUp(self) -> None:
         super(TestUser, self).setUp()
         self.user = User(first_name='test_first',
                          last_name='test_last',
@@ -26,13 +25,11 @@ class TestUser(unittest.TestCase):
                          updated_at=1,
                          role_name='swe')
 
-    def test_get_user_model_key(self):
-        # type: () -> None
+    def test_get_user_model_key(self) -> None:
         user_email = User.get_user_model_key(email=self.user.email)
         self.assertEquals(user_email, '{email}'.format(email='test@email.com'))
 
-    def test_create_nodes(self):
-        # type: () -> None
+    def test_create_nodes(self) -> None:
         nodes = self.user.create_nodes()
         self.assertEquals(len(nodes), 1)
 
@@ -55,8 +52,7 @@ class TestUser(unittest.TestCase):
         self.assertEqual(nodes[0]['role_name'], 'swe')
         self.assertTrue(nodes[0]['enable_notify'])
 
-    def test_create_relation(self):
-        # type: () -> None
+    def test_create_relation(self) -> None:
         relations = self.user.create_relation()
         self.assertEquals(len(relations), 1)
 
@@ -74,8 +70,7 @@ class TestUser(unittest.TestCase):
 
         self.assertTrue(relation in relations)
 
-    def test_not_including_empty_attribute(self):
-        # type: () -> None
+    def test_not_including_empty_attribute(self) -> None:
         test_user = User(email='test@email.com',
                          foo='bar')
 

--- a/tests/unit/models/test_user.py
+++ b/tests/unit/models/test_user.py
@@ -74,7 +74,7 @@ class TestUser(unittest.TestCase):
         test_user = User(email='test@email.com',
                          foo='bar')
 
-        self.assertDictEqual(test_user.create_next_node(),
+        self.assertDictEqual(test_user.create_next_node() or {},
                              {'KEY': 'test@email.com', 'LABEL': 'User', 'email': 'test@email.com',
                               'is_active:UNQUOTED': True, 'first_name': '', 'last_name': '', 'full_name': '',
                               'github_username': '', 'team_name': '', 'employee_type': '', 'slack_id': '',
@@ -82,8 +82,8 @@ class TestUser(unittest.TestCase):
 
         test_user2 = User(email='test@email.com',
                           foo='bar',
-                          is_active=None,
+                          is_active=False,
                           do_not_update_empty_attribute=True)
 
-        self.assertDictEqual(test_user2.create_next_node(),
+        self.assertDictEqual(test_user2.create_next_node() or {},
                              {'KEY': 'test@email.com', 'LABEL': 'User', 'email': 'test@email.com', 'foo': 'bar'})

--- a/tests/unit/models/test_user.py
+++ b/tests/unit/models/test_user.py
@@ -33,7 +33,7 @@ class TestUser(unittest.TestCase):
         nodes = self.user.create_nodes()
         self.assertEquals(len(nodes), 1)
 
-    def test_create_node_additional_attr(self):
+    def test_create_node_additional_attr(self) -> None:
         test_user = User(first_name='test_first',
                          last_name='test_last',
                          name='test_first test_last',

--- a/tests/unit/models/test_user_elasticsearch_document.py
+++ b/tests/unit/models/test_user_elasticsearch_document.py
@@ -9,8 +9,7 @@ from databuilder.models.user_elasticsearch_document import UserESDocument
 
 class TestUserElasticsearchDocument(unittest.TestCase):
 
-    def test_to_json(self):
-        # type: () -> None
+    def test_to_json(self) -> None:
         """
         Test string generated from to_json method
         """

--- a/tests/unit/models/test_watermark.py
+++ b/tests/unit/models/test_watermark.py
@@ -20,8 +20,7 @@ PART_TYPE = 'LOW_WATERMARK'
 
 class TestWatermark(unittest.TestCase):
 
-    def setUp(self):
-        # type: () -> None
+    def setUp(self) -> None:
         super(TestWatermark, self).setUp()
         self.watermark = Watermark(create_time='2017-09-18T00:00:00',
                                    database=DATABASE,
@@ -65,8 +64,7 @@ class TestWatermark(unittest.TestCase):
             RELATION_REVERSE_TYPE: 'WATERMARK'
         }
 
-    def test_get_watermark_model_key(self):
-        # type: () -> None
+    def test_get_watermark_model_key(self) -> None:
         watermark = self.watermark.get_watermark_model_key()
         self.assertEquals(
             watermark, '{database}://{cluster}.{schema}/{table}/{part_type}/'
@@ -76,8 +74,7 @@ class TestWatermark(unittest.TestCase):
                     table=TABLE.lower(),
                     part_type=PART_TYPE.lower()))
 
-    def test_get_metadata_model_key(self):
-        # type: () -> None
+    def test_get_metadata_model_key(self) -> None:
         metadata = self.watermark.get_metadata_model_key()
         self.assertEquals(metadata, '{database}://{cluster}.{schema}/{table}'
                           .format(database=DATABASE.lower(),
@@ -85,24 +82,20 @@ class TestWatermark(unittest.TestCase):
                                   schema=SCHEMA.lower(),
                                   table=TABLE.lower()))
 
-    def test_create_nodes(self):
-        # type: () -> None
+    def test_create_nodes(self) -> None:
         nodes = self.watermark.create_nodes()
         self.assertEquals(len(nodes), 1)
         self.assertEquals(nodes[0], self.expected_node_result)
 
-    def test_create_relation(self):
-        # type: () -> None
+    def test_create_relation(self) -> None:
         relation = self.watermark.create_relation()
         self.assertEquals(len(relation), 1)
         self.assertEquals(relation[0], self.expected_relation_result)
 
-    def test_create_next_node(self):
-        # type: () -> None
+    def test_create_next_node(self) -> None:
         next_node = self.watermark.create_next_node()
         self.assertEquals(next_node, self.expected_node_result)
 
-    def test_create_next_relation(self):
-        # type: () -> None
+    def test_create_next_relation(self) -> None:
         next_relation = self.watermark.create_next_relation()
         self.assertEquals(next_relation, self.expected_relation_result)

--- a/tests/unit/publisher/test_elasticsearch_publisher.py
+++ b/tests/unit/publisher/test_elasticsearch_publisher.py
@@ -13,8 +13,7 @@ from databuilder.publisher.elasticsearch_publisher import ElasticsearchPublisher
 
 class TestElasticsearchPublisher(unittest.TestCase):
 
-    def setUp(self):
-        # type: () -> None
+    def setUp(self) -> None:
         self.test_file_path = 'test_publisher_file.json'
         self.test_file_mode = 'r'
 
@@ -32,8 +31,7 @@ class TestElasticsearchPublisher(unittest.TestCase):
 
         self.conf = ConfigFactory.from_dict(config_dict)
 
-    def test_publish_with_no_data(self):
-        # type: () -> None
+    def test_publish_with_no_data(self) -> None:
         """
         Test Publish functionality with no data
         """
@@ -49,8 +47,7 @@ class TestElasticsearchPublisher(unittest.TestCase):
             # no calls should be made through elasticseach_client when there is no data
             self.assertTrue(self.mock_es_client.call_count == 0)
 
-    def test_publish_with_data_and_no_old_index(self):
-        # type: () -> None
+    def test_publish_with_data_and_no_old_index(self) -> None:
         """
         Test Publish functionality with data but no index in place
         """
@@ -83,8 +80,7 @@ class TestElasticsearchPublisher(unittest.TestCase):
                 {'actions': [{"add": {"index": self.test_es_new_index, "alias": self.test_es_alias}}]}
             )
 
-    def test_publish_with_data_and_old_index(self):
-        # type: () -> None
+    def test_publish_with_data_and_old_index(self) -> None:
         """
         Test Publish functionality with data and with old_index in place
         """

--- a/tests/unit/publisher/test_neo4j_csv_publisher.py
+++ b/tests/unit/publisher/test_neo4j_csv_publisher.py
@@ -16,14 +16,12 @@ from databuilder.publisher.neo4j_csv_publisher import Neo4jCsvPublisher
 
 class TestPublish(unittest.TestCase):
 
-    def setUp(self):
-        # type: () -> None
+    def setUp(self) -> None:
         logging.basicConfig(level=logging.INFO)
         self._resource_path = '{}/../resources/csv_publisher' \
             .format(os.path.join(os.path.dirname(__file__)))
 
-    def test_publisher(self):
-        # type: () -> None
+    def test_publisher(self) -> None:
         with patch.object(GraphDatabase, 'driver') as mock_driver:
             mock_session = MagicMock()
             mock_driver.return_value.session.return_value = mock_session
@@ -54,8 +52,7 @@ class TestPublish(unittest.TestCase):
             # 2 node files, 1 relation file
             self.assertEqual(mock_commit.call_count, 1)
 
-    def test_preprocessor(self):
-        # type: () -> None
+    def test_preprocessor(self) -> None:
         with patch.object(GraphDatabase, 'driver') as mock_driver:
             mock_session = MagicMock()
             mock_driver.return_value.session.return_value = mock_session

--- a/tests/unit/publisher/test_neo4j_preprocessor.py
+++ b/tests/unit/publisher/test_neo4j_preprocessor.py
@@ -15,7 +15,7 @@ class TestNeo4jPreprocessor(unittest.TestCase):
 
         self.assertTrue(not preprocessor.is_perform_preprocess())
 
-    def testDeleteRelationPreprocessor(self)  -> None:  # noqa: W293
+    def testDeleteRelationPreprocessor(self) -> None:  # noqa: W293
         preprocessor = DeleteRelationPreprocessor()
 
         self.assertTrue(preprocessor.is_perform_preprocess())

--- a/tests/unit/publisher/test_neo4j_preprocessor.py
+++ b/tests/unit/publisher/test_neo4j_preprocessor.py
@@ -10,13 +10,12 @@ from databuilder.publisher.neo4j_preprocessor import NoopRelationPreprocessor, D
 
 class TestNeo4jPreprocessor(unittest.TestCase):
 
-    def testNoopRelationPreprocessor(self):
-        # type () -> None
+    def testNoopRelationPreprocessor(self) -> None:
         preprocessor = NoopRelationPreprocessor()
 
         self.assertTrue(not preprocessor.is_perform_preprocess())
 
-    def testDeleteRelationPreprocessor(self):  # noqa: W293
+    def testDeleteRelationPreprocessor(self)  -> None:  # noqa: W293
         preprocessor = DeleteRelationPreprocessor()
 
         self.assertTrue(preprocessor.is_perform_preprocess())
@@ -52,7 +51,7 @@ class TestNeo4jPreprocessor(unittest.TestCase):
 
         self.assertEqual(expected, actual)
 
-    def testDeleteRelationPreprocessorFilter(self):
+    def testDeleteRelationPreprocessorFilter(self) -> None:
         preprocessor = DeleteRelationPreprocessor(label_tuples=[('foo', 'bar')])
 
         self.assertTrue(preprocessor.filter(start_label='foo',

--- a/tests/unit/publisher/test_publisher.py
+++ b/tests/unit/publisher/test_publisher.py
@@ -10,8 +10,7 @@ from databuilder.publisher.base_publisher import Publisher, NoopPublisher
 
 class TestPublisher(unittest.TestCase):
 
-    def testCallback(self):
-        # type: () -> None
+    def testCallback(self) -> None:
 
         publisher = NoopPublisher()
         callback = MagicMock()
@@ -20,8 +19,7 @@ class TestPublisher(unittest.TestCase):
 
         self.assertTrue(callback.on_success.called)
 
-    def testFailureCallback(self):
-        # type: () -> None
+    def testFailureCallback(self) -> None:
 
         publisher = FailedPublisher()
         callback = MagicMock()
@@ -37,16 +35,13 @@ class TestPublisher(unittest.TestCase):
 
 class FailedPublisher(Publisher):
 
-    def __init__(self):
-        # type: () -> None
+    def __init__(self) -> None:
         super(FailedPublisher, self).__init__()
 
-    def init(self, conf):
-        # type: (ConfigTree) -> None
+    def init(self, conf: ConfigTree) -> None:
         pass
 
-    def publish_impl(self):
-        # type: () -> None
+    def publish_impl(self) -> None:
         raise Exception('Bomb')
 
 

--- a/tests/unit/publisher/test_publisher.py
+++ b/tests/unit/publisher/test_publisher.py
@@ -4,6 +4,7 @@
 import unittest
 
 from mock import MagicMock
+from pyhocon import ConfigTree
 
 from databuilder.publisher.base_publisher import Publisher, NoopPublisher
 

--- a/tests/unit/publisher/test_publisher.py
+++ b/tests/unit/publisher/test_publisher.py
@@ -11,7 +11,6 @@ from databuilder.publisher.base_publisher import Publisher, NoopPublisher
 class TestPublisher(unittest.TestCase):
 
     def testCallback(self) -> None:
-
         publisher = NoopPublisher()
         callback = MagicMock()
         publisher.register_call_back(callback)
@@ -20,7 +19,6 @@ class TestPublisher(unittest.TestCase):
         self.assertTrue(callback.on_success.called)
 
     def testFailureCallback(self) -> None:
-
         publisher = FailedPublisher()
         callback = MagicMock()
         publisher.register_call_back(callback)
@@ -34,7 +32,6 @@ class TestPublisher(unittest.TestCase):
 
 
 class FailedPublisher(Publisher):
-
     def __init__(self) -> None:
         super(FailedPublisher, self).__init__()
 

--- a/tests/unit/rest_api/mode_analytics/test_mode_paginated_rest_api_query.py
+++ b/tests/unit/rest_api/mode_analytics/test_mode_paginated_rest_api_query.py
@@ -14,7 +14,7 @@ logging.basicConfig(level=logging.INFO)
 
 class TestModePaginatedRestApiQuery(unittest.TestCase):
 
-    def test_pagination(self):
+    def test_pagination(self) -> None:
         seed_record = [{'foo1': 'bar1'},
                        {'foo2': 'bar2'}]
         seed_query = RestApiQuerySeed(seed_record=seed_record)
@@ -57,7 +57,7 @@ class TestModePaginatedRestApiQuery(unittest.TestCase):
             ]
             mock_get.assert_has_calls(calls, any_order=True)
 
-    def test_no_pagination(self):
+    def test_no_pagination(self) -> None:
         seed_record = [{'foo1': 'bar1'},
                        {'foo2': 'bar2'},
                        {'foo3': 'bar3'}]

--- a/tests/unit/rest_api/test_rest_api_failure_handlers.py
+++ b/tests/unit/rest_api/test_rest_api_failure_handlers.py
@@ -9,9 +9,7 @@ from mock import MagicMock
 
 class TestHttpFailureSkipOnStatus(unittest.TestCase):
 
-    def testSkip(self):
-        # typ: (...) -> None
-
+    def testSkip(self) -> None:
         failure_handler = HttpFailureSkipOnStatus([404, 400])
 
         exception = MagicMock()

--- a/tests/unit/rest_api/test_rest_api_query.py
+++ b/tests/unit/rest_api/test_rest_api_query.py
@@ -11,7 +11,7 @@ from databuilder.rest_api.rest_api_query import RestApiQuery
 
 class TestRestApiQuery(unittest.TestCase):
 
-    def test_rest_api_query_seed(self):
+    def test_rest_api_query_seed(self) -> None:
         rest_api_query = RestApiQuerySeed(seed_record=[
             {'foo': 'bar'},
             {'john': 'doe'}
@@ -25,13 +25,13 @@ class TestRestApiQuery(unittest.TestCase):
 
         self.assertListEqual(expected, result)
 
-    def test_empty_rest_api_query_seed(self):
+    def test_empty_rest_api_query_seed(self) -> None:
         rest_api_query = EmptyRestApiQuerySeed()
 
         result = [v for v in rest_api_query.execute()]
         assert len(result) == 1
 
-    def test_rest_api_query(self):
+    def test_rest_api_query(self) -> None:
 
         seed_record = [{'foo1': 'bar1'},
                        {'foo2': 'bar2'}]
@@ -56,7 +56,7 @@ class TestRestApiQuery(unittest.TestCase):
             for actual in query.execute():
                 self.assertDictEqual(expected.pop(0), actual)
 
-    def test_rest_api_query_multiple_fields(self):
+    def test_rest_api_query_multiple_fields(self) -> None:
 
         seed_record = [{'foo1': 'bar1'},
                        {'foo2': 'bar2'}]
@@ -81,7 +81,7 @@ class TestRestApiQuery(unittest.TestCase):
             for actual in query.execute():
                 self.assertDictEqual(expected.pop(0), actual)
 
-    def test_compute_subresult_single_field(self):
+    def test_compute_subresult_single_field(self) -> None:
         sub_records = RestApiQuery._compute_sub_records(result_list=['1', '2', '3'], field_names=['foo'])
 
         expected_records = [
@@ -95,7 +95,7 @@ class TestRestApiQuery(unittest.TestCase):
 
         assert expected_records == sub_records
 
-    def test_compute_subresult_multiple_fields_json_path_and_expression(self):
+    def test_compute_subresult_multiple_fields_json_path_and_expression(self) -> None:
         sub_records = RestApiQuery._compute_sub_records(
             result_list=['1', 'a', '2', 'b', '3', 'c'], field_names=['foo', 'bar'])
 
@@ -114,7 +114,7 @@ class TestRestApiQuery(unittest.TestCase):
 
         assert expected_records == sub_records
 
-    def test_compute_subresult_multiple_fields_json_path_or_expression(self):
+    def test_compute_subresult_multiple_fields_json_path_or_expression(self) -> None:
         sub_records = RestApiQuery._compute_sub_records(
             result_list=['1', '2', '3', 'a', 'b', 'c'],
             field_names=['foo', 'bar'],

--- a/tests/unit/task/test_neo4j_staleness_removal_task.py
+++ b/tests/unit/task/test_neo4j_staleness_removal_task.py
@@ -166,22 +166,22 @@ class TestRemoveStaleData(unittest.TestCase):
             mock_execute.assert_any_call(param_dict={'marker': u'foo'},
                                          statement=textwrap.dedent("""
             MATCH (n)
-            WHERE
+            WHERE{}
             n.published_tag <> $marker
             OR NOT EXISTS(n.published_tag)
             WITH DISTINCT labels(n) as node, count(*) as count
             RETURN head(node) as type, count
-            """))
+            """.format(' ')))
 
             task._validate_relation_staleness_pct()
             mock_execute.assert_any_call(param_dict={'marker': u'foo'},
                                          statement=textwrap.dedent("""
             MATCH ()-[n]-()
-            WHERE
+            WHERE{}
             n.published_tag <> $marker
             OR NOT EXISTS(n.published_tag)
             RETURN type(n) as type, count(*) as count
-            """))
+            """.format(' ')))
 
     def test_validation_statement_ms_to_expire(self) -> None:
         with patch.object(GraphDatabase, 'driver'), patch.object(Neo4jStalenessRemovalTask, '_execute_cypher_query') \
@@ -214,22 +214,22 @@ class TestRemoveStaleData(unittest.TestCase):
             mock_execute.assert_any_call(param_dict={'marker': 9876543210},
                                          statement=textwrap.dedent("""
             MATCH (n)
-            WHERE
+            WHERE{}
             n.publisher_last_updated_epoch_ms < (timestamp() - $marker)
             OR NOT EXISTS(n.publisher_last_updated_epoch_ms)
             WITH DISTINCT labels(n) as node, count(*) as count
             RETURN head(node) as type, count
-            """))
+            """.format(' ')))
 
             task._validate_relation_staleness_pct()
             mock_execute.assert_any_call(param_dict={'marker': 9876543210},
                                          statement=textwrap.dedent("""
             MATCH ()-[n]-()
-            WHERE
+            WHERE{}
             n.publisher_last_updated_epoch_ms < (timestamp() - $marker)
             OR NOT EXISTS(n.publisher_last_updated_epoch_ms)
             RETURN type(n) as type, count(*) as count
-            """))
+            """.format(' ')))
 
     def test_delete_statement_publish_tag(self) -> None:
         with patch.object(GraphDatabase, 'driver'), patch.object(Neo4jStalenessRemovalTask, '_execute_cypher_query') \
@@ -261,25 +261,25 @@ class TestRemoveStaleData(unittest.TestCase):
                                          param_dict={'marker': u'foo', 'batch_size': 100},
                                          statement=textwrap.dedent("""
             MATCH (n:Foo)
-            WHERE
+            WHERE{}
             n.published_tag <> $marker
             OR NOT EXISTS(n.published_tag)
             WITH n LIMIT $batch_size
             DETACH DELETE (n)
             RETURN COUNT(*) as count;
-            """))
+            """.format(' ')))
 
             mock_execute.assert_any_call(dry_run=False,
                                          param_dict={'marker': u'foo', 'batch_size': 100},
                                          statement=textwrap.dedent("""
             MATCH ()-[n:BAR]-()
-            WHERE
+            WHERE{}
             n.published_tag <> $marker
             OR NOT EXISTS(n.published_tag)
             WITH n LIMIT $batch_size
             DELETE n
             RETURN count(*) as count;
-                        """))
+                        """.format(' ')))
 
     def test_delete_statement_ms_to_expire(self) -> None:
         with patch.object(GraphDatabase, 'driver'), patch.object(Neo4jStalenessRemovalTask, '_execute_cypher_query') \
@@ -312,25 +312,25 @@ class TestRemoveStaleData(unittest.TestCase):
                                          param_dict={'marker': 9876543210, 'batch_size': 100},
                                          statement=textwrap.dedent("""
             MATCH (n:Foo)
-            WHERE
+            WHERE{}
             n.publisher_last_updated_epoch_ms < (timestamp() - $marker)
             OR NOT EXISTS(n.publisher_last_updated_epoch_ms)
             WITH n LIMIT $batch_size
             DETACH DELETE (n)
             RETURN COUNT(*) as count;
-            """))
+            """.format(' ')))
 
             mock_execute.assert_any_call(dry_run=False,
                                          param_dict={'marker': 9876543210, 'batch_size': 100},
                                          statement=textwrap.dedent("""
             MATCH ()-[n:BAR]-()
-            WHERE
+            WHERE{}
             n.publisher_last_updated_epoch_ms < (timestamp() - $marker)
             OR NOT EXISTS(n.publisher_last_updated_epoch_ms)
             WITH n LIMIT $batch_size
             DELETE n
             RETURN count(*) as count;
-                        """))
+                        """.format(' ')))
 
     def test_ms_to_expire_too_small(self) -> None:
         with patch.object(GraphDatabase, 'driver'):

--- a/tests/unit/task/test_neo4j_staleness_removal_task.py
+++ b/tests/unit/task/test_neo4j_staleness_removal_task.py
@@ -95,7 +95,7 @@ class TestRemoveStaleData(unittest.TestCase):
             targets = {'foo', 'bar'}
             task._validate_staleness_pct(total_records=total_records, stale_records=stale_records, types=targets)
 
-    def test_marker(self):
+    def test_marker(self) -> None:
         with patch.object(GraphDatabase, 'driver'):
             task = Neo4jStalenessRemovalTask()
             job_config = ConfigFactory.from_dict({
@@ -134,7 +134,7 @@ class TestRemoveStaleData(unittest.TestCase):
             self.assertIsNotNone(task.ms_to_expire)
             self.assertEqual(task.marker, 86400000)
 
-    def test_validation_statement_publish_tag(self):
+    def test_validation_statement_publish_tag(self) -> None:
         with patch.object(GraphDatabase, 'driver'), patch.object(Neo4jStalenessRemovalTask, '_execute_cypher_query') \
                 as mock_execute:
             task = Neo4jStalenessRemovalTask()
@@ -166,7 +166,7 @@ class TestRemoveStaleData(unittest.TestCase):
             mock_execute.assert_any_call(param_dict={'marker': u'foo'},
                                          statement=textwrap.dedent("""
             MATCH (n)
-            WHERE 
+            WHERE
             n.published_tag <> $marker
             OR NOT EXISTS(n.published_tag)
             WITH DISTINCT labels(n) as node, count(*) as count
@@ -177,13 +177,13 @@ class TestRemoveStaleData(unittest.TestCase):
             mock_execute.assert_any_call(param_dict={'marker': u'foo'},
                                          statement=textwrap.dedent("""
             MATCH ()-[n]-()
-            WHERE 
+            WHERE
             n.published_tag <> $marker
             OR NOT EXISTS(n.published_tag)
             RETURN type(n) as type, count(*) as count
             """))
 
-    def test_validation_statement_ms_to_expire(self):
+    def test_validation_statement_ms_to_expire(self) -> None:
         with patch.object(GraphDatabase, 'driver'), patch.object(Neo4jStalenessRemovalTask, '_execute_cypher_query') \
                 as mock_execute:
             task = Neo4jStalenessRemovalTask()
@@ -214,7 +214,7 @@ class TestRemoveStaleData(unittest.TestCase):
             mock_execute.assert_any_call(param_dict={'marker': 9876543210},
                                          statement=textwrap.dedent("""
             MATCH (n)
-            WHERE 
+            WHERE
             n.publisher_last_updated_epoch_ms < (timestamp() - $marker)
             OR NOT EXISTS(n.publisher_last_updated_epoch_ms)
             WITH DISTINCT labels(n) as node, count(*) as count
@@ -225,13 +225,13 @@ class TestRemoveStaleData(unittest.TestCase):
             mock_execute.assert_any_call(param_dict={'marker': 9876543210},
                                          statement=textwrap.dedent("""
             MATCH ()-[n]-()
-            WHERE 
+            WHERE
             n.publisher_last_updated_epoch_ms < (timestamp() - $marker)
             OR NOT EXISTS(n.publisher_last_updated_epoch_ms)
             RETURN type(n) as type, count(*) as count
             """))
 
-    def test_delete_statement_publish_tag(self):
+    def test_delete_statement_publish_tag(self) -> None:
         with patch.object(GraphDatabase, 'driver'), patch.object(Neo4jStalenessRemovalTask, '_execute_cypher_query') \
                 as mock_execute:
             mock_execute.return_value.single.return_value = {'count': 0}
@@ -261,7 +261,7 @@ class TestRemoveStaleData(unittest.TestCase):
                                          param_dict={'marker': u'foo', 'batch_size': 100},
                                          statement=textwrap.dedent("""
             MATCH (n:Foo)
-            WHERE 
+            WHERE
             n.published_tag <> $marker
             OR NOT EXISTS(n.published_tag)
             WITH n LIMIT $batch_size
@@ -273,7 +273,7 @@ class TestRemoveStaleData(unittest.TestCase):
                                          param_dict={'marker': u'foo', 'batch_size': 100},
                                          statement=textwrap.dedent("""
             MATCH ()-[n:BAR]-()
-            WHERE 
+            WHERE
             n.published_tag <> $marker
             OR NOT EXISTS(n.published_tag)
             WITH n LIMIT $batch_size
@@ -281,7 +281,7 @@ class TestRemoveStaleData(unittest.TestCase):
             RETURN count(*) as count;
                         """))
 
-    def test_delete_statement_ms_to_expire(self):
+    def test_delete_statement_ms_to_expire(self) -> None:
         with patch.object(GraphDatabase, 'driver'), patch.object(Neo4jStalenessRemovalTask, '_execute_cypher_query') \
                 as mock_execute:
             mock_execute.return_value.single.return_value = {'count': 0}
@@ -312,7 +312,7 @@ class TestRemoveStaleData(unittest.TestCase):
                                          param_dict={'marker': 9876543210, 'batch_size': 100},
                                          statement=textwrap.dedent("""
             MATCH (n:Foo)
-            WHERE 
+            WHERE
             n.publisher_last_updated_epoch_ms < (timestamp() - $marker)
             OR NOT EXISTS(n.publisher_last_updated_epoch_ms)
             WITH n LIMIT $batch_size
@@ -324,7 +324,7 @@ class TestRemoveStaleData(unittest.TestCase):
                                          param_dict={'marker': 9876543210, 'batch_size': 100},
                                          statement=textwrap.dedent("""
             MATCH ()-[n:BAR]-()
-            WHERE 
+            WHERE
             n.publisher_last_updated_epoch_ms < (timestamp() - $marker)
             OR NOT EXISTS(n.publisher_last_updated_epoch_ms)
             WITH n LIMIT $batch_size
@@ -332,7 +332,7 @@ class TestRemoveStaleData(unittest.TestCase):
             RETURN count(*) as count;
                         """))
 
-    def test_ms_to_expire_too_small(self):
+    def test_ms_to_expire_too_small(self) -> None:
         with patch.object(GraphDatabase, 'driver'):
             task = Neo4jStalenessRemovalTask()
             job_config = ConfigFactory.from_dict({
@@ -380,7 +380,7 @@ class TestRemoveStaleData(unittest.TestCase):
             })
             task.init(job_config)
 
-    def test_delete_dry_run(self):
+    def test_delete_dry_run(self) -> None:
         with patch.object(GraphDatabase, 'driver') as mock_driver:
             session_mock = mock_driver.return_value.session
 

--- a/tests/unit/task/test_neo4j_staleness_removal_task.py
+++ b/tests/unit/task/test_neo4j_staleness_removal_task.py
@@ -19,12 +19,10 @@ from databuilder.task.neo4j_staleness_removal_task import Neo4jStalenessRemovalT
 
 class TestRemoveStaleData(unittest.TestCase):
 
-    def setUp(self):
-        # type: () -> None
+    def setUp(self) -> None:
         logging.basicConfig(level=logging.INFO)
 
-    def test_validation_failure(self):
-        # type: () -> None
+    def test_validation_failure(self) -> None:
 
         with patch.object(GraphDatabase, 'driver'):
             task = Neo4jStalenessRemovalTask()
@@ -47,8 +45,7 @@ class TestRemoveStaleData(unittest.TestCase):
             targets = {'foo'}
             task._validate_staleness_pct(total_records=total_records, stale_records=stale_records, types=targets)
 
-    def test_validation(self):
-        # type: () -> None
+    def test_validation(self) -> None:
 
         with patch.object(GraphDatabase, 'driver'):
             task = Neo4jStalenessRemovalTask()
@@ -71,8 +68,7 @@ class TestRemoveStaleData(unittest.TestCase):
             targets = {'foo'}
             self.assertRaises(Exception, task._validate_staleness_pct, total_records, stale_records, targets)
 
-    def test_validation_threshold_override(self):
-        # type: () -> None
+    def test_validation_threshold_override(self) -> None:
 
         with patch.object(GraphDatabase, 'driver'):
             task = Neo4jStalenessRemovalTask()

--- a/tests/unit/test_base_job.py
+++ b/tests/unit/test_base_job.py
@@ -19,19 +19,16 @@ from databuilder.transformer.base_transformer import Transformer
 
 class TestJob(unittest.TestCase):
 
-    def setUp(self):
-        # type: () -> None
+    def setUp(self) -> None:
         self.temp_dir_path = tempfile.mkdtemp()
         self.dest_file_name = '{}/superhero.json'.format(self.temp_dir_path)
         self.conf = ConfigFactory.from_dict(
             {'loader.superhero.dest_file': self.dest_file_name})
 
-    def tearDown(self):
-        # type: () -> None
+    def tearDown(self) -> None:
         shutil.rmtree(self.temp_dir_path)
 
-    def test_job(self):
-        # type: () -> None
+    def test_job(self) -> None:
 
         with patch("databuilder.job.job.StatsClient") as mock_statsd:
             task = DefaultTask(SuperHeroExtractor(),
@@ -54,19 +51,16 @@ class TestJob(unittest.TestCase):
 
 class TestJobNoTransform(unittest.TestCase):
 
-    def setUp(self):
-        # type: () -> None
+    def setUp(self) -> None:
         self.temp_dir_path = tempfile.mkdtemp()
         self.dest_file_name = '{}/superhero.json'.format(self.temp_dir_path)
         self.conf = ConfigFactory.from_dict(
             {'loader.superhero.dest_file': self.dest_file_name})
 
-    def tearDown(self):
-        # type: () -> None
+    def tearDown(self) -> None:
         shutil.rmtree(self.temp_dir_path)
 
-    def test_job(self):
-        # type: () -> None
+    def test_job(self) -> None:
         task = DefaultTask(SuperHeroExtractor(), SuperHeroLoader())
 
         job = DefaultJob(self.conf, task)
@@ -83,8 +77,7 @@ class TestJobNoTransform(unittest.TestCase):
 
 class TestJobStatsd(unittest.TestCase):
 
-    def setUp(self):
-        # type: () -> None
+    def setUp(self) -> None:
         self.temp_dir_path = tempfile.mkdtemp()
         self.dest_file_name = '{}/superhero.json'.format(self.temp_dir_path)
         self.conf = ConfigFactory.from_dict(
@@ -92,12 +85,10 @@ class TestJobStatsd(unittest.TestCase):
              'job.is_statsd_enabled': True,
              'job.identifier': 'foobar'})
 
-    def tearDown(self):
-        # type: () -> None
+    def tearDown(self) -> None:
         shutil.rmtree(self.temp_dir_path)
 
-    def test_job(self):
-        # type: () -> None
+    def test_job(self) -> None:
         with patch("databuilder.job.job.StatsClient") as mock_statsd:
             task = DefaultTask(SuperHeroExtractor(), SuperHeroLoader())
 
@@ -116,77 +107,64 @@ class TestJobStatsd(unittest.TestCase):
 
 
 class SuperHeroExtractor(Extractor):
-    def __init__(self):
-        # type: () -> None
+    def __init__(self) -> None:
         pass
 
-    def init(self, conf):
-        # type: (ConfigTree) -> None
+    def init(self, conf: ConfigTree) -> None:
         self.records = [SuperHero(hero='Super man', name='Clark Kent'),
                         SuperHero(hero='Bat man', name='Bruce Wayne')]
         self.iter = iter(self.records)
 
-    def extract(self):
-        # type: () -> Any
+    def extract(self) -> Any:
         try:
             return next(self.iter)
         except StopIteration:
             return None
 
-    def get_scope(self):
-        # type: () -> str
+    def get_scope(self) -> str:
         return 'extractor.superhero'
 
 
 class SuperHero:
     def __init__(self,
-                 hero,
-                 name):
-        # type: (str, str) -> None
+                 hero: str,
+                 name: str) -> None:
         self.hero = hero
         self.name = name
 
-    def __repr__(self):
-        # type: () -> str
+    def __repr__(self) -> str:
         return "SuperHero(hero={0}, name={1})".format(self.hero, self.name)
 
 
 class SuperHeroReverseNameTransformer(Transformer):
-    def __init__(self):
-        # type: () -> None
+    def __init__(self) -> None:
         pass
 
-    def init(self, conf):
-        # type: (ConfigTree) -> None
+    def init(self, conf: ConfigTree) -> None:
         pass
 
-    def transform(self, record):
-        # type: (Any) -> Any
+    def transform(self, record: Any) -> Any:
         record.name = record.name[::-1]
         return record
 
-    def get_scope(self):
-        # type: () -> str
+    def get_scope(self) -> str:
         return 'transformer.superhero'
 
 
 class SuperHeroLoader(Loader):
-    def init(self, conf):
-        # type: (ConfigTree) -> None
+    def init(self, conf: ConfigTree) -> None:
         self.conf = conf
         dest_file_path = self.conf.get_string('dest_file')
         print('Loading to {}'.format(dest_file_path))
         self.dest_file_obj = open(self.conf.get_string('dest_file'), 'w')
 
-    def load(self, record):
-        # type: (Any) -> None
+    def load(self, record: Any) -> None:
         str = json.dumps(record.__dict__, sort_keys=True)
         print('Writing record: {}'.format(str))
         self.dest_file_obj.write('{}\n'.format(str))
         self.dest_file_obj.flush()
 
-    def get_scope(self):
-        # type: () -> str
+    def get_scope(self) -> str:
         return 'loader.superhero'
 
 

--- a/tests/unit/transformer/test_bigquery_usage_transformer.py
+++ b/tests/unit/transformer/test_bigquery_usage_transformer.py
@@ -36,9 +36,11 @@ class TestBigQueryUsageTransform(unittest.TestCase):
         t1 = (key, TestBigQueryUsageTransform.READ_COUNT)
         xformed = transformer.transform(t1)
 
+        assert xformed is not None
         self.assertIsInstance(xformed, TableColumnUsage)
-        self.assertEqual(len(xformed.col_readers), 1)
-        col_reader = xformed.col_readers[0]
+        col_readers = list(xformed.col_readers)
+        self.assertEqual(len(col_readers), 1)
+        col_reader = col_readers[0]
         self.assertEqual(col_reader.cluster, TestBigQueryUsageTransform.CLUSTER)
         self.assertEqual(col_reader.database, TestBigQueryUsageTransform.DATABASE)
         self.assertEqual(col_reader.schema, TestBigQueryUsageTransform.DATASET)

--- a/tests/unit/transformer/test_bigquery_usage_transformer.py
+++ b/tests/unit/transformer/test_bigquery_usage_transformer.py
@@ -20,8 +20,7 @@ class TestBigQueryUsageTransform(unittest.TestCase):
     EMAIL = 'your-user-here@test.com'
     READ_COUNT = 305
 
-    def test_transform_function(self):
-        # type: () -> None
+    def test_transform_function(self) -> None:
         config = ConfigFactory.from_dict({})
 
         transformer = BigqueryUsageTransformer()

--- a/tests/unit/transformer/test_bigquery_usage_transformer.py
+++ b/tests/unit/transformer/test_bigquery_usage_transformer.py
@@ -47,7 +47,7 @@ class TestBigQueryUsageTransform(unittest.TestCase):
         self.assertEqual(col_reader.user_email, TestBigQueryUsageTransform.EMAIL)
         self.assertEqual(col_reader.read_count, TestBigQueryUsageTransform.READ_COUNT)
 
-    def test_scope(self):
+    def test_scope(self) -> None:
         config = ConfigFactory.from_dict({})
 
         transformer = BigqueryUsageTransformer()

--- a/tests/unit/transformer/test_chained_transformer.py
+++ b/tests/unit/transformer/test_chained_transformer.py
@@ -11,8 +11,7 @@ from databuilder.transformer.base_transformer import ChainedTransformer
 
 class TestChainedTransformer(unittest.TestCase):
 
-    def test_init_not_called(self):
-        # type: () -> None
+    def test_init_not_called(self) -> None:
 
         mock_transformer1 = MagicMock()
         mock_transformer2 = MagicMock()
@@ -32,8 +31,7 @@ class TestChainedTransformer(unittest.TestCase):
         mock_transformer2.init.assert_not_called()
         mock_transformer2.transform.assert_called_once()
 
-    def test_init_called(self):
-        # type: () -> None
+    def test_init_called(self) -> None:
 
         mock_transformer1 = MagicMock()
         mock_transformer1.get_scope.return_value = 'foo'

--- a/tests/unit/transformer/test_dict_to_model_transformer.py
+++ b/tests/unit/transformer/test_dict_to_model_transformer.py
@@ -11,8 +11,7 @@ from databuilder.models.dashboard.dashboard_execution import DashboardExecution
 
 class TestDictToModel(unittest.TestCase):
 
-    def test_conversion(self):
-        # type: () -> None
+    def test_conversion(self) -> None:
 
         transformer = DictToModel()
         config = ConfigFactory.from_dict({

--- a/tests/unit/transformer/test_regex_str_replace_transformer.py
+++ b/tests/unit/transformer/test_regex_str_replace_transformer.py
@@ -11,8 +11,7 @@ from databuilder.transformer.regex_str_replace_transformer import RegexStrReplac
 
 class TestRegexReplacement(unittest.TestCase):
 
-    def test(self):
-        # type: () -> None
+    def test(self) -> None:
         transformer = self._default_test_transformer()
 
         foo = Foo('abc')
@@ -20,8 +19,7 @@ class TestRegexReplacement(unittest.TestCase):
 
         self.assertEqual('bba', actual.val)
 
-    def test_numeric_val(self):
-        # type: () -> None
+    def test_numeric_val(self) -> None:
         transformer = self._default_test_transformer()
 
         foo = Foo(6)
@@ -29,8 +27,7 @@ class TestRegexReplacement(unittest.TestCase):
 
         self.assertEqual(6, actual.val)
 
-    def test_none_val(self):
-        # type: () -> None
+    def test_none_val(self) -> None:
         transformer = self._default_test_transformer()
 
         foo = Foo(None)
@@ -38,8 +35,7 @@ class TestRegexReplacement(unittest.TestCase):
 
         self.assertEqual(None, actual.val)
 
-    def _default_test_transformer(self):
-        # type: () -> RegexStrReplaceTransformer
+    def _default_test_transformer(self) -> RegexStrReplaceTransformer:
         config = ConfigFactory.from_dict({
             REGEX_REPLACE_TUPLE_LIST: [('a', 'b'), ('c', 'a')],
             ATTRIBUTE_NAME: 'val'
@@ -50,8 +46,7 @@ class TestRegexReplacement(unittest.TestCase):
 
         return transformer
 
-    def test_dict_replace(self):
-        # type: () -> None
+    def test_dict_replace(self) -> None:
         config = ConfigFactory.from_dict({
             REGEX_REPLACE_TUPLE_LIST: [('\\', '\\\\')],
             ATTRIBUTE_NAME: 'val'
@@ -68,8 +63,7 @@ class TestRegexReplacement(unittest.TestCase):
 
 
 class Foo(object):
-    def __init__(self, val):
-        # type: (str) -> None
+    def __init__(self, val: str) -> None:
         self.val = val
 
 

--- a/tests/unit/transformer/test_regex_str_replace_transformer.py
+++ b/tests/unit/transformer/test_regex_str_replace_transformer.py
@@ -4,6 +4,7 @@
 import unittest
 
 from pyhocon import ConfigFactory
+from typing import Any
 
 from databuilder.transformer.regex_str_replace_transformer import RegexStrReplaceTransformer, \
     REGEX_REPLACE_TUPLE_LIST, ATTRIBUTE_NAME
@@ -63,7 +64,7 @@ class TestRegexReplacement(unittest.TestCase):
 
 
 class Foo(object):
-    def __init__(self, val: str) -> None:
+    def __init__(self, val: Any) -> None:
         self.val = val
 
 

--- a/tests/unit/transformer/test_remove_field_transformer.py
+++ b/tests/unit/transformer/test_remove_field_transformer.py
@@ -10,8 +10,7 @@ from databuilder.transformer.remove_field_transformer import RemoveFieldTransfor
 
 class TestRemoveFieldTransformer(unittest.TestCase):
 
-    def test_conversion(self):
-        # type: () -> None
+    def test_conversion(self) -> None:
 
         transformer = RemoveFieldTransformer()
         config = ConfigFactory.from_dict({
@@ -29,8 +28,7 @@ class TestRemoveFieldTransformer(unittest.TestCase):
         }
         self.assertDictEqual(expected, actual)
 
-    def test_conversion_missing_field(self):
-        # type: () -> None
+    def test_conversion_missing_field(self) -> None:
 
         transformer = RemoveFieldTransformer()
         config = ConfigFactory.from_dict({

--- a/tests/unit/transformer/test_table_tag_transformer.py
+++ b/tests/unit/transformer/test_table_tag_transformer.py
@@ -10,7 +10,7 @@ from databuilder.models.table_metadata import TableMetadata
 
 
 class TestTableTagTransformer(unittest.TestCase):
-    def test_single_tag(self):
+    def test_single_tag(self) -> None:
         transformer = TableTagTransformer()
         config = ConfigFactory.from_dict({
             TableTagTransformer.TAGS: 'foo',
@@ -27,7 +27,7 @@ class TestTableTagTransformer(unittest.TestCase):
 
         self.assertEqual(result.tags, ['foo'])
 
-    def test_multiple_tags_comma_delimited(self):
+    def test_multiple_tags_comma_delimited(self) -> None:
         transformer = TableTagTransformer()
         config = ConfigFactory.from_dict({
             TableTagTransformer.TAGS: 'foo,bar',
@@ -44,7 +44,7 @@ class TestTableTagTransformer(unittest.TestCase):
 
         self.assertEqual(result.tags, ['foo', 'bar'])
 
-    def test_add_tag_to_existing_tags(self):
+    def test_add_tag_to_existing_tags(self) -> None:
         transformer = TableTagTransformer()
         config = ConfigFactory.from_dict({
             TableTagTransformer.TAGS: 'baz',
@@ -61,7 +61,7 @@ class TestTableTagTransformer(unittest.TestCase):
         ))
         self.assertEqual(result.tags, ['foo', 'bar', 'baz'])
 
-    def test_tags_not_added_to_other_objects(self):
+    def test_tags_not_added_to_other_objects(self) -> None:
         transformer = TableTagTransformer()
         config = ConfigFactory.from_dict({
             TableTagTransformer.TAGS: 'new_tag',

--- a/tests/unit/transformer/test_template_variable_substitution_transformer.py
+++ b/tests/unit/transformer/test_template_variable_substitution_transformer.py
@@ -11,8 +11,7 @@ from databuilder.transformer.template_variable_substitution_transformer import \
 
 class TestTemplateVariableSubstitutionTransformer(unittest.TestCase):
 
-    def test_conversion(self):
-        # type: () -> None
+    def test_conversion(self) -> None:
 
         transformer = TemplateVariableSubstitutionTransformer()
         config = ConfigFactory.from_dict({

--- a/tests/unit/transformer/test_timestamp_string_to_epoch_transformer.py
+++ b/tests/unit/transformer/test_timestamp_string_to_epoch_transformer.py
@@ -10,8 +10,7 @@ from databuilder.transformer.timestamp_string_to_epoch import TimestampStringToE
 
 class TestTimestampStrToEpoch(unittest.TestCase):
 
-    def test_conversion(self):
-        # type: () -> None
+    def test_conversion(self) -> None:
 
         transformer = TimestampStringToEpoch()
         config = ConfigFactory.from_dict({
@@ -22,8 +21,7 @@ class TestTimestampStrToEpoch(unittest.TestCase):
         actual = transformer.transform({'foo': '2020-02-19T19:52:33.1Z'})
         self.assertDictEqual({'foo': 1582141953}, actual)
 
-    def test_conversion_with_format(self):
-        # type: () -> None
+    def test_conversion_with_format(self) -> None:
 
         transformer = TimestampStringToEpoch()
         config = ConfigFactory.from_dict({


### PR DESCRIPTION
ref: https://github.com/lyft/amundsen/issues/560.

### Summary of Changes

Convert (most) existing typings from comment to annotation style, and add missing type annotations wherever they exist. Just the same as the other Amundsen repos, we now require functions to declare their argument and return types.

* I generally favored the minimal change necessary to get tests to pass. I didn't TODO any because I felt the added noise would be worse than too-weak typings
* There were some legit bugs: formatting strings that weren't complete, etc. Tried to use my best judgement for these. 
* There are some spots where adding `TypeVar`s would make the typings more accurate, but it was Any before, and so Any it will stay for now.
* There were a lot of missing type signatures in args and return values. For the vast majority, I tracked down the correct type and included it. I didn't add many "bad" `Any`s
* There were a lot of places with incorrect types. For example, there were some places labeled `Iterator` where callers were expecting to be able to call `len`, meaning the type signature was incorrect. I fixed these.
* I had to add some None guards assertions to tests so that the compiler knows the nullness of some variables and doesn't complain about expected and actual type mismatches
* I didn't add any `cast`s, instead I refactored those sections to use `try` blocks
* The BigQuery inheritance chain got a bit mixed up, and needed some surgery, I split that into a commit
* There was some dead code that referenced non-existent class members. I removed it. I'm assuming there's not any crazy dynamism going on (even if there was, those methods would have thrown)
* I organized the commits for development sanity, not for review. I believe the easiest way to review for both correctness and style is to review the combined diff. But it's a huge diff, and I know it's going to be a huge pain to review carefully. I'm happy to reorganize the commits in any way that makes it easier to review this beast.
* I also don't know any way to make this a smaller PR, but open to feedback. I considered structuring it as a progressive sequence with some checks disabled, then enable the check and fix violations. But this was a lot faster, and I felt like the test suite was good enough, and the existing type annotations complete enough, and the failure modes obvious enough, that the combined risk was low enough to merit doing the far-faster option of doing it all at once. But if this is too much to digest, I can break it up differently.

Some things I intend to do immediately after this lands (since they impact so many files, I wanted to do it later to avoid big merge conflicts):
* Re-enable unused import option
* Remove unused import `# noqa: F401` comments
* Conversion of remaining comment types into annotations

And some things we should do piece-by-piece but I don't plan to open immediately:
* There were some lingering `Union[..., None]` that can be safely replaced with `Optional`, but I didn't replace all of them.

### Tests

* Added mypy to Travis CI
* Many existing tests were modified to add typings. I mostly just used `Any`, since mocks are challenging to type and the benefits are small

### Documentation

No documentation changes, the user-facing experience is transparent since `mypy` is called from `make test` and CI

### CheckList
Make sure you have checked **all** steps below to ensure a timely review.
- [x] PR title addresses the issue accurately and concisely. Example: "Updates the version of Flask to v1.0.2"
    - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
- [x] PR includes a summary of changes. 
- [x] PR adds unit tests, updates existing unit tests, __OR__ documents why no test additions or modifications are needed.
- [x] In case of new functionality, my PR adds documentation that describes how to use it.
    - All the public functions and the classes in the PR contain docstrings that explain what it does
- [ ] PR passes `make test`