### PR TITLE
chore: Try unpinning neo4j & testing with 4.1.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -47,7 +47,7 @@ pyparsing==2.2.0
 six>=1.11.0,<2.0.0
 sqlalchemy>=1.3.0,<2.0
 wheel==0.31.1
-neo4j-driver==1.7.2
+neo4j-driver==4.1.1
 neotime==1.7.1
 mypy==0.782
 pytz==2018.4

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ __version__ = '3.2.0'
 
 
 requirements = [
-    "neo4j-driver>=1.7.2,<4.0",
+    "neo4j-driver>=1.7.2",
     "pytz>=2018.4",
     "statsd>=3.2.1",
     "retrying>=1.3.3",


### PR DESCRIPTION
### Summary of Changes

I'm curious to see if unpinning neo4j and testing with 4.1.1 will work, and if not, what fails in CI. We're tried running Amundsen against neo4j > 4 and ran into some issues, so this might help.

### Tests

_What tests did you add or modify and why? If no tests were added or modified, explain why. Remove this line_

### Documentation

_What documentation did you add or modify and why? Add any relevant links then remove this line_

### CheckList

Make sure you have checked **all** steps below to ensure a timely review.

- [ ] PR title addresses the issue accurately and concisely. Example: "Updates the version of Flask to v1.0.2"
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
- [ ] PR includes a summary of changes.
- [ ] PR adds unit tests, updates existing unit tests, **OR** documents why no test additions or modifications are needed.
- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
- [ ] PR passes `make test`
