### PR TITLE
fix(deps): Remove absolute requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -31,7 +31,7 @@ pytest-mock>=1.1,<2.0
 # PEP 484
 # License: PSF
 # Upstream url: https://github.com/python/typing
-typing>=3.6.4
+typing>=3.6.4,<3.7; python_version < '3.7'
 
 # Python client for ElasticSearch
 # License: Apache Software License

--- a/requirements.txt
+++ b/requirements.txt
@@ -38,9 +38,10 @@ typing>=3.6.4
 # Upstream url: https://pypi.org/project/elasticsearch/
 elasticsearch>=6.2.0,<7.0
 
+neo4j-driver>=1.7.2,<4.0
+
 pyhocon>=0.3.42
 sqlalchemy>=1.3.0,<2.0
-neo4j-driver>=1.7.2
 pytz>=2018.4
 statsd>=3.2.1
 retrying>=1.3.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 # The modular source code checker: pep8, pyflakes and co
 # License: MIT
 # Upstream url: http://bitbucket.org/tarek/flake8
-flake8==3.5.0
+flake8>=3.5.0
 
 # A flake8 plugin that helps you write tidier imports.
 # License: ISCL
@@ -31,31 +31,20 @@ pytest-mock>=1.1,<2.0
 # PEP 484
 # License: PSF
 # Upstream url: https://github.com/python/typing
-typing==3.6.4
+typing>=3.6.4
 
 # Python client for ElasticSearch
 # License: Apache Software License
 # Upstream url: https://pypi.org/project/elasticsearch/
 elasticsearch>=6.2.0,<7.0
 
-atomicwrites==1.1.5
-attrs==18.1.0
-more-itertools==4.2.0
-pluggy>=0.6.0
-py==1.5.3
-pyhocon==0.3.42
-pyparsing==2.2.0
-six>=1.11.0,<2.0.0
+pyhocon>=0.3.42
 sqlalchemy>=1.3.0,<2.0
-wheel==0.31.1
-neo4j-driver==1.7.2
-neotime==1.7.1
-pytz==2018.4
-statsd==3.2.1
-retrying==1.3.3
-unicodecsv==0.14.1,<1.0
-
+neo4j-driver>=1.7.2
+pytz>=2018.4
+statsd>=3.2.1
+retrying>=1.3.3
 httplib2>=0.18.0
 unidecode
 
-requests==2.23.0,<3.0
+requests>=2.23.0,<3.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -40,7 +40,7 @@ elasticsearch>=6.2.0,<7.0
 
 neo4j-driver>=1.7.2,<4.0
 
-pyhocon>=0.3.42
+pyhocon==0.3.42
 sqlalchemy>=1.3.0,<2.0
 pytz>=2018.4
 statsd>=3.2.1

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ import os
 from setuptools import setup, find_packages
 
 
-__version__ = '3.0.0'
+__version__ = '3.1.0'
 
 requirements_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'requirements.txt')
 with open(requirements_path) as requirements_file:


### PR DESCRIPTION
### Summary of Changes

This removes absolute requirements from the requirements.txt file.

#### Motivation

The specific requirement which has been causing me problems is `attrs==18.1.0`. I have been working on a Looker integration, but the `looker_sdk` library users a feature of `attrs` only available in `>=19`. When I install both libraries at the same time, pip installs `attrs==18.1.0` due to amundsendatabuilder's restriction, and then `looker_sdk` fails.

It is worth noting that Looker ought to update their own [setup.py](https://github.com/looker-open-source/sdk-codegen/blob/adc500b1e09d5b064016fe09dc49cf05a6cec97f/python/setup.py#L11) to include `attrs>=19.0.0` or something like that, but all that would do is make this problem happen at pip install time instead of runtime.

In general, pinning dependencies in libraries is liable to cause this kind of problem. I also noticed that a lot of the pinned dependencies were _transitive_ dependencies not actually required by amundsendatabuilder itself. My feeling is that unless there's a specific reason to pin them due to e.g. a bug or issue, pip can sort these out itself.

Thus, I have removed all transitive dependencies in `requirements.txt`, and changed remaining dependencies from `==` to `>=`.

I have also incremented the version number to 3.1.0 so that this change can be picked up immediately.

This is a fairly significant change so I understand if it needs some work - please let me know if there's anything else I need to do.

### Tests

No new tests needed. Hopefully this will just pass in CI.

### Documentation

N/A

### CheckList
Make sure you have checked **all** steps below to ensure a timely review.
- [x] PR title addresses the issue accurately and concisely. Example: "Updates the version of Flask to v1.0.2"
    - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
- [x] PR includes a summary of changes. 
- [x] PR adds unit tests, updates existing unit tests, __OR__ documents why no test additions or modifications are needed.
- [x] In case of new functionality, my PR adds documentation that describes how to use it.
    - All the public functions and the classes in the PR contain docstrings that explain what it does
- [ ] PR passes `make test`
