### PR TITLE
fix: update connection string in Snowflake extractor to include wareh…

### DIFF
--- a/example/dags/snowflake_sample_dag.py
+++ b/example/dags/snowflake_sample_dag.py
@@ -69,11 +69,13 @@ SUPPORTED_SCHEMAS = ['public']
 SUPPORTED_SCHEMA_SQL_IN_CLAUSE = "('{schemas}')".format(schemas="', '".join(SUPPORTED_SCHEMAS))
 
 # SNOWFLAKE CONFIGs
-SNOWFLAKE_DATABASE = 'YOUR_SNOWFLAKE_DB_NAME'
+SNOWFLAKE_DATABASE_KEY = 'YOUR_SNOWFLAKE_DB_NAME'
 
 
 # todo: connection string needs to change
 def connection_string():
+    # Refer this doc: https://docs.snowflake.com/en/user-guide/sqlalchemy.html#connection-parameters
+    # for supported connection parameters and configurations
     user = 'username'
     password = 'password'
     account = 'YourSnowflakeAccountHere'
@@ -83,7 +85,7 @@ def connection_string():
         user=user,
         password=password,
         account=account,
-        database=SNOWFLAKE_DATABASE,
+        database=SNOWFLAKE_DATABASE_KEY,
         warehouse=warehouse,
     )
 
@@ -107,7 +109,7 @@ def create_snowflake_table_metadata_job():
         'extractor.snowflake.extractor.sqlalchemy.{}'.format(SQLAlchemyExtractor.CONN_STRING):
             connection_string(),
         'extractor.snowflake.{}'.format(SnowflakeMetadataExtractor.SNOWFLAKE_DATABASE_KEY):
-            SNOWFLAKE_DATABASE,
+            SNOWFLAKE_DATABASE_KEY,
         'extractor.snowflake.{}'.format(SnowflakeMetadataExtractor.WHERE_CLAUSE_SUFFIX_KEY):
             where_clause_suffix,
         'loader.filesystem_csv_neo4j.{}'.format(FsNeo4jCSVLoader.NODE_DIR_PATH):

--- a/example/dags/snowflake_sample_dag.py
+++ b/example/dags/snowflake_sample_dag.py
@@ -69,7 +69,7 @@ SUPPORTED_SCHEMAS = ['public']
 SUPPORTED_SCHEMA_SQL_IN_CLAUSE = "('{schemas}')".format(schemas="', '".join(SUPPORTED_SCHEMAS))
 
 # SNOWFLAKE CONFIGs
-SNOWFLAKE_DATABASE_KEY = 'YOUR_SNOWFLAKE_DB_NAME'
+SNOWFLAKE_DATABASE = 'YOUR_SNOWFLAKE_DB_NAME'
 
 
 # todo: connection string needs to change
@@ -77,7 +77,16 @@ def connection_string():
     user = 'username'
     password = 'password'
     account = 'YourSnowflakeAccountHere'
-    return "snowflake://%s:%s@%s" % (user, password, account)
+    # specify a warehouse to connect to.
+    warehouse = 'yourwarehouse'
+    return 'snowflake://{user}:{password}@{account}/{database}?warehouse={warehouse}'.format(
+            user=user,
+            password=password,
+            account=account,
+            database=SNOWFLAKE_DATABASE,
+            warehouse=warehouse,
+        )
+    return "snowflake://%s:%s@%s" % (user, password, account, warehouse)
 
 
 def create_snowflake_table_metadata_job():
@@ -99,7 +108,7 @@ def create_snowflake_table_metadata_job():
         'extractor.snowflake.extractor.sqlalchemy.{}'.format(SQLAlchemyExtractor.CONN_STRING):
             connection_string(),
         'extractor.snowflake.{}'.format(SnowflakeMetadataExtractor.SNOWFLAKE_DATABASE_KEY):
-            SNOWFLAKE_DATABASE_KEY,
+            SNOWFLAKE_DATABASE,
         'extractor.snowflake.{}'.format(SnowflakeMetadataExtractor.WHERE_CLAUSE_SUFFIX_KEY):
             where_clause_suffix,
         'loader.filesystem_csv_neo4j.{}'.format(FsNeo4jCSVLoader.NODE_DIR_PATH):

--- a/example/dags/snowflake_sample_dag.py
+++ b/example/dags/snowflake_sample_dag.py
@@ -80,12 +80,12 @@ def connection_string():
     # specify a warehouse to connect to.
     warehouse = 'yourwarehouse'
     return 'snowflake://{user}:{password}@{account}/{database}?warehouse={warehouse}'.format(
-            user=user,
-            password=password,
-            account=account,
-            database=SNOWFLAKE_DATABASE,
-            warehouse=warehouse,
-        )
+        user=user,
+        password=password,
+        account=account,
+        database=SNOWFLAKE_DATABASE,
+        warehouse=warehouse,
+    )
     return "snowflake://%s:%s@%s" % (user, password, account, warehouse)
 
 

--- a/example/dags/snowflake_sample_dag.py
+++ b/example/dags/snowflake_sample_dag.py
@@ -86,7 +86,6 @@ def connection_string():
         database=SNOWFLAKE_DATABASE,
         warehouse=warehouse,
     )
-    return "snowflake://%s:%s@%s" % (user, password, account, warehouse)
 
 
 def create_snowflake_table_metadata_job():

--- a/example/scripts/sample_snowflake_data_loader.py
+++ b/example/scripts/sample_snowflake_data_loader.py
@@ -31,7 +31,7 @@ LOGGER.setLevel(logging.INFO)
 # Disable snowflake logging
 logging.getLogger("snowflake.connector.network").disabled = True
 
-SNOWFLAKE_DATABASE_KEY = 'YourSnowflakeDbName'
+SNOWFLAKE_DATABASE = 'YourSnowflakeDbName'
 
 # set env NEO4J_HOST to override localhost
 NEO4J_ENDPOINT = 'bolt://{}:7687'.format(os.getenv('NEO4J_HOST', 'localhost'))
@@ -59,7 +59,16 @@ def connection_string():
     user = 'username'
     password = 'password'
     account = 'YourSnowflakeAccountHere'
-    return "snowflake://%s:%s@%s" % (user, unquote_plus(password), account)
+    # specify a warehouse to connect to.
+    warehouse = 'yourwarehouse'
+    return 'snowflake://{user}:{password}@{account}/{database}?warehouse={warehouse}'.format(
+        user=user,
+        password=password,
+        account=account,
+        database=SNOWFLAKE_DATABASE,
+        warehouse=warehouse,
+    )
+    return "snowflake://%s:%s@%s" % (user, password, account, warehouse)
 
 
 def create_sample_snowflake_job():
@@ -82,7 +91,7 @@ def create_sample_snowflake_job():
 
     job_config = ConfigFactory.from_dict({
         'extractor.snowflake.extractor.sqlalchemy.{}'.format(SQLAlchemyExtractor.CONN_STRING): connection_string(),
-        'extractor.snowflake.{}'.format(SnowflakeMetadataExtractor.SNOWFLAKE_DATABASE_KEY): SNOWFLAKE_DATABASE_KEY,
+        'extractor.snowflake.{}'.format(SnowflakeMetadataExtractor.SNOWFLAKE_DATABASE_KEY): SNOWFLAKE_DATABASE,
         'extractor.snowflake.{}'.format(SnowflakeMetadataExtractor.WHERE_CLAUSE_SUFFIX_KEY): where_clause,
         'loader.filesystem_csv_neo4j.{}'.format(FsNeo4jCSVLoader.NODE_DIR_PATH): node_files_folder,
         'loader.filesystem_csv_neo4j.{}'.format(FsNeo4jCSVLoader.RELATION_DIR_PATH): relationship_files_folder,

--- a/example/scripts/sample_snowflake_data_loader.py
+++ b/example/scripts/sample_snowflake_data_loader.py
@@ -30,7 +30,7 @@ LOGGER.setLevel(logging.INFO)
 # Disable snowflake logging
 logging.getLogger("snowflake.connector.network").disabled = True
 
-SNOWFLAKE_DATABASE = 'YourSnowflakeDbName'
+SNOWFLAKE_DATABASE_KEY = 'YourSnowflakeDbName'
 
 # set env NEO4J_HOST to override localhost
 NEO4J_ENDPOINT = 'bolt://{}:7687'.format(os.getenv('NEO4J_HOST', 'localhost'))
@@ -55,6 +55,8 @@ es = Elasticsearch([
 
 # todo: connection string needs to change
 def connection_string():
+    # Refer this doc: https://docs.snowflake.com/en/user-guide/sqlalchemy.html#connection-parameters
+    # for supported connection parameters and configurations
     user = 'username'
     password = 'password'
     account = 'YourSnowflakeAccountHere'
@@ -64,7 +66,7 @@ def connection_string():
         user=user,
         password=password,
         account=account,
-        database=SNOWFLAKE_DATABASE,
+        database=SNOWFLAKE_DATABASE_KEY,
         warehouse=warehouse,
     )
 
@@ -89,7 +91,7 @@ def create_sample_snowflake_job():
 
     job_config = ConfigFactory.from_dict({
         'extractor.snowflake.extractor.sqlalchemy.{}'.format(SQLAlchemyExtractor.CONN_STRING): connection_string(),
-        'extractor.snowflake.{}'.format(SnowflakeMetadataExtractor.SNOWFLAKE_DATABASE_KEY): SNOWFLAKE_DATABASE,
+        'extractor.snowflake.{}'.format(SnowflakeMetadataExtractor.SNOWFLAKE_DATABASE_KEY): SNOWFLAKE_DATABASE_KEY,
         'extractor.snowflake.{}'.format(SnowflakeMetadataExtractor.WHERE_CLAUSE_SUFFIX_KEY): where_clause,
         'loader.filesystem_csv_neo4j.{}'.format(FsNeo4jCSVLoader.NODE_DIR_PATH): node_files_folder,
         'loader.filesystem_csv_neo4j.{}'.format(FsNeo4jCSVLoader.RELATION_DIR_PATH): relationship_files_folder,

--- a/example/scripts/sample_snowflake_data_loader.py
+++ b/example/scripts/sample_snowflake_data_loader.py
@@ -8,7 +8,6 @@ This is a example script which demo how to load data into neo4j without using Ai
 import logging
 import os
 from pyhocon import ConfigFactory
-from urllib.parse import unquote_plus
 import uuid
 import sys
 

--- a/example/scripts/sample_snowflake_data_loader.py
+++ b/example/scripts/sample_snowflake_data_loader.py
@@ -67,7 +67,6 @@ def connection_string():
         database=SNOWFLAKE_DATABASE,
         warehouse=warehouse,
     )
-    return "snowflake://%s:%s@%s" % (user, password, account, warehouse)
 
 
 def create_sample_snowflake_job():


### PR DESCRIPTION
…ouse as param

Signed-off-by: Alagappan Sethuraman <alagappan.als@gmail.com>


### Summary of Changes

Updated Snowflake sample data loader script and DAG to include warehouse in the connection string. Without the `warehouse` param, snowflake throws an error asking to select a warehouse via `USE [WAREHOUSE_NAME]` command before executing extraction query.

### CheckList

Make sure you have checked **all** steps below to ensure a timely review.

- [X] PR title addresses the issue accurately and concisely. Example: "Updates the version of Flask to v1.0.2"
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
- [X] PR includes a summary of changes.
- [X] PR adds unit tests, updates existing unit tests, **OR** documents why no test additions or modifications are needed.
- [X] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
- [X] PR passes `make test`
