### PR TITLE
feat: Feast extractor

### DIFF
--- a/databuilder/extractor/feast_extractor.py
+++ b/databuilder/extractor/feast_extractor.py
@@ -86,9 +86,10 @@ class FeastExtractor(Extractor):
             )
             description = f"* Created at **{created_at}**\n"
 
-            description += '* Labels\n'
-            for key, value in feature_table.labels.items():
-                description += f"    * {key}: **{value}**\n"
+            if feature_table.labels:
+                description += '* Labels:\n'
+                for key, value in feature_table.labels.items():
+                    description += f"    * {key}: **{value}**\n"
 
             yield TableMetadata(
                 "feast",

--- a/databuilder/extractor/feast_extractor.py
+++ b/databuilder/extractor/feast_extractor.py
@@ -85,17 +85,10 @@ class FeastExtractor(Extractor):
                 feature_table.created_timestamp.seconds
             )
             description = f"* Created at **{created_at}**\n"
-            for key, value in feature_table.labels.items():
-                description += f"* {key}: **{value}**\n"
 
-            if feature_table.batch_source:
-                batch_source = yaml.dump(feature_table.to_dict()["spec"]["batchSource"])
-                description += f"\nBatch source:\n```\n{batch_source}```"
-            if feature_table.stream_source:
-                stream_source = yaml.dump(
-                    feature_table.to_dict()["spec"]["streamSource"]
-                )
-                description += f"\nStream source:\n```\n{stream_source}```"
+            description += '* Labels\n'
+            for key, value in feature_table.labels.items():
+                description += f"    * {key}: **{value}**\n"
 
             yield TableMetadata(
                 "feast",
@@ -105,3 +98,22 @@ class FeastExtractor(Extractor):
                 description,
                 description_source="feature_table_details",
             )
+
+            yield TableMetadata(
+                "feast",
+                self._feast_service,
+                project,
+                feature_table.name,
+                f'```\n{yaml.dump(feature_table.to_dict()["spec"]["batchSource"])}```',
+                description_source="batch_source",
+            )
+
+            if feature_table.stream_source:
+                yield TableMetadata(
+                    "feast",
+                    self._feast_service,
+                    project,
+                    feature_table.name,
+                    f'```\n{yaml.dump(feature_table.to_dict()["spec"]["streamSource"])}```',
+                    description_source="stream_source",
+                )

--- a/databuilder/extractor/feast_extractor.py
+++ b/databuilder/extractor/feast_extractor.py
@@ -1,3 +1,6 @@
+# Copyright Contributors to the Amundsen project.
+# SPDX-License-Identifier: Apache-2.0
+
 from typing import Iterator, Union
 from datetime import datetime
 

--- a/databuilder/extractor/feast_extractor.py
+++ b/databuilder/extractor/feast_extractor.py
@@ -1,0 +1,107 @@
+from typing import Iterator, Union
+from datetime import datetime
+
+import yaml
+from feast import Client
+from feast.feature_table import FeatureTable
+from pyhocon import ConfigFactory, ConfigTree
+
+from databuilder.extractor.base_extractor import Extractor
+from databuilder.models.table_metadata import TableMetadata, ColumnMetadata
+
+
+class FeastExtractor(Extractor):
+    """
+    Extracts tables and columns metadata from Feast Core service
+    """
+
+    FEAST_SERVICE_CONFIG_KEY = "instance_name"
+    FEAST_ENDPOINT_CONFIG_KEY = "endpoint"
+    DESCRIBE_FEATURE_TABLES = "describe_feature_tables"
+    DEFAULT_CONFIG = ConfigFactory.from_dict(
+        {FEAST_SERVICE_CONFIG_KEY: "main", DESCRIBE_FEATURE_TABLES: True}
+    )
+
+    def init(self, conf: ConfigTree) -> None:
+        conf = conf.with_fallback(FeastExtractor.DEFAULT_CONFIG)
+        self._feast_service = conf.get_string(FeastExtractor.FEAST_SERVICE_CONFIG_KEY)
+        self._describe_feature_tables = conf.get_bool(
+            FeastExtractor.DESCRIBE_FEATURE_TABLES
+        )
+        self._client = Client(
+            core_url=conf.get_string(FeastExtractor.FEAST_ENDPOINT_CONFIG_KEY)
+        )
+        self._extract_iter: Union[None, Iterator] = None
+
+    def get_scope(self) -> str:
+        return "extractor.feast"
+
+    def extract(self) -> Union[TableMetadata, None]:
+        if not self._extract_iter:
+            self._extract_iter = self._get_extract_iter()
+        try:
+            return next(self._extract_iter)
+        except StopIteration:
+            return None
+
+    def _get_extract_iter(self) -> Iterator[TableMetadata]:
+        for project in self._client.list_projects():
+            for feature_table in self._client.list_feature_tables(project=project):
+                yield from self._extract_feature_table(project, feature_table)
+
+    def _extract_feature_table(
+        self, project: str, feature_table: FeatureTable
+    ) -> Iterator[TableMetadata]:
+        columns = []
+        for index, entity_name in enumerate(feature_table.entities):
+            entity = self._client.get_entity(entity_name, project=project)
+            columns.append(
+                ColumnMetadata(
+                    entity.name, entity.description, entity.value_type, index
+                )
+            )
+
+        for index, feature in enumerate(feature_table.features):
+            columns.append(
+                ColumnMetadata(
+                    feature.name,
+                    None,
+                    feature.dtype.name,
+                    len(feature_table.entities) + index,
+                )
+            )
+
+        yield TableMetadata(
+            "feast",
+            self._feast_service,
+            project,
+            feature_table.name,
+            None,
+            columns,
+        )
+
+        if self._describe_feature_tables:
+            created_at = datetime.utcfromtimestamp(
+                feature_table.created_timestamp.seconds
+            )
+            description = f"* Created at **{created_at}**\n"
+            for key, value in feature_table.labels.items():
+                description += f"* {key}: **{value}**\n"
+
+            if feature_table.batch_source:
+                batch_source = yaml.dump(feature_table.to_dict()["spec"]["batchSource"])
+                description += f"\nBatch source:\n```\n{batch_source}```"
+            if feature_table.stream_source:
+                stream_source = yaml.dump(
+                    feature_table.to_dict()["spec"]["streamSource"]
+                )
+                description += f"\nStream source:\n```\n{stream_source}```"
+
+            yield TableMetadata(
+                "feast",
+                self._feast_service,
+                project,
+                feature_table.name,
+                description,
+                description_source="feature_table_details",
+            )

--- a/databuilder/extractor/feast_extractor.py
+++ b/databuilder/extractor/feast_extractor.py
@@ -12,7 +12,13 @@ from databuilder.models.table_metadata import TableMetadata, ColumnMetadata
 
 class FeastExtractor(Extractor):
     """
-    Extracts tables and columns metadata from Feast Core service
+    Extracts feature tables from Feast Core service. Since Feast is
+    a metadata store (and not the database itself), it maps the
+    following atributes:
+
+     * a database is name of feast project
+     * table name is a name of the feature table
+     * columns are features stored in the feature table
     """
 
     FEAST_SERVICE_CONFIG_KEY = "instance_name"
@@ -37,6 +43,16 @@ class FeastExtractor(Extractor):
         return "extractor.feast"
 
     def extract(self) -> Union[TableMetadata, None]:
+        """
+        For every feature table from Feast, a multiple objets are extracted:
+
+        1. TableMetadata with feature table description
+        2. Programmatic Description of the feature table, containing
+           metadata - date of creation and labels
+        3. Programmatic Description with Batch Source specification
+        4. (if applicable) Programmatic Description with Stream Source
+           specification
+        """
         if not self._extract_iter:
             self._extract_iter = self._get_extract_iter()
         try:
@@ -87,7 +103,7 @@ class FeastExtractor(Extractor):
             description = f"* Created at **{created_at}**\n"
 
             if feature_table.labels:
-                description += '* Labels:\n'
+                description += "* Labels:\n"
                 for key, value in feature_table.labels.items():
                     description += f"    * {key}: **{value}**\n"
 

--- a/example/scripts/sample_feast_loader.py
+++ b/example/scripts/sample_feast_loader.py
@@ -1,3 +1,6 @@
+# Copyright Contributors to the Amundsen project.
+# SPDX-License-Identifier: Apache-2.0
+
 """
 This is a example script for extracting Feast feature tables
 """

--- a/example/scripts/sample_feast_loader.py
+++ b/example/scripts/sample_feast_loader.py
@@ -1,0 +1,55 @@
+"""
+This is a example script for extracting Feast feature tables
+"""
+
+from databuilder.extractor.feast_extractor import FeastExtractor
+from databuilder.job.job import DefaultJob
+from databuilder.loader.file_system_neo4j_csv_loader import FsNeo4jCSVLoader
+from databuilder.publisher import neo4j_csv_publisher
+from databuilder.task.task import DefaultTask
+from pyhocon import ConfigFactory
+
+# NEO4J cluster endpoints
+NEO4J_ENDPOINT = 'bolt://localhost:7687/'
+
+neo4j_endpoint = NEO4J_ENDPOINT
+neo4j_user = 'neo4j'
+neo4j_password = 'test'
+
+FEAST_ENDPOINT = 'feast-core.featurestore.svc.cluster.local:6565'
+
+feast_endpoint = FEAST_ENDPOINT
+
+
+def create_feast_job_config():
+    tmp_folder = '/var/tmp/amundsen/table_metadata'
+    node_files_folder = '{tmp_folder}/nodes/'.format(tmp_folder=tmp_folder)
+    relationship_files_folder = '{tmp_folder}/relationships/'.format(tmp_folder=tmp_folder)
+
+    job_config = ConfigFactory.from_dict({
+        'extractor.feast.{}'.format(FeastExtractor.FEAST_ENDPOINT_CONFIG_KEY): feast_endpoint,
+        'loader.filesystem_csv_neo4j.{}'.format(FsNeo4jCSVLoader.NODE_DIR_PATH):
+            node_files_folder,
+        'loader.filesystem_csv_neo4j.{}'.format(FsNeo4jCSVLoader.RELATION_DIR_PATH):
+            relationship_files_folder,
+        'publisher.neo4j.{}'.format(neo4j_csv_publisher.NODE_FILES_DIR):
+            node_files_folder,
+        'publisher.neo4j.{}'.format(neo4j_csv_publisher.RELATION_FILES_DIR):
+            relationship_files_folder,
+        'publisher.neo4j.{}'.format(neo4j_csv_publisher.NEO4J_END_POINT_KEY):
+            neo4j_endpoint,
+        'publisher.neo4j.{}'.format(neo4j_csv_publisher.NEO4J_USER):
+            neo4j_user,
+        'publisher.neo4j.{}'.format(neo4j_csv_publisher.NEO4J_PASSWORD):
+            neo4j_password,
+        'publisher.neo4j.job_publish_tag':
+            'some_unique_tag'  # TO-DO unique tag must be added
+    })
+    return job_config
+
+
+if __name__ == "__main__":
+    job = DefaultJob(conf=create_feast_job_config(),
+                     task=DefaultTask(extractor=FeastExtractor(), loader=FsNeo4jCSVLoader()),
+                     publisher=neo4j_csv_publisher.Neo4jCsvPublisher())
+    job.launch()

--- a/setup.py
+++ b/setup.py
@@ -61,8 +61,12 @@ spark = [
     'pyspark == 3.0.1'
 ]
 
+feast = [
+    'feast==0.8.0'
+]
+
 all_deps = requirements + kafka + cassandra + glue + snowflake + athena + \
-    bigquery + jsonpath + db2 + dremio + druid + spark
+    bigquery + jsonpath + db2 + dremio + druid + spark + feast
 
 setup(
     name='amundsen-databuilder',
@@ -87,7 +91,8 @@ setup(
         'db2': db2,
         'dremio': dremio,
         'druid': druid,
-        'delta-lake': spark
+        'delta-lake': spark,
+        'feast': feast,
     },
     classifiers=[
         'Programming Language :: Python :: 3.6',

--- a/tests/unit/extractor/test_feast_extractor.py
+++ b/tests/unit/extractor/test_feast_extractor.py
@@ -1,3 +1,6 @@
+# Copyright Contributors to the Amundsen project.
+# SPDX-License-Identifier: Apache-2.0
+
 import json
 import re
 import unittest

--- a/tests/unit/extractor/test_feast_extractor.py
+++ b/tests/unit/extractor/test_feast_extractor.py
@@ -1,0 +1,228 @@
+import json
+import re
+import unittest
+
+from mock import call, MagicMock
+from pyhocon import ConfigFactory
+from feast.feature_table import FeatureTable
+from feast.entity import Entity
+
+from databuilder import Scoped
+from databuilder.extractor.feast_extractor import FeastExtractor
+from databuilder.models.table_metadata import (
+    TableMetadata,
+    ColumnMetadata,
+    DescriptionMetadata,
+)
+
+
+class TestFeastExtractor(unittest.TestCase):
+    def test_no_feature_tables_registered(self) -> None:
+        self._init_extractor()
+        self.extractor._client.list_projects.return_value = ["default"]
+
+        self.assertIsNone(self.extractor.extract())
+
+    def test_every_project_is_scanned(self) -> None:
+        self._init_extractor()
+        self.extractor._client.list_projects.return_value = ["default", "dev", "prod"]
+        list_feature_tables_mock = self.extractor._client.list_feature_tables
+        list_feature_tables_mock.return_value = []
+
+        self.assertIsNone(self.extractor.extract())
+        list_feature_tables_mock.assert_has_calls(
+            [
+                call(project="default"),
+                call(project="dev"),
+                call(project="prod"),
+            ]
+        )
+
+    def test_feature_table_extraction(self) -> None:
+        self._init_extractor(programmatic_description_enabled=False)
+        self.extractor._client.list_projects.return_value = ["default"]
+        self._mock_feature_table()
+
+        table = self.extractor.extract()
+        self.extractor._client.get_entity.assert_called_with(
+            "driver_id", project="default"
+        )
+        expected = TableMetadata(
+            database="feast",
+            cluster="unittest-feast-instance",
+            schema="default",
+            name="driver_trips",
+            description=None,
+            columns=[
+                ColumnMetadata(
+                    "driver_id", "Internal identifier of the driver", "INT64", 0
+                ),
+                ColumnMetadata("trips_today", None, "INT32", 1),
+            ],
+        )
+
+        self.assertEqual(expected.__repr__(), table.__repr__())
+        self.assertIsNone(self.extractor.extract())
+
+    def test_feature_table_extraction_with_description_batch(self) -> None:
+        self._init_extractor(programmatic_description_enabled=True)
+        self.extractor._client.list_projects.return_value = ["default"]
+        self._mock_feature_table(labels={"label1": "value1"})
+
+        self.extractor.extract()  # table definition
+        programmatic_description = self.extractor.extract()
+        assert isinstance(programmatic_description, TableMetadata)
+        text = """* Created at **2020-01-01 00:00:00**
+                 |* label1: **value1**
+                 |
+                 |Batch source:
+                 |```
+                 |fileOptions:
+                 |  fileFormat:
+                 |    parquetFormat: {}
+                 |  fileUrl: file:///some/location
+                 |type: BATCH_FILE
+                 |```"""
+
+        expected = DescriptionMetadata(
+            TestFeastExtractor._strip_margin(text), "feature_table_details"
+        )
+        self.assertEqual(
+            expected.__repr__(), programmatic_description.description.__repr__()
+        )
+        self.assertIsNone(self.extractor.extract())
+
+    def test_feature_table_extraction_with_description_stream(self) -> None:
+        self._init_extractor(programmatic_description_enabled=True)
+        self.extractor._client.list_projects.return_value = ["default"]
+        self._mock_feature_table(labels={"label1": "value1"}, add_stream_source=True)
+
+        self.extractor.extract()  # table definition
+        programmatic_description = self.extractor.extract()
+        assert isinstance(programmatic_description, TableMetadata)
+        text = """* Created at **2020-01-01 00:00:00**
+                 |* label1: **value1**
+                 |
+                 |Batch source:
+                 |```
+                 |fileOptions:
+                 |  fileFormat:
+                 |    parquetFormat: {}
+                 |  fileUrl: file:///some/location
+                 |type: BATCH_FILE
+                 |```
+                 |Stream source:
+                 |```
+                 |createdTimestampColumn: datetime
+                 |eventTimestampColumn: datetime
+                 |kafkaOptions:
+                 |  bootstrapServers: broker1
+                 |  messageFormat:
+                 |    avroFormat:
+                 |      schemaJson: '{"type": "record", "name": "DriverTrips", "fields": [{"name": "driver_id",
+                 |        "type": "long"}, {"name": "trips_today", "type": "int"}, {"name": "datetime",
+                 |        "type": {"type": "long", "logicalType": "timestamp-micros"}}]}'
+                 |  topic: driver_trips
+                 |type: STREAM_KAFKA
+                 |```"""
+        expected = DescriptionMetadata(
+            TestFeastExtractor._strip_margin(text), "feature_table_details"
+        )
+        self.assertEqual(
+            expected.__repr__(), programmatic_description.description.__repr__()
+        )
+        self.assertIsNone(self.extractor.extract())
+
+    def _init_extractor(self, programmatic_description_enabled: bool = True) -> None:
+        conf = {
+            "extractor.feast.{}".format(
+                FeastExtractor.FEAST_ENDPOINT_CONFIG_KEY
+            ): "feast-core.example.com:6565",
+            "extractor.feast.{}".format(
+                FeastExtractor.FEAST_SERVICE_CONFIG_KEY
+            ): "unittest-feast-instance",
+            "extractor.feast.{}".format(
+                FeastExtractor.DESCRIBE_FEATURE_TABLES
+            ): programmatic_description_enabled,
+        }
+        self.extractor = FeastExtractor()
+        self.extractor.init(
+            Scoped.get_scoped_conf(
+                conf=ConfigFactory.from_dict(conf), scope=self.extractor.get_scope()
+            )
+        )
+        self.extractor._client = MagicMock(return_value=None)
+
+    @staticmethod
+    def _strip_margin(text: str) -> str:
+        return re.sub("\n[ \t]*\\|", "\n", text)
+
+    def _mock_feature_table(
+        self, labels: dict = {}, add_stream_source: bool = False
+    ) -> None:
+        table_spec = {
+            "name": "driver_trips",
+            "entities": ["driver_id"],
+            "features": [{"name": "trips_today", "valueType": "INT32"}],
+            "labels": labels,
+            "batchSource": {
+                "type": "BATCH_FILE",
+                "fileOptions": {
+                    "fileFormat": {"parquetFormat": {}},
+                    "fileUrl": "file:///some/location",
+                },
+            },
+        }
+
+        if add_stream_source:
+            avro_schema_json = json.dumps(
+                {
+                    "type": "record",
+                    "name": "DriverTrips",
+                    "fields": [
+                        {"name": "driver_id", "type": "long"},
+                        {"name": "trips_today", "type": "int"},
+                        {
+                            "name": "datetime",
+                            "type": {"type": "long", "logicalType": "timestamp-micros"},
+                        },
+                    ],
+                }
+            )
+
+            table_spec["streamSource"] = {
+                "type": "STREAM_KAFKA",
+                "eventTimestampColumn": "datetime",
+                "createdTimestampColumn": "datetime",
+                "kafkaOptions": {
+                    "bootstrapServers": "broker1",
+                    "topic": "driver_trips",
+                    "messageFormat": {
+                        "avroFormat": {
+                            "schemaJson": avro_schema_json,
+                        }
+                    },
+                },
+            }
+
+        self.extractor._client.list_feature_tables.return_value = [
+            FeatureTable.from_dict(
+                {
+                    "spec": table_spec,
+                    "meta": {"createdTimestamp": "2020-01-01T00:00:00Z"},
+                }
+            )
+        ]
+        self.extractor._client.get_entity.return_value = Entity.from_dict(
+            {
+                "spec": {
+                    "name": "driver_id",
+                    "valueType": "INT64",
+                    "description": "Internal identifier of the driver",
+                }
+            }
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### Summary of Changes

This PR provider Extractor for [Feast](https://feast.dev/) feature store, announced in https://github.com/amundsen-io/amundsen/issues/815. Apart from FeatureTables definitions, the extractor also pushes the metadata collected by Feast as programmatic descriptions, so they look like this on the Frontend:

![Screenshot_2020-11-24 demo driver_trips - Amundsen Table Details](https://user-images.githubusercontent.com/4659069/100068000-3d369b80-2e37-11eb-9aa2-00d5ea12e006.png)

The new "extra" dependency is added: `feast` (python sdk for Feast), it is distributed [on ASF licence](https://github.com/feast-dev/feast/blob/master/LICENSE). 

Fixes amundsen-io/amundsen#815



### Tests

Unit tests for the extractor class.

### Documentation

A sample job with loader definition, doc strings for FeastExtractor class and `extract` method

### CheckList

Make sure you have checked **all** steps below to ensure a timely review.

- [x] PR title addresses the issue accurately and concisely. Example: "Updates the version of Flask to v1.0.2"
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
- [x] PR includes a summary of changes.
- [x] PR adds unit tests, updates existing unit tests, **OR** documents why no test additions or modifications are needed.
- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
- [x] PR passes `make test`
