### PR TITLE
build: fix broken tests in Python 3.7, test in CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: python
-python: 
+python:
 - '3.6'
+- '3.7'
 install:
 - pip install -r requirements.txt
 - pip install .[all]

--- a/tests/unit/rest_api/mode_analytics/test_mode_paginated_rest_api_query.py
+++ b/tests/unit/rest_api/mode_analytics/test_mode_paginated_rest_api_query.py
@@ -30,11 +30,13 @@ class TestModePaginatedRestApiQuery(unittest.TestCase):
                 {'foo': [{'name': 'v3'}]},
                 {'foo': [{'name': 'v4'}, {'name': 'v5'}]},
                 {'foo': [{'name': 'v4'}, {'name': 'v5'}]},
+                {},
+                {}
             ]
 
             query = ModePaginatedRestApiQuery(query_to_join=seed_query, url='foobar', params={},
                                               json_path=json_path, field_names=field_names,
-                                              pagination_json_path='foo[*]',
+                                              skip_no_result=True, pagination_json_path='foo[*]',
                                               max_record_size=2)
 
             expected_list = [


### PR DESCRIPTION
ref: https://github.com/amundsen-io/amundsen/issues/606

### Summary of Changes

Python 3.7 introduced breaking changes involving generators and `StopIteration`, which broke two of our tests. As far as I can tell, no actual functionality was broken.

Fix the tests, and enable 3.7 in CI.

### Tests
Comments in commit messages for the trickier one


### Documentation

n/a

### CheckList
Make sure you have checked **all** steps below to ensure a timely review.
- [ ] PR title addresses the issue accurately and concisely. Example: "Updates the version of Flask to v1.0.2"
    - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
- [ ] PR includes a summary of changes. 
- [ ] PR adds unit tests, updates existing unit tests, __OR__ documents why no test additions or modifications are needed.
- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
    - All the public functions and the classes in the PR contain docstrings that explain what it does
- [ ] PR passes `make test`


cc @feng-tao 