### PR TITLE
Update postgres_sample_dag to set table extract job as upstream for elasticsearch publisher

### DIFF
--- a/example/dags/postgres_sample_dag.py
+++ b/example/dags/postgres_sample_dag.py
@@ -170,3 +170,6 @@ with DAG('amundsen_databuilder', default_args=default_args, **dag_args) as dag:
         task_id='create_es_publisher_sample_job',
         python_callable=create_es_publisher_sample_job
     )
+
+    # elastic search update run after table metadata has been updated
+    create_table_extract_job >> create_es_index_job


### PR DESCRIPTION
### Summary of Changes

Update postgres_sample_dag to make elasticsearch publisher run after table extract job has completed.

### CheckList
Make sure you have checked **all** steps below to ensure a timely review.
- [X] PR title addresses the issue accurately and concisely.
- [X] PR includes a summary of changes. 
- [] PR adds unit tests, updates existing unit tests, __OR__ documents why no test additions or modifications are needed.
- [] In case of new functionality, my PR adds documentation that describes how to use it.
    - All the public functions and the classes in the PR contain docstrings that explain what it does
- [X] PR passes `make test`
