### PR TITLE
fix: Table stat values should always be represented with a string 

### DIFF
--- a/databuilder/models/table_stats.py
+++ b/databuilder/models/table_stats.py
@@ -1,6 +1,5 @@
 # Copyright Contributors to the Amundsen project.
 # SPDX-License-Identifier: Apache-2.0
-import ast
 from typing import List, Optional
 
 from databuilder.models.graph_serializable import GraphSerializable
@@ -42,11 +41,7 @@ class TableColumnStats(GraphSerializable):
         self.end_epoch = end_epoch
         self.cluster = cluster
         self.stat_name = stat_name
-        try:
-            stat_val = ast.literal_eval(stat_val)
-        except ValueError:
-            stat_val = stat_val
-        self.stat_val = stat_val
+        self.stat_val = str(stat_val)
         self._node_iter = iter(self.create_nodes())
         self._relation_iter = iter(self.create_relation())
 

--- a/tests/unit/models/test_table_stats.py
+++ b/tests/unit/models/test_table_stats.py
@@ -24,7 +24,7 @@ class TestTableStats(unittest.TestCase):
         self.expected_node_result = {
             NODE_KEY: 'hive://gold.base/test/col/avg/',
             NODE_LABEL: 'Stat',
-            'stat_val:UNQUOTED': 1,
+            'stat_val': '1',
             'stat_name': 'avg',
             'start_epoch': '1',
             'end_epoch': '2',


### PR DESCRIPTION
Signed-off-by: Andrew <andrjc4@vt.edu>

<!---
Provide a general summary of your changes in the Title above
Include one of these prefixes:
  fix – Fixes an unexpected problem or unintended behavior
  feat – Adds a new feature
  docs – A documentation improvement task
  build – A task related to our build system
  ci – A task related to our ci system
  perf – A performance improvement
  refactor – A code refactor PR
  style – A task about styling
  test – A PR that improve test coverage
  chore – A regular maintenance chore or task
  other – Any other kind of PR
-->

### Summary of Changes

This change makes it so all stat values are casted with a string. In the past there was some inconsistencies on if this should be a integer value or a string value. This change here makes it so its consistently treated as a string. 

### Tests

Modified the table stats test so it expects a string. 

### Documentation

_What documentation did you add or modify and why? Add any relevant links then remove this line_

### CheckList

Make sure you have checked **all** steps below to ensure a timely review.

- [ ] PR title addresses the issue accurately and concisely. Example: "Updates the version of Flask to v1.0.2"
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
- [ ] PR includes a summary of changes.
- [ ] PR adds unit tests, updates existing unit tests, **OR** documents why no test additions or modifications are needed.
- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
- [ ] PR passes `make test`
