### PR TITLE
fix: add error handling in rest_api_query.execute for preprocessing

### DIFF
--- a/databuilder/extractor/dashboard/mode_analytics/mode_dashboard_extractor.py
+++ b/databuilder/extractor/dashboard/mode_analytics/mode_dashboard_extractor.py
@@ -111,5 +111,7 @@ class ModeDashboardExtractor(Extractor):
         json_path = '_embedded.reports[*].[token,name,description,created_at]'
         field_names = ['dashboard_id', 'dashboard_name', 'description', 'created_timestamp']
         reports_query = ModePaginatedRestApiQuery(query_to_join=spaces_query, url=reports_url_template, params=params,
-                                                  json_path=json_path, field_names=field_names, skip_no_result=True)
+                                                  json_path=json_path, field_names=field_names, skip_no_result=True,
+                                                  can_skip_failure=lambda exception: isinstance(exception, KeyError),
+                                                  )
         return reports_query

--- a/databuilder/rest_api/rest_api_query.py
+++ b/databuilder/rest_api/rest_api_query.py
@@ -141,11 +141,11 @@ class RestApiQuery(BaseRestApiQuery):
             while first_try or self._more_pages:
                 first_try = False
 
-                url = self._preprocess_url(record=record_dict)
-
                 try:
+                    url = self._preprocess_url(record=record_dict)
                     response = self._send_request(url=url)
                 except Exception as e:
+                    LOGGER.exception('Failed to process record: {}'.format(record_dict))
                     if self._can_skip_failure and self._can_skip_failure(exception=e):
                         continue
                     raise e

--- a/tests/unit/rest_api/test_rest_api_query.py
+++ b/tests/unit/rest_api/test_rest_api_query.py
@@ -56,6 +56,20 @@ class TestRestApiQuery(unittest.TestCase):
             for actual in query.execute():
                 self.assertDictEqual(expected.pop(0), actual)
 
+    def test_rest_api_query_preprocessing_key_error(self):
+        seed_record = [{}]
+        seed_query = RestApiQuerySeed(seed_record=seed_record)
+
+        json_path = 'foo.[name,hobby]'
+        field_names = ['name_field', 'hobby']
+
+        query = RestApiQuery(query_to_join=seed_query, url='foobar-{not_exist}', params={},
+                             json_path=json_path, field_names=field_names,
+                             can_skip_failure=lambda exception: isinstance(exception, KeyError))
+
+        for _ in query.execute():
+            pass
+
     def test_rest_api_query_multiple_fields(self):
 
         seed_record = [{'foo1': 'bar1'},


### PR DESCRIPTION
### Summary of Changes

Allow ignore `KeyError` during `execute` if the `record_dict` does not contain the required keys.


### Tests

Added test_rest_api_query_preprocessing_key_error

### Documentation

No

### CheckList
Make sure you have checked **all** steps below to ensure a timely review.
- [x] PR title addresses the issue accurately and concisely. Example: "Updates the version of Flask to v1.0.2"
    - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
- [x] PR includes a summary of changes. 
- [x] PR adds unit tests, updates existing unit tests, __OR__ documents why no test additions or modifications are needed.
- [x] In case of new functionality, my PR adds documentation that describes how to use it.
    - All the public functions and the classes in the PR contain docstrings that explain what it does
- [ ] PR passes `make test`
