### PR TITLE
fix: Use dataset_id & table_id as the key of set 'grouped_tables' in bigquery_metadata_extractor

### DIFF
--- a/databuilder/extractor/base_bigquery_extractor.py
+++ b/databuilder/extractor/base_bigquery_extractor.py
@@ -32,6 +32,7 @@ class BaseBigQueryExtractor(Extractor):
     DEFAULT_PAGE_SIZE = 300
     NUM_RETRIES = 3
     DATE_LENGTH = 8
+    SHARDED_TABLE_KEY_FORMAT = '{dataset_id}/{table_id}'
 
     def init(self, conf: ConfigTree) -> None:
         # should use key_path, or cred_key if the former doesn't exist

--- a/databuilder/extractor/bigquery_metadata_extractor.py
+++ b/databuilder/extractor/bigquery_metadata_extractor.py
@@ -46,13 +46,16 @@ class BigQueryMetadataExtractor(BaseBigQueryExtractor):
                     # If the last eight characters are digits, we assume the table is of a table date range type
                     # and then we only need one schema definition
                     table_prefix = table_id[:-BigQueryMetadataExtractor.DATE_LENGTH]
-                    if table_prefix in self.grouped_tables:
+                    table_id = table_prefix
+                    sharded_table_key = BigQueryMetadataExtractor.SHARDED_TABLE_KEY_FORMAT.format(
+                        dataset_id=tableRef['datasetId'],
+                        table_id=table_id)
+                    if sharded_table_key in self.grouped_tables:
                         # If one table in the date range is processed, then ignore other ones
                         # (it adds too much metadata)
                         continue
 
-                    table_id = table_prefix
-                    self.grouped_tables.add(table_prefix)
+                    self.grouped_tables.add(sharded_table_key)
 
                 table = self.bigquery_service.tables().get(
                     projectId=tableRef['projectId'],


### PR DESCRIPTION
Fix the issue that some table keys of sharded tables are missing from BQ metadata extractor. Currently, there is a set 'grouped_tables' storing table_prefix of sharded tables to avoid duplicate metadata records, but it is possible the table prefixes would be same in different datasets. 

### Summary of Changes

Related issue: [833](https://github.com/amundsen-io/amundsen/issues/833)

Sharded tables will use the concatenation of dataset_id & table_id as the key of set 'grouped_tables' in bigquery_metadata_extractor

### Tests

No more tests were added and current test can still work

### Documentation

More details are in [issue 833](https://github.com/amundsen-io/amundsen/issues/833)

### CheckList

Make sure you have checked **all** steps below to ensure a timely review.

- [ ] PR title addresses the issue accurately and concisely. Example: "Updates the version of Flask to v1.0.2"
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
- [ ] PR includes a summary of changes.
- [ ] PR adds unit tests, updates existing unit tests, **OR** documents why no test additions or modifications are needed.
- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
- [ ] PR passes `make test`
