### PR TITLE
fix(deps) Stop importing requirements.txt into setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,15 +1,22 @@
 # Copyright Contributors to the Amundsen project.
 # SPDX-License-Identifier: Apache-2.0
 
-import os
 from setuptools import setup, find_packages
 
 
 __version__ = '3.1.0'
 
-requirements_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'requirements.txt')
-with open(requirements_path) as requirements_file:
-    requirements = requirements_file.readlines()
+
+requirements = [
+    "neo4j-driver>=1.7.2,<4.0",
+    "pytz>=2018.4",
+    "statsd>=3.2.1",
+    "retrying>=1.3.3",
+    "requests>=2.23.0,<3.0",
+    "elasticsearch>=6.2.0,<7.0",
+    "pyhocon>=0.3.42",
+    "unidecode",
+]
 
 kafka = ['confluent-kafka==1.0.0']
 

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@
 from setuptools import setup, find_packages
 
 
-__version__ = '3.1.0'
+__version__ = '3.2.0'
 
 
 requirements = [


### PR DESCRIPTION
### Summary of Changes

This is my second attempt to solve the problems described in #331, since #332 didn't really go far enough.

Essentially, this solves the problem by simply no longer forcing the CI requirements on the package itself.

The thing is, this somewhat skirts the issue... the change is basically untested, since the requirements in CI are the same. The difference is that the requirements _in general_ are looser now.

We could also start removing some of the requirements in requirements.txt but having see #127 I understand now (I think) that these files are used internally at Lyft - if that's correct then it would make sense that we can't really mess with them. However, perhaps we could use a different requirements file for CI?

### CheckList
Make sure you have checked **all** steps below to ensure a timely review.
- [x] PR title addresses the issue accurately and concisely. Example: "Updates the version of Flask to v1.0.2"
    - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
- [x] PR includes a summary of changes. 
- [x] PR adds unit tests, updates existing unit tests, __OR__ documents why no test additions or modifications are needed.
- [x] In case of new functionality, my PR adds documentation that describes how to use it.
    - All the public functions and the classes in the PR contain docstrings that explain what it does
- [x] PR passes `make test`
