### PR TITLE
fix: pandas 'nan' values when loading csv files

### DIFF
--- a/databuilder/publisher/neo4j_csv_publisher.py
+++ b/databuilder/publisher/neo4j_csv_publisher.py
@@ -219,7 +219,7 @@ class Neo4jCsvPublisher(Publisher):
         LOGGER.info('Creating indices. (Existing indices will be ignored)')
 
         with open(node_file, 'r', encoding='utf8') as node_csv:
-            for node_record in pandas.read_csv(node_csv).to_dict(orient='records'):
+            for node_record in pandas.read_csv(node_csv, na_filter=False).to_dict(orient='records'):
                 label = node_record[NODE_LABEL_KEY]
                 if label not in self.labels:
                     self._try_create_index(label)
@@ -246,7 +246,7 @@ class Neo4jCsvPublisher(Publisher):
         """
 
         with open(node_file, 'r', encoding='utf8') as node_csv:
-            for node_record in pandas.read_csv(node_csv).to_dict(orient="records"):
+            for node_record in pandas.read_csv(node_csv, na_filter=False).to_dict(orient="records"):
                 stmt = self.create_node_merge_statement(node_record=node_record)
                 params = self._create_props_param(node_record)
                 tx = self._execute_statement(stmt, tx, params)
@@ -301,7 +301,7 @@ class Neo4jCsvPublisher(Publisher):
 
             count = 0
             with open(relation_file, 'r', encoding='utf8') as relation_csv:
-                for rel_record in pandas.read_csv(relation_csv).to_dict(orient="records"):
+                for rel_record in pandas.read_csv(relation_csv, na_filter=False).to_dict(orient="records"):
                     stmt, params = self._relation_preprocessor.preprocess_cypher(
                         start_label=rel_record[RELATION_START_LABEL],
                         end_label=rel_record[RELATION_END_LABEL],
@@ -317,7 +317,7 @@ class Neo4jCsvPublisher(Publisher):
             LOGGER.info('Executed pre-processing Cypher statement {} times'.format(count))
 
         with open(relation_file, 'r', encoding='utf8') as relation_csv:
-            for rel_record in pandas.read_csv(relation_csv).to_dict(orient="records"):
+            for rel_record in pandas.read_csv(relation_csv, na_filter=False).to_dict(orient="records"):
                 stmt = self.create_relationship_merge_statement(rel_record=rel_record)
                 params = self._create_props_param(rel_record)
                 tx = self._execute_statement(stmt, tx, params,


### PR DESCRIPTION
### Summary of Changes

Pandas detect missing values as default when reading a csv file. Due this configuration, Pandas was changing empty table and columns' descriptions to 'nan'. The solution is add one parameter when reading these csv files on **pandas.read_csv( )** method
 also passing **na_filter=False** can improve the performance of reading a large file.

### Tests
N/A
### Documentation

The documentation comes from oficial [pandas](https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.read_csv.html) lib

### CheckList

Make sure you have checked **all** steps below to ensure a timely review.

- [X] PR title addresses the issue accurately and concisely. Example: "Updates the version of Flask to v1.0.2"
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
- [X] PR includes a summary of changes.
- [X] PR adds unit tests, updates existing unit tests, **OR** documents why no test additions or modifications are needed.
- [X] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
- [X] PR passes `make test`
