### PR TITLE
docs: Update DashboardMetadata docs

### DIFF
--- a/databuilder/models/dashboard/dashboard_metadata.py
+++ b/databuilder/models/dashboard/dashboard_metadata.py
@@ -20,7 +20,7 @@ class DashboardMetadata(Neo4jCsvSerializable):
     """
     Dashboard metadata including dashboard group name, dashboardgroup description, dashboard description,
     and tags.
-    
+
     Some other metadata e.g. Owners and last-reload/modified times are provided by other models
     e.g. DashboardOwner
 

--- a/databuilder/models/dashboard/dashboard_metadata.py
+++ b/databuilder/models/dashboard/dashboard_metadata.py
@@ -18,16 +18,15 @@ RelTuple = namedtuple('RelKeys', ['start_label', 'end_label', 'start_key', 'end_
 
 class DashboardMetadata(Neo4jCsvSerializable):
     """
-    Dashboard metadata that contains dashboard group name, dashboardgroup description, dashboard description,
-    along with tags, owner userid and lastreloadtime.
-    (Owner ID and last reload time will be supported by separate Extractor later on with more information)
+    Dashboard metadata including dashboard group name, dashboardgroup description, dashboard description,
+    and tags.
+    
+    Some other metadata e.g. Owners and last-reload/modified times are provided by other models
+    e.g. DashboardOwner
 
     It implements Neo4jCsvSerializable so that it can be serialized to produce
-    Dashboard, Tag, Description, Lastreloadtime and relation of those. Additionally, it will create
-    Dashboardgroup with relationships to Dashboard. If users exist in neo4j, it will create
-    the relation between dashboard and user (owner).
-
-    Lastreloadtime is the time when the Dashboard was last reloaded.
+    Dashboard, Tag, Description and relations between those. Additionally, it will create a
+    Dashboardgroup with relationships to the Dashboard.
     """
     CLUSTER_KEY_FORMAT = '{product}_dashboard://{cluster}'
     CLUSTER_DASHBOARD_GROUP_RELATION_TYPE = 'DASHBOARD_GROUP'


### PR DESCRIPTION
I noticed that the DashboardMetadata docs are outdated, and reference e.g. 'lastreloadtime' which no longer exists, and is instead implemented in a separate model.

This updates the docs to reflect the current state of Dashboard metadata.