### PR TITLE
chore: Fix 'typing' requirement in requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -31,7 +31,7 @@ pytest-mock>=1.1,<2.0
 # PEP 484
 # License: PSF
 # Upstream url: https://github.com/python/typing
-typing==3.6.4
+typing==3.6.4;python_version<"3.5"
 
 # Python client for ElasticSearch
 # License: Apache Software License


### PR DESCRIPTION
### Summary of Changes

In my PR #405 I hit a CI failure because of `typing`. Weirdly, this happened to me too today for an unrelated project internal to Brex... so I'm not sure what's changed in PythonLand, but clearly the advice on typing's [PyPi](https://pypi.org/project/typing/) page to condition the install using `;python_version<"3.5"` has become mandatory.

I know we're removing requirements.txt in #401 , but until that happens, this is a very quick change and simple which will unblock future contributions.

