### PR TITLE
chore: Change deprecated pytest function

### DIFF
--- a/tests/unit/extractor/test_deltalake_extractor.py
+++ b/tests/unit/extractor/test_deltalake_extractor.py
@@ -219,7 +219,7 @@ class TestDeltaLakeExtractor(unittest.TestCase):
                   Table(name="test_table3", database="test_schema1", description=None,
                         tableType="delta", isTemporary=False)]
         actual = self.dExtractor.scrape_all_tables(tables)
-        self.assertEquals(2, len(actual))
+        self.assertEqual(2, len(actual))
 
 
 if __name__ == '__main__':

--- a/tests/unit/models/test_badge.py
+++ b/tests/unit/models/test_badge.py
@@ -28,11 +28,11 @@ class TestBadge(unittest.TestCase):
 
     def test_get_badge_key(self) -> None:
         badge_key = self.badge_metada.get_badge_key(badge1.name)
-        self.assertEquals(badge_key, badge1.name)
+        self.assertEqual(badge_key, badge1.name)
 
     def test_create_nodes(self) -> None:
         nodes = self.badge_metada.create_nodes()
-        self.assertEquals(len(nodes), 2)
+        self.assertEqual(len(nodes), 2)
 
         node1 = {
             NODE_KEY: BadgeMetadata.BADGE_KEY_FORMAT.format(badge=badge1.name),
@@ -75,7 +75,7 @@ class TestBadge(unittest.TestCase):
 
     def test_create_relation(self) -> None:
         relations = self.badge_metada.create_relation()
-        self.assertEquals(len(relations), 2)
+        self.assertEqual(len(relations), 2)
 
         relation1 = {
             RELATION_START_LABEL: self.badge_metada.start_label,


### PR DESCRIPTION
Signed-off-by: Wonyeong Choi <ciwnyg0815@gmail.com>

<!---
Provide a general summary of your changes in the Title above
Include one of these prefixes:
  fix – Fixes an unexpected problem or unintended behavior
  feat – Adds a new feature
  docs – A documentation improvement task
  build – A task related to our build system
  ci – A task related to our ci system
  perf – A performance improvement
  refactor – A code refactor PR
  style – A task about styling
  test – A PR that improve test coverage
  chore – A regular maintenance chore or task
  other – Any other kind of PR
-->

### Summary of Changes

Since the `assertEquals` function has been deprecated, replaced it with the `assertEqual` function for all test files.

### Tests

Passed all existing unit tests

### Documentation

pytest doc about deprecated function: https://docs.python.org/3.3/library/unittest.html#deprecated-aliases

### CheckList

Make sure you have checked **all** steps below to ensure a timely review.

- [x] PR title addresses the issue accurately and concisely. Example: "Updates the version of Flask to v1.0.2"
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
- [x] PR includes a summary of changes.
- [x] PR adds unit tests, updates existing unit tests, **OR** documents why no test additions or modifications are needed.
- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
- [x] PR passes `make test`
