### PR TITLE
chore: Remove support for Python<3.6

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -28,11 +28,6 @@ mock>=2.0.0,<3.0
 # Upstream url: https://pypi.python.org/pypi/pytest-mock
 pytest-mock>=1.1,<2.0
 
-# PEP 484
-# License: PSF
-# Upstream url: https://github.com/python/typing
-typing==3.6.4
-
 # Python client for ElasticSearch
 # License: Apache Software License
 # Upstream url: https://pypi.org/project/elasticsearch/

--- a/setup.py
+++ b/setup.py
@@ -74,9 +74,8 @@ setup(
     packages=find_packages(exclude=['tests*']),
     dependency_links=[],
     install_requires=requirements,
-    python_requires='>=3.6,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*',
+    python_requires='>=3.6',
     extras_require={
-        ':python_version=="2.7"': ['typing>=3.6'],  # allow typehinting PY2
         'all': all_deps,
         'kafka': kafka,  # To use with Kafka source extractor
         'cassandra': cassandra,


### PR DESCRIPTION
An alternative to #406 : this PR acknowledges that this repo no longer effectively supports any Python versions lower than 3.6, since full typing syntax is used in various modules, and no versions below 3.6 are tested in CI. Therefore, it:

1. Removes the `typing` requirement completely
2. Simplifies `python_requires`
3. Removes the `:python_version=="2.7"` entry from `extras_require`