### PR TITLE
fix: Cast the read counts in the table usage models to be ints

### DIFF
--- a/databuilder/models/column_usage_model.py
+++ b/databuilder/models/column_usage_model.py
@@ -43,7 +43,7 @@ class ColumnUsageModel(GraphSerializable):
         self.table_name = table_name
         self.column_name = column_name
         self.user_email = user_email
-        self.read_count = read_count
+        self.read_count = int(read_count)
 
         self._node_iter = iter(self.create_nodes())
         self._relation_iter = iter(self.create_relation())

--- a/databuilder/models/table_column_usage.py
+++ b/databuilder/models/table_column_usage.py
@@ -32,7 +32,7 @@ class ColumnReader(object):
         self.table = table
         self.column = column
         self.user_email = user_email
-        self.read_count = read_count
+        self.read_count = int(read_count)
 
     def __repr__(self) -> str:
         return """\


### PR DESCRIPTION
Signed-off-by: Andrew <andrjc4@vt.edu>

<!---
Provide a general summary of your changes in the Title above
Include one of these prefixes:
  fix – Fixes an unexpected problem or unintended behavior
  feat – Adds a new feature
  docs – A documentation improvement task
  build – A task related to our build system
  ci – A task related to our ci system
  perf – A performance improvement
  refactor – A code refactor PR
  style – A task about styling
  test – A PR that improve test coverage
  chore – A regular maintenance chore or task
  other – Any other kind of PR
-->

### Summary of Changes

When the read counts are read from a csv they are read as a string not an integer. This ensures all read counts are ints. 

### Tests

_What tests did you add or modify and why? If no tests were added or modified, explain why. Remove this line_

### Documentation

_What documentation did you add or modify and why? Add any relevant links then remove this line_

### CheckList

Make sure you have checked **all** steps below to ensure a timely review.

- [ ] PR title addresses the issue accurately and concisely. Example: "Updates the version of Flask to v1.0.2"
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
- [ ] PR includes a summary of changes.
- [ ] PR adds unit tests, updates existing unit tests, **OR** documents why no test additions or modifications are needed.
- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
- [x] PR passes `make test`
