### PR TITLE
chore: using f-string instead of string.format

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,18 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+indent_size = 2
+indent_style = space
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.py]
+indent_size = 4
+
+[{*.mk,*.make,Makefile}]
+indent_style = tab
+
+[*.md]
+trim_trailing_whitespace = false

--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,13 @@ lint:
 mypy:
 	mypy .
 
-.PHONY: test
-test: test_unit lint mypy
+.PHONY: isort
+isort:
+	isort .
 
+.PHONY: isort_check
+isort_check:
+	isort ./ --check --diff
+
+.PHONY: test
+test: test_unit lint mypy isort_check

--- a/databuilder/__init__.py
+++ b/databuilder/__init__.py
@@ -3,7 +3,7 @@
 
 import abc
 
-from pyhocon import ConfigTree, ConfigFactory
+from pyhocon import ConfigFactory, ConfigTree
 
 
 class Scoped(object, metaclass=abc.ABCMeta):

--- a/databuilder/callback/call_back.py
+++ b/databuilder/callback/call_back.py
@@ -3,7 +3,6 @@
 
 import abc
 import logging
-
 from typing import List, Optional
 
 LOGGER = logging.getLogger(__name__)

--- a/databuilder/extractor/athena_metadata_extractor.py
+++ b/databuilder/extractor/athena_metadata_extractor.py
@@ -3,15 +3,17 @@
 
 import logging
 from collections import namedtuple
+from itertools import groupby
+from typing import (
+    Any, Dict, Iterator, Union,
+)
 
 from pyhocon import ConfigFactory, ConfigTree
-from typing import Iterator, Union, Dict, Any
 
 from databuilder import Scoped
 from databuilder.extractor.base_extractor import Extractor
 from databuilder.extractor.sql_alchemy_extractor import SQLAlchemyExtractor
-from databuilder.models.table_metadata import TableMetadata, ColumnMetadata
-from itertools import groupby
+from databuilder.models.table_metadata import ColumnMetadata, TableMetadata
 
 TableKey = namedtuple('TableKey', ['schema', 'table_name'])
 

--- a/databuilder/extractor/athena_metadata_extractor.py
+++ b/databuilder/extractor/athena_metadata_extractor.py
@@ -45,14 +45,14 @@ class AthenaMetadataExtractor(Extractor):
 
     def init(self, conf: ConfigTree) -> None:
         conf = conf.with_fallback(AthenaMetadataExtractor.DEFAULT_CONFIG)
-        self._cluster = '{}'.format(conf.get_string(AthenaMetadataExtractor.CATALOG_KEY))
+        self._cluster = conf.get_string(AthenaMetadataExtractor.CATALOG_KEY)
 
         self.sql_stmt = AthenaMetadataExtractor.SQL_STATEMENT.format(
             where_clause_suffix=conf.get_string(AthenaMetadataExtractor.WHERE_CLAUSE_SUFFIX_KEY),
             catalog_source=self._cluster
         )
 
-        LOGGER.info('SQL for Athena metadata: {}'.format(self.sql_stmt))
+        LOGGER.info('SQL for Athena metadata: %s', self.sql_stmt)
 
         self._alchemy_extractor = SQLAlchemyExtractor()
         sql_alch_conf = Scoped.get_scoped_conf(conf, self._alchemy_extractor.get_scope())\

--- a/databuilder/extractor/base_bigquery_extractor.py
+++ b/databuilder/extractor/base_bigquery_extractor.py
@@ -4,16 +4,17 @@
 import json
 import logging
 from collections import namedtuple
+from typing import (
+    Any, Dict, Iterator, List,
+)
 
 import google.oauth2.service_account
 import google_auth_httplib2
-from googleapiclient.discovery import build
 import httplib2
+from googleapiclient.discovery import build
 from pyhocon import ConfigTree
-from typing import Any, Dict, Iterator, List
 
 from databuilder.extractor.base_extractor import Extractor
-
 
 DatasetRef = namedtuple('DatasetRef', ['datasetId', 'projectId'])
 TableKey = namedtuple('TableKey', ['schema', 'table_name'])

--- a/databuilder/extractor/base_extractor.py
+++ b/databuilder/extractor/base_extractor.py
@@ -2,9 +2,9 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import abc
+from typing import Any
 
 from pyhocon import ConfigTree
-from typing import Any
 
 from databuilder import Scoped
 

--- a/databuilder/extractor/base_postgres_metadata_extractor.py
+++ b/databuilder/extractor/base_postgres_metadata_extractor.py
@@ -47,7 +47,7 @@ class BasePostgresMetadataExtractor(Extractor):
 
     def init(self, conf: ConfigTree) -> None:
         conf = conf.with_fallback(BasePostgresMetadataExtractor.DEFAULT_CONFIG)
-        self._cluster = '{}'.format(conf.get_string(BasePostgresMetadataExtractor.CLUSTER_KEY))
+        self._cluster = conf.get_string(BasePostgresMetadataExtractor.CLUSTER_KEY)
 
         self._database = conf.get_string(BasePostgresMetadataExtractor.DATABASE_KEY, default='postgres')
 
@@ -62,7 +62,7 @@ class BasePostgresMetadataExtractor(Extractor):
 
         self.sql_stmt = sql_alch_conf.get_string(SQLAlchemyExtractor.EXTRACT_SQL)
 
-        LOGGER.info('SQL for postgres metadata: {}'.format(self.sql_stmt))
+        LOGGER.info('SQL for postgres metadata: %s', self.sql_stmt)
 
         self._alchemy_extractor.init(sql_alch_conf)
         self._extract_iter: Union[None, Iterator] = None

--- a/databuilder/extractor/base_postgres_metadata_extractor.py
+++ b/databuilder/extractor/base_postgres_metadata_extractor.py
@@ -4,16 +4,17 @@
 import abc
 import logging
 from collections import namedtuple
+from itertools import groupby
+from typing import (
+    Any, Dict, Iterator, Union,
+)
 
 from pyhocon import ConfigFactory, ConfigTree
-from typing import Iterator, Union, Dict, Any
 
 from databuilder import Scoped
 from databuilder.extractor.base_extractor import Extractor
 from databuilder.extractor.sql_alchemy_extractor import SQLAlchemyExtractor
-from databuilder.models.table_metadata import TableMetadata, ColumnMetadata
-from itertools import groupby
-
+from databuilder.models.table_metadata import ColumnMetadata, TableMetadata
 
 TableKey = namedtuple('TableKey', ['schema', 'table_name'])
 

--- a/databuilder/extractor/bigquery_metadata_extractor.py
+++ b/databuilder/extractor/bigquery_metadata_extractor.py
@@ -91,7 +91,7 @@ class BigQueryMetadataExtractor(BaseBigQueryExtractor):
                            cols: List[ColumnMetadata],
                            total_cols: int) -> int:
         if len(parent) > 0:
-            col_name = '{parent}.{field}'.format(parent=parent, field=column['name'])
+            col_name = f'{parent}.{column["name"]}'
         else:
             col_name = column['name']
 

--- a/databuilder/extractor/bigquery_metadata_extractor.py
+++ b/databuilder/extractor/bigquery_metadata_extractor.py
@@ -2,13 +2,14 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import logging
+from typing import (
+    Any, Dict, List, Set, cast,
+)
 
 from pyhocon import ConfigTree
-from typing import cast, Any, Dict, List, Set
 
 from databuilder.extractor.base_bigquery_extractor import BaseBigQueryExtractor, DatasetRef
-from databuilder.models.table_metadata import TableMetadata, ColumnMetadata
-
+from databuilder.models.table_metadata import ColumnMetadata, TableMetadata
 
 LOGGER = logging.getLogger(__name__)
 

--- a/databuilder/extractor/bigquery_usage_extractor.py
+++ b/databuilder/extractor/bigquery_usage_extractor.py
@@ -6,10 +6,13 @@ import re
 from collections import namedtuple
 from datetime import date, timedelta
 from time import sleep
-from typing import Any, Iterator, Dict, Optional, Tuple, List
+from typing import (
+    Any, Dict, Iterator, List, Optional, Tuple,
+)
+
+from pyhocon import ConfigTree
 
 from databuilder.extractor.base_bigquery_extractor import BaseBigQueryExtractor
-from pyhocon import ConfigTree
 
 TableColumnUsageTuple = namedtuple('TableColumnUsageTuple', ['database', 'cluster', 'schema',
                                                              'table', 'column', 'email'])

--- a/databuilder/extractor/bigquery_usage_extractor.py
+++ b/databuilder/extractor/bigquery_usage_extractor.py
@@ -1,16 +1,15 @@
 # Copyright Contributors to the Amundsen project.
 # SPDX-License-Identifier: Apache-2.0
 
-from collections import namedtuple
-from datetime import date, timedelta
 import logging
 import re
+from collections import namedtuple
+from datetime import date, timedelta
 from time import sleep
-
-from pyhocon import ConfigTree
 from typing import Any, Iterator, Dict, Optional, Tuple, List
 
 from databuilder.extractor.base_bigquery_extractor import BaseBigQueryExtractor
+from pyhocon import ConfigTree
 
 TableColumnUsageTuple = namedtuple('TableColumnUsageTuple', ['database', 'cluster', 'schema',
                                                              'table', 'column', 'email'])
@@ -47,7 +46,7 @@ class BigQueryTableUsageExtractor(BaseBigQueryExtractor):
         for entry in self._retrieve_records():
             count += 1
             if count % self.pagesize == 0:
-                LOGGER.info('Aggregated {} records'.format(count))
+                LOGGER.info(f'Aggregated %i records', count)
 
             if entry is None:
                 continue
@@ -93,9 +92,7 @@ class BigQueryTableUsageExtractor(BaseBigQueryExtractor):
                 return
 
         if len(refResources) != resourcesProcessed:
-            LOGGER.warn(
-                'The number of tables listed in job {job_id} is not consistent'
-                .format(job_id=jobId))
+            LOGGER.warning(f'The number of tables listed in job {jobId} is not consistent')
             return
 
         for refResource in refResources:
@@ -117,17 +114,15 @@ class BigQueryTableUsageExtractor(BaseBigQueryExtractor):
         :return: Provides a record or None if no more to extract
         """
         body = {
-            'resourceNames': [
-                'projects/{project_id}'.format(project_id=self.project_id)
-            ],
+            'resourceNames': [f'projects/{self.project_id}'],
             'pageSize': self.pagesize,
             'filter': 'resource.type="bigquery_resource" AND '
                       'protoPayload.methodName="jobservice.jobcompleted" AND '
-                      'timestamp >= "{timestamp}"'.format(timestamp=self.timestamp)
+                      f'timestamp >= "{self.timestamp}"'
         }
         for page in self._page_over_results(body):
             for entry in page['entries']:
-                yield(entry)
+                yield entry
 
     def extract(self) -> Optional[Tuple[Any, int]]:
         try:

--- a/databuilder/extractor/bigquery_watermark_extractor.py
+++ b/databuilder/extractor/bigquery_watermark_extractor.py
@@ -1,14 +1,15 @@
 # Copyright Contributors to the Amundsen project.
 # SPDX-License-Identifier: Apache-2.0
 
-from collections import namedtuple
-
-import logging
 import datetime
+import logging
 import textwrap
+from collections import namedtuple
+from typing import (
+    Any, Dict, Iterator, List, Tuple, Union,
+)
 
 from pyhocon import ConfigTree
-from typing import Any, Dict, Iterator, List, Tuple, Union
 
 from databuilder.extractor.base_bigquery_extractor import BaseBigQueryExtractor, DatasetRef
 from databuilder.models.watermark import Watermark

--- a/databuilder/extractor/bigquery_watermark_extractor.py
+++ b/databuilder/extractor/bigquery_watermark_extractor.py
@@ -70,7 +70,7 @@ class BigQueryWatermarkExtractor(BaseBigQueryExtractor):
                     'bigquery',
                     tableRef['datasetId'],
                     prefix,
-                    '__table__={partition_id}'.format(partition_id=td['low']),
+                    f'__table__={td["low"]}',
                     part_type="low_watermark",
                     cluster=tableRef['projectId']
                 )
@@ -80,7 +80,7 @@ class BigQueryWatermarkExtractor(BaseBigQueryExtractor):
                     'bigquery',
                     tableRef['datasetId'],
                     prefix,
-                    '__table__={partition_id}'.format(partition_id=td['high']),
+                    f'__table__={td["high"]}',
                     part_type="high_watermark",
                     cluster=tableRef['projectId']
                 )
@@ -129,7 +129,7 @@ class BigQueryWatermarkExtractor(BaseBigQueryExtractor):
             'bigquery',
             tableRef['datasetId'],
             tableRef['tableId'],
-            '{field}={partition_id}'.format(field=field, partition_id=low.partition_id),
+            f'{field}={low.partition_id}',
             part_type="low_watermark",
             cluster=tableRef['projectId']
         )
@@ -140,7 +140,7 @@ class BigQueryWatermarkExtractor(BaseBigQueryExtractor):
             'bigquery',
             tableRef['datasetId'],
             tableRef['tableId'],
-            '{field}={partition_id}'.format(field=field, partition_id=high.partition_id),
+            f'{field}={high.partition_id}',
             part_type="high_watermark",
             cluster=tableRef['projectId']
         )

--- a/databuilder/extractor/cassandra_extractor.py
+++ b/databuilder/extractor/cassandra_extractor.py
@@ -1,14 +1,16 @@
 # Copyright Contributors to the Amundsen project.
 # SPDX-License-Identifier: Apache-2.0
 
-from cassandra.cluster import Cluster
-import cassandra.metadata
+from typing import (
+    Dict, Iterator, Union,
+)
 
+import cassandra.metadata
+from cassandra.cluster import Cluster
 from pyhocon import ConfigFactory, ConfigTree
-from typing import Iterator, Union, Dict
 
 from databuilder.extractor.base_extractor import Extractor
-from databuilder.models.table_metadata import TableMetadata, ColumnMetadata
+from databuilder.models.table_metadata import ColumnMetadata, TableMetadata
 
 
 class CassandraExtractor(Extractor):

--- a/databuilder/extractor/cassandra_extractor.py
+++ b/databuilder/extractor/cassandra_extractor.py
@@ -38,7 +38,7 @@ class CassandraExtractor(Extractor):
 
     def init(self, conf: ConfigTree) -> None:
         conf = conf.with_fallback(CassandraExtractor.DEFAULT_CONFIG)
-        self._cluster = '{}'.format(conf.get_string(CassandraExtractor.CLUSTER_KEY))
+        self._cluster = conf.get_string(CassandraExtractor.CLUSTER_KEY)
         self._filter = conf.get(CassandraExtractor.FILTER_FUNCTION_KEY)
         ips = conf.get_list(CassandraExtractor.IPS_KEY)
         kwargs = conf.get(CassandraExtractor.KWARGS_KEY)

--- a/databuilder/extractor/csv_extractor.py
+++ b/databuilder/extractor/csv_extractor.py
@@ -4,13 +4,13 @@
 import csv
 import importlib
 from collections import defaultdict
-
-from pyhocon import ConfigTree
 from typing import Any
 
+from pyhocon import ConfigTree
+
 from databuilder.extractor.base_extractor import Extractor
-from databuilder.models.table_metadata import TableMetadata, ColumnMetadata
 from databuilder.models.badge import Badge, BadgeMetadata
+from databuilder.models.table_metadata import ColumnMetadata, TableMetadata
 
 
 class CsvExtractor(Extractor):

--- a/databuilder/extractor/dashboard/mode_analytics/batch/mode_dashboard_charts_batch_extractor.py
+++ b/databuilder/extractor/dashboard/mode_analytics/batch/mode_dashboard_charts_batch_extractor.py
@@ -2,19 +2,18 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import logging
-
-from pyhocon import ConfigTree, ConfigFactory
 from typing import Any
+
+from pyhocon import ConfigFactory, ConfigTree
 
 from databuilder import Scoped
 from databuilder.extractor.base_extractor import Extractor
+from databuilder.extractor.dashboard.mode_analytics.mode_dashboard_constants import ORGANIZATION
 from databuilder.extractor.dashboard.mode_analytics.mode_dashboard_utils import ModeDashboardUtils
+from databuilder.rest_api.base_rest_api_query import RestApiQuerySeed
 from databuilder.rest_api.mode_analytics.mode_paginated_rest_api_query import ModePaginatedRestApiQuery
 from databuilder.rest_api.rest_api_query import RestApiQuery
-from databuilder.rest_api.base_rest_api_query import RestApiQuerySeed
-from databuilder.extractor.dashboard.mode_analytics.mode_dashboard_constants import ORGANIZATION
-from databuilder.transformer.dict_to_model import DictToModel, MODEL_CLASS
-
+from databuilder.transformer.dict_to_model import MODEL_CLASS, DictToModel
 
 LOGGER = logging.getLogger(__name__)
 

--- a/databuilder/extractor/dashboard/mode_analytics/mode_dashboard_charts_extractor.py
+++ b/databuilder/extractor/dashboard/mode_analytics/mode_dashboard_charts_extractor.py
@@ -2,9 +2,9 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import logging
-
-from pyhocon import ConfigTree, ConfigFactory
 from typing import Any, List
+
+from pyhocon import ConfigFactory, ConfigTree
 
 from databuilder import Scoped
 from databuilder.extractor.base_extractor import Extractor
@@ -12,9 +12,10 @@ from databuilder.extractor.dashboard.mode_analytics.mode_dashboard_utils import 
 from databuilder.rest_api.mode_analytics.mode_paginated_rest_api_query import ModePaginatedRestApiQuery
 from databuilder.rest_api.rest_api_query import RestApiQuery
 from databuilder.transformer.base_transformer import ChainedTransformer, Transformer
-from databuilder.transformer.dict_to_model import DictToModel, MODEL_CLASS
-from databuilder.transformer.template_variable_substitution_transformer import \
-    TemplateVariableSubstitutionTransformer, FIELD_NAME, TEMPLATE
+from databuilder.transformer.dict_to_model import MODEL_CLASS, DictToModel
+from databuilder.transformer.template_variable_substitution_transformer import (
+    FIELD_NAME, TEMPLATE, TemplateVariableSubstitutionTransformer,
+)
 
 LOGGER = logging.getLogger(__name__)
 

--- a/databuilder/extractor/dashboard/mode_analytics/mode_dashboard_executions_extractor.py
+++ b/databuilder/extractor/dashboard/mode_analytics/mode_dashboard_executions_extractor.py
@@ -2,9 +2,9 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import logging
-
-from pyhocon import ConfigTree, ConfigFactory
 from typing import Any, List
+
+from pyhocon import ConfigFactory, ConfigTree
 
 from databuilder import Scoped
 from databuilder.extractor.base_extractor import Extractor
@@ -12,8 +12,8 @@ from databuilder.extractor.dashboard.mode_analytics.mode_dashboard_utils import 
 from databuilder.rest_api.mode_analytics.mode_paginated_rest_api_query import ModePaginatedRestApiQuery
 from databuilder.rest_api.rest_api_query import RestApiQuery
 from databuilder.transformer.base_transformer import ChainedTransformer, Transformer
-from databuilder.transformer.dict_to_model import DictToModel, MODEL_CLASS
-from databuilder.transformer.timestamp_string_to_epoch import TimestampStringToEpoch, FIELD_NAME
+from databuilder.transformer.dict_to_model import MODEL_CLASS, DictToModel
+from databuilder.transformer.timestamp_string_to_epoch import FIELD_NAME, TimestampStringToEpoch
 
 LOGGER = logging.getLogger(__name__)
 

--- a/databuilder/extractor/dashboard/mode_analytics/mode_dashboard_extractor.py
+++ b/databuilder/extractor/dashboard/mode_analytics/mode_dashboard_extractor.py
@@ -2,9 +2,9 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import logging
-
-from pyhocon import ConfigTree, ConfigFactory
 from typing import Any, List
+
+from pyhocon import ConfigFactory, ConfigTree
 
 from databuilder import Scoped
 from databuilder.extractor.base_extractor import Extractor
@@ -12,10 +12,11 @@ from databuilder.extractor.dashboard.mode_analytics.mode_dashboard_utils import 
 from databuilder.rest_api.mode_analytics.mode_paginated_rest_api_query import ModePaginatedRestApiQuery
 from databuilder.rest_api.rest_api_query import RestApiQuery
 from databuilder.transformer.base_transformer import ChainedTransformer, Transformer
-from databuilder.transformer.dict_to_model import DictToModel, MODEL_CLASS
-from databuilder.transformer.template_variable_substitution_transformer import \
-    TemplateVariableSubstitutionTransformer, TEMPLATE, FIELD_NAME as VAR_FIELD_NAME
-from databuilder.transformer.timestamp_string_to_epoch import TimestampStringToEpoch, FIELD_NAME
+from databuilder.transformer.dict_to_model import MODEL_CLASS, DictToModel
+from databuilder.transformer.template_variable_substitution_transformer import (
+    FIELD_NAME as VAR_FIELD_NAME, TEMPLATE, TemplateVariableSubstitutionTransformer,
+)
+from databuilder.transformer.timestamp_string_to_epoch import FIELD_NAME, TimestampStringToEpoch
 
 LOGGER = logging.getLogger(__name__)
 

--- a/databuilder/extractor/dashboard/mode_analytics/mode_dashboard_last_modified_timestamp_extractor.py
+++ b/databuilder/extractor/dashboard/mode_analytics/mode_dashboard_last_modified_timestamp_extractor.py
@@ -3,15 +3,17 @@
 
 import logging
 
-from databuilder.extractor.dashboard.mode_analytics.mode_dashboard_executions_extractor import \
-    ModeDashboardExecutionsExtractor
+from pyhocon import ConfigFactory, ConfigTree
+
+from databuilder.extractor.dashboard.mode_analytics.mode_dashboard_executions_extractor import (
+    ModeDashboardExecutionsExtractor,
+)
 from databuilder.extractor.dashboard.mode_analytics.mode_dashboard_utils import ModeDashboardUtils
 from databuilder.extractor.restapi.rest_api_extractor import STATIC_RECORD_DICT
 from databuilder.rest_api.mode_analytics.mode_paginated_rest_api_query import ModePaginatedRestApiQuery
 from databuilder.rest_api.rest_api_query import RestApiQuery
-from databuilder.transformer.dict_to_model import DictToModel, MODEL_CLASS
-from databuilder.transformer.timestamp_string_to_epoch import TimestampStringToEpoch, FIELD_NAME
-from pyhocon import ConfigTree, ConfigFactory
+from databuilder.transformer.dict_to_model import MODEL_CLASS, DictToModel
+from databuilder.transformer.timestamp_string_to_epoch import FIELD_NAME, TimestampStringToEpoch
 
 LOGGER = logging.getLogger(__name__)
 

--- a/databuilder/extractor/dashboard/mode_analytics/mode_dashboard_last_modified_timestamp_extractor.py
+++ b/databuilder/extractor/dashboard/mode_analytics/mode_dashboard_last_modified_timestamp_extractor.py
@@ -3,8 +3,6 @@
 
 import logging
 
-from pyhocon import ConfigTree, ConfigFactory
-
 from databuilder.extractor.dashboard.mode_analytics.mode_dashboard_executions_extractor import \
     ModeDashboardExecutionsExtractor
 from databuilder.extractor.dashboard.mode_analytics.mode_dashboard_utils import ModeDashboardUtils
@@ -13,6 +11,7 @@ from databuilder.rest_api.mode_analytics.mode_paginated_rest_api_query import Mo
 from databuilder.rest_api.rest_api_query import RestApiQuery
 from databuilder.transformer.dict_to_model import DictToModel, MODEL_CLASS
 from databuilder.transformer.timestamp_string_to_epoch import TimestampStringToEpoch, FIELD_NAME
+from pyhocon import ConfigTree, ConfigFactory
 
 LOGGER = logging.getLogger(__name__)
 
@@ -30,9 +29,9 @@ class ModeDashboardLastModifiedTimestampExtractor(ModeDashboardExecutionsExtract
         conf = conf.with_fallback(
             ConfigFactory.from_dict({
                 STATIC_RECORD_DICT: {'product': 'mode'},
-                '{}.{}'.format(DictToModel().get_scope(), MODEL_CLASS):
+                f'{DictToModel().get_scope()}.{MODEL_CLASS}':
                     'databuilder.models.dashboard.dashboard_last_modified.DashboardLastModifiedTimestamp',
-                '{}.{}'.format(TimestampStringToEpoch().get_scope(), FIELD_NAME):
+                f'{TimestampStringToEpoch().get_scope()}.{FIELD_NAME}':
                     'last_modified_timestamp'
             })
         )

--- a/databuilder/extractor/dashboard/mode_analytics/mode_dashboard_last_successful_executions_extractor.py
+++ b/databuilder/extractor/dashboard/mode_analytics/mode_dashboard_last_successful_executions_extractor.py
@@ -3,10 +3,11 @@
 
 import logging
 
-from pyhocon import ConfigTree, ConfigFactory
+from pyhocon import ConfigFactory, ConfigTree
 
-from databuilder.extractor.dashboard.mode_analytics.mode_dashboard_executions_extractor import \
-    ModeDashboardExecutionsExtractor
+from databuilder.extractor.dashboard.mode_analytics.mode_dashboard_executions_extractor import (
+    ModeDashboardExecutionsExtractor,
+)
 from databuilder.extractor.dashboard.mode_analytics.mode_dashboard_utils import ModeDashboardUtils
 from databuilder.extractor.restapi.rest_api_extractor import STATIC_RECORD_DICT
 from databuilder.models.dashboard.dashboard_execution import DashboardExecution

--- a/databuilder/extractor/dashboard/mode_analytics/mode_dashboard_owner_extractor.py
+++ b/databuilder/extractor/dashboard/mode_analytics/mode_dashboard_owner_extractor.py
@@ -2,9 +2,9 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import logging
-
-from pyhocon import ConfigTree, ConfigFactory
 from typing import Any
+
+from pyhocon import ConfigFactory, ConfigTree
 
 from databuilder.extractor.base_extractor import Extractor
 from databuilder.extractor.dashboard.mode_analytics.mode_dashboard_utils import ModeDashboardUtils

--- a/databuilder/extractor/dashboard/mode_analytics/mode_dashboard_queries_extractor.py
+++ b/databuilder/extractor/dashboard/mode_analytics/mode_dashboard_queries_extractor.py
@@ -2,9 +2,9 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import logging
-
-from pyhocon import ConfigTree, ConfigFactory
 from typing import Any, List
+
+from pyhocon import ConfigFactory, ConfigTree
 
 from databuilder import Scoped
 from databuilder.extractor.base_extractor import Extractor
@@ -12,11 +12,13 @@ from databuilder.extractor.dashboard.mode_analytics.mode_dashboard_utils import 
 from databuilder.rest_api.mode_analytics.mode_paginated_rest_api_query import ModePaginatedRestApiQuery
 from databuilder.rest_api.rest_api_query import RestApiQuery
 from databuilder.transformer.base_transformer import ChainedTransformer, Transformer
-from databuilder.transformer.dict_to_model import DictToModel, MODEL_CLASS
-from databuilder.transformer.regex_str_replace_transformer import RegexStrReplaceTransformer, \
-    REGEX_REPLACE_TUPLE_LIST, ATTRIBUTE_NAME
-from databuilder.transformer.template_variable_substitution_transformer import \
-    TemplateVariableSubstitutionTransformer, TEMPLATE, FIELD_NAME
+from databuilder.transformer.dict_to_model import MODEL_CLASS, DictToModel
+from databuilder.transformer.regex_str_replace_transformer import (
+    ATTRIBUTE_NAME, REGEX_REPLACE_TUPLE_LIST, RegexStrReplaceTransformer,
+)
+from databuilder.transformer.template_variable_substitution_transformer import (
+    FIELD_NAME, TEMPLATE, TemplateVariableSubstitutionTransformer,
+)
 
 LOGGER = logging.getLogger(__name__)
 

--- a/databuilder/extractor/dashboard/mode_analytics/mode_dashboard_usage_extractor.py
+++ b/databuilder/extractor/dashboard/mode_analytics/mode_dashboard_usage_extractor.py
@@ -2,9 +2,9 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import logging
+from typing import Any
 
 from pyhocon import ConfigTree
-from typing import Any
 
 from databuilder.extractor.base_extractor import Extractor
 from databuilder.extractor.dashboard.mode_analytics.mode_dashboard_utils import ModeDashboardUtils

--- a/databuilder/extractor/dashboard/mode_analytics/mode_dashboard_user_extractor.py
+++ b/databuilder/extractor/dashboard/mode_analytics/mode_dashboard_user_extractor.py
@@ -2,22 +2,23 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import logging
-
-from pyhocon import ConfigTree, ConfigFactory
-from requests.auth import HTTPBasicAuth
 from typing import Any, List
+
+from pyhocon import ConfigFactory, ConfigTree
+from requests.auth import HTTPBasicAuth
 
 from databuilder import Scoped
 from databuilder.extractor.base_extractor import Extractor
-from databuilder.extractor.dashboard.mode_analytics.mode_dashboard_constants import ORGANIZATION, MODE_ACCESS_TOKEN, \
-    MODE_PASSWORD_TOKEN
+from databuilder.extractor.dashboard.mode_analytics.mode_dashboard_constants import (
+    MODE_ACCESS_TOKEN, MODE_PASSWORD_TOKEN, ORGANIZATION,
+)
 from databuilder.extractor.dashboard.mode_analytics.mode_dashboard_utils import ModeDashboardUtils
 from databuilder.rest_api.base_rest_api_query import RestApiQuerySeed
 from databuilder.rest_api.rest_api_failure_handlers import HttpFailureSkipOnStatus
 from databuilder.rest_api.rest_api_query import RestApiQuery
 from databuilder.transformer.base_transformer import ChainedTransformer, Transformer
-from databuilder.transformer.dict_to_model import DictToModel, MODEL_CLASS
-from databuilder.transformer.remove_field_transformer import RemoveFieldTransformer, FIELD_NAMES
+from databuilder.transformer.dict_to_model import MODEL_CLASS, DictToModel
+from databuilder.transformer.remove_field_transformer import FIELD_NAMES, RemoveFieldTransformer
 
 LOGGER = logging.getLogger(__name__)
 

--- a/databuilder/extractor/dashboard/mode_analytics/mode_dashboard_utils.py
+++ b/databuilder/extractor/dashboard/mode_analytics/mode_dashboard_utils.py
@@ -1,16 +1,19 @@
 # Copyright Contributors to the Amundsen project.
 # SPDX-License-Identifier: Apache-2.0
 
-from pyhocon import ConfigTree, ConfigFactory
-from requests.auth import HTTPBasicAuth
 from typing import Any, Dict
 
+from pyhocon import ConfigFactory, ConfigTree
+from requests.auth import HTTPBasicAuth
+
 from databuilder import Scoped
-from databuilder.extractor.dashboard.mode_analytics.mode_dashboard_constants import ORGANIZATION, MODE_ACCESS_TOKEN, \
-    MODE_PASSWORD_TOKEN, MODE_BEARER_TOKEN
-from databuilder.extractor.restapi.rest_api_extractor import RestAPIExtractor, REST_API_QUERY, STATIC_RECORD_DICT
-from databuilder.rest_api.base_rest_api_query import BaseRestApiQuery
-from databuilder.rest_api.base_rest_api_query import RestApiQuerySeed
+from databuilder.extractor.dashboard.mode_analytics.mode_dashboard_constants import (
+    MODE_ACCESS_TOKEN, MODE_BEARER_TOKEN, MODE_PASSWORD_TOKEN, ORGANIZATION,
+)
+from databuilder.extractor.restapi.rest_api_extractor import (
+    REST_API_QUERY, STATIC_RECORD_DICT, RestAPIExtractor,
+)
+from databuilder.rest_api.base_rest_api_query import BaseRestApiQuery, RestApiQuerySeed
 from databuilder.rest_api.rest_api_query import RestApiQuery
 
 

--- a/databuilder/extractor/dashboard/redash/redash_dashboard_extractor.py
+++ b/databuilder/extractor/dashboard/redash/redash_dashboard_extractor.py
@@ -2,15 +2,18 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import importlib
-from typing import Any, Dict, Iterator, Optional
+from typing import (
+    Any, Dict, Iterator, Optional,
+)
 
 from pyhocon import ConfigFactory, ConfigTree
 
 from databuilder.extractor.base_extractor import Extractor
-from databuilder.extractor.dashboard.redash.redash_dashboard_utils import \
-    get_auth_headers, get_text_widgets, get_visualization_widgets, sort_widgets, \
-    generate_dashboard_description, RedashPaginatedRestApiQuery
-from databuilder.extractor.restapi.rest_api_extractor import RestAPIExtractor, REST_API_QUERY
+from databuilder.extractor.dashboard.redash.redash_dashboard_utils import (
+    RedashPaginatedRestApiQuery, generate_dashboard_description, get_auth_headers, get_text_widgets,
+    get_visualization_widgets, sort_widgets,
+)
+from databuilder.extractor.restapi.rest_api_extractor import REST_API_QUERY, RestAPIExtractor
 from databuilder.models.dashboard.dashboard_chart import DashboardChart
 from databuilder.models.dashboard.dashboard_last_modified import DashboardLastModifiedTimestamp
 from databuilder.models.dashboard.dashboard_metadata import DashboardMetadata
@@ -21,7 +24,7 @@ from databuilder.models.table_metadata import TableMetadata
 from databuilder.rest_api.base_rest_api_query import EmptyRestApiQuerySeed
 from databuilder.rest_api.rest_api_query import RestApiQuery
 from databuilder.transformer.base_transformer import ChainedTransformer
-from databuilder.transformer.timestamp_string_to_epoch import TimestampStringToEpoch, FIELD_NAME as TS_FIELD_NAME
+from databuilder.transformer.timestamp_string_to_epoch import FIELD_NAME as TS_FIELD_NAME, TimestampStringToEpoch
 
 
 class TableRelationData:

--- a/databuilder/extractor/dashboard/redash/redash_dashboard_extractor.py
+++ b/databuilder/extractor/dashboard/redash/redash_dashboard_extractor.py
@@ -2,24 +2,24 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import importlib
-
-from pyhocon import ConfigFactory, ConfigTree
 from typing import Any, Dict, Iterator, Optional
 
-from databuilder.models.dashboard.dashboard_metadata import DashboardMetadata
-from databuilder.models.dashboard.dashboard_last_modified import DashboardLastModifiedTimestamp
-from databuilder.models.dashboard.dashboard_owner import DashboardOwner
-from databuilder.models.dashboard.dashboard_query import DashboardQuery
-from databuilder.models.dashboard.dashboard_table import DashboardTable
-from databuilder.models.dashboard.dashboard_chart import DashboardChart
-from databuilder.models.table_metadata import TableMetadata
+from pyhocon import ConfigFactory, ConfigTree
+
 from databuilder.extractor.base_extractor import Extractor
-from databuilder.rest_api.rest_api_query import RestApiQuery
-from databuilder.rest_api.base_rest_api_query import EmptyRestApiQuerySeed
-from databuilder.extractor.restapi.rest_api_extractor import RestAPIExtractor, REST_API_QUERY
 from databuilder.extractor.dashboard.redash.redash_dashboard_utils import \
     get_auth_headers, get_text_widgets, get_visualization_widgets, sort_widgets, \
     generate_dashboard_description, RedashPaginatedRestApiQuery
+from databuilder.extractor.restapi.rest_api_extractor import RestAPIExtractor, REST_API_QUERY
+from databuilder.models.dashboard.dashboard_chart import DashboardChart
+from databuilder.models.dashboard.dashboard_last_modified import DashboardLastModifiedTimestamp
+from databuilder.models.dashboard.dashboard_metadata import DashboardMetadata
+from databuilder.models.dashboard.dashboard_owner import DashboardOwner
+from databuilder.models.dashboard.dashboard_query import DashboardQuery
+from databuilder.models.dashboard.dashboard_table import DashboardTable
+from databuilder.models.table_metadata import TableMetadata
+from databuilder.rest_api.base_rest_api_query import EmptyRestApiQuerySeed
+from databuilder.rest_api.rest_api_query import RestApiQuery
 from databuilder.transformer.base_transformer import ChainedTransformer
 from databuilder.transformer.timestamp_string_to_epoch import TimestampStringToEpoch, FIELD_NAME as TS_FIELD_NAME
 
@@ -35,12 +35,10 @@ class TableRelationData:
                  cluster: str,
                  schema: str,
                  name: str) -> None:
-
         self._data = {'db': database, 'cluster': cluster, 'schema': schema, 'tbl': name}
 
     @property
     def key(self) -> str:
-
         return TableMetadata.TABLE_KEY_FORMAT.format(**self._data)
 
 
@@ -126,8 +124,7 @@ class RedashDashboardExtractor(Extractor):
                 'dashboard_name':
                     record['dashboard_name'],
                 'dashboard_url':
-                    '{redash}/dashboards/{id}'
-                    .format(redash=self._redash_base_url, id=record['dashboard_id']),
+                    f'{self._redash_base_url}/dashboards/{record["dashboard_id"]}',
                 'created_timestamp':
                     record['created_timestamp']
             }
@@ -195,7 +192,7 @@ class RedashDashboardExtractor(Extractor):
 
         dashes_query = RedashPaginatedRestApiQuery(
             query_to_join=EmptyRestApiQuerySeed(),
-            url='{redash_api}/dashboards'.format(redash_api=self._api_base_url),
+            url=f'{self._api_base_url}/dashboards',
             params=self._get_default_api_query_params(),
             json_path='results[*].[id,name,slug,created_at,updated_at,is_archived,is_draft,user]',
             field_names=[
@@ -207,7 +204,7 @@ class RedashDashboardExtractor(Extractor):
 
         return RestApiQuery(
             query_to_join=dashes_query,
-            url='{redash_api}/dashboards/{{dashboard_id}}'.format(redash_api=self._api_base_url),
+            url=f'{self._api_base_url}/dashboards/{{dashboard_id}}',
             params=self._get_default_api_query_params(),
             json_path='widgets',
             field_names=['widgets'],

--- a/databuilder/extractor/dashboard/redash/redash_dashboard_utils.py
+++ b/databuilder/extractor/dashboard/redash/redash_dashboard_utils.py
@@ -1,7 +1,9 @@
 # Copyright Contributors to the Amundsen project.
 # SPDX-License-Identifier: Apache-2.0
 
-from typing import Any, Dict, Iterable, List, Tuple
+from typing import (
+    Any, Dict, Iterable, List, Tuple,
+)
 
 from databuilder.rest_api.rest_api_query import RestApiQuery
 

--- a/databuilder/extractor/dashboard/redash/redash_dashboard_utils.py
+++ b/databuilder/extractor/dashboard/redash/redash_dashboard_utils.py
@@ -31,7 +31,7 @@ class RedashVisualizationWidget:
 
     @property
     def query_relative_url(self) -> str:
-        return '/queries/{id}'.format(id=self.query_id)
+        return f'/queries/{self.query_id}'
 
     @property
     def query_name(self) -> str:
@@ -131,7 +131,7 @@ def get_visualization_widgets(widgets: Iterable[Dict[str, Any]]) -> List[RedashV
 
 
 def get_auth_headers(api_key: str) -> Dict[str, str]:
-    return {'Authorization': 'Key {}'.format(api_key)}
+    return {'Authorization': f'Key {api_key}'}
 
 
 def generate_dashboard_description(text_widgets: List[RedashTextWidget],
@@ -147,7 +147,7 @@ def generate_dashboard_description(text_widgets: List[RedashTextWidget],
     if len(text_widgets) > 0:
         return '\n\n'.join([w.text for w in text_widgets])
     elif len(viz_widgets) > 0:
-        query_list = '\n'.join(set(['- {}'.format(v.query_name) for v in set(viz_widgets)]))
+        query_list = '\n'.join(set([f'- {v.query_name}' for v in set(viz_widgets)]))
         return 'A dashboard containing the following queries:\n\n' + query_list
 
     return 'This dashboard appears to be empty!'

--- a/databuilder/extractor/dashboard/tableau/tableau_dashboard_extractor.py
+++ b/databuilder/extractor/dashboard/tableau/tableau_dashboard_extractor.py
@@ -9,14 +9,15 @@ from pyhocon import ConfigFactory, ConfigTree
 import databuilder.extractor.dashboard.tableau.tableau_dashboard_constants as const
 from databuilder import Scoped
 from databuilder.extractor.base_extractor import Extractor
-from databuilder.extractor.dashboard.tableau.tableau_dashboard_utils import TableauGraphQLApiExtractor,\
+from databuilder.extractor.dashboard.tableau.tableau_dashboard_utils import (
+    TableauGraphQLApiExtractor,
     TableauDashboardUtils
+)
 from databuilder.extractor.restapi.rest_api_extractor import STATIC_RECORD_DICT
 from databuilder.transformer.base_transformer import ChainedTransformer
 from databuilder.transformer.base_transformer import Transformer
 from databuilder.transformer.dict_to_model import DictToModel, MODEL_CLASS
 from databuilder.transformer.timestamp_string_to_epoch import TimestampStringToEpoch, FIELD_NAME
-
 
 LOGGER = logging.getLogger(__name__)
 
@@ -37,21 +38,15 @@ class TableauGraphQLApiMetadataExtractor(TableauGraphQLApiExtractor):
         workbooks_data = [workbook for workbook in response['workbooks']
                           if workbook['projectName'] not in
                           self._conf.get_list(TableauGraphQLApiMetadataExtractor.EXCLUDED_PROJECTS)]
-
+        base_url = self._conf.get(TableauGraphQLApiMetadataExtractor.TABLEAU_BASE_URL)
         for workbook in workbooks_data:
             data = {
                 'dashboard_group': workbook['projectName'],
                 'dashboard_name': TableauDashboardUtils.sanitize_workbook_name(workbook['name']),
                 'description': workbook.get('description', ''),
                 'created_timestamp': workbook['createdAt'],
-                'dashboard_group_url': '{}/#/projects/{}'.format(
-                    self._conf.get(TableauGraphQLApiMetadataExtractor.TABLEAU_BASE_URL),
-                    workbook['projectVizportalUrlId']
-                ),
-                'dashboard_url': '{}/#/workbooks/{}/views'.format(
-                    self._conf.get(TableauGraphQLApiMetadataExtractor.TABLEAU_BASE_URL),
-                    workbook['vizportalUrlId']
-                ),
+                'dashboard_group_url': f'{base_url}/#/projects/{workbook["projectVizportalUrlId"]}',
+                'dashboard_url': f'{base_url}/#/workbooks/{workbook["vizportalUrlId"]}/views',
                 'cluster': self._conf.get_string(TableauGraphQLApiMetadataExtractor.CLUSTER)
             }
             yield data
@@ -126,13 +121,9 @@ class TableauDashboardExtractor(Extractor):
         :return: A TableauGraphQLApiMetadataExtractor that provides core dashboard metadata.
         """
         extractor = TableauGraphQLApiMetadataExtractor()
-        tableau_extractor_conf = \
-            Scoped.get_scoped_conf(self._conf, extractor.get_scope())\
-                  .with_fallback(self._conf)\
-                  .with_fallback(ConfigFactory.from_dict({TableauGraphQLApiExtractor.QUERY: self.query,
-                                                          STATIC_RECORD_DICT: {'product': 'tableau'}
-                                                          }
-                                                         )
-                                 )
+        tableau_extractor_conf = Scoped.get_scoped_conf(self._conf, extractor.get_scope()) \
+            .with_fallback(self._conf) \
+            .with_fallback(ConfigFactory.from_dict({TableauGraphQLApiExtractor.QUERY: self.query,
+                                                    STATIC_RECORD_DICT: {'product': 'tableau'}}))
         extractor.init(conf=tableau_extractor_conf)
         return extractor

--- a/databuilder/extractor/dashboard/tableau/tableau_dashboard_extractor.py
+++ b/databuilder/extractor/dashboard/tableau/tableau_dashboard_extractor.py
@@ -2,7 +2,9 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import logging
-from typing import Any, Dict, Iterator, List
+from typing import (
+    Any, Dict, Iterator, List,
+)
 
 from pyhocon import ConfigFactory, ConfigTree
 
@@ -10,14 +12,12 @@ import databuilder.extractor.dashboard.tableau.tableau_dashboard_constants as co
 from databuilder import Scoped
 from databuilder.extractor.base_extractor import Extractor
 from databuilder.extractor.dashboard.tableau.tableau_dashboard_utils import (
-    TableauGraphQLApiExtractor,
-    TableauDashboardUtils
+    TableauDashboardUtils, TableauGraphQLApiExtractor,
 )
 from databuilder.extractor.restapi.rest_api_extractor import STATIC_RECORD_DICT
-from databuilder.transformer.base_transformer import ChainedTransformer
-from databuilder.transformer.base_transformer import Transformer
-from databuilder.transformer.dict_to_model import DictToModel, MODEL_CLASS
-from databuilder.transformer.timestamp_string_to_epoch import TimestampStringToEpoch, FIELD_NAME
+from databuilder.transformer.base_transformer import ChainedTransformer, Transformer
+from databuilder.transformer.dict_to_model import MODEL_CLASS, DictToModel
+from databuilder.transformer.timestamp_string_to_epoch import FIELD_NAME, TimestampStringToEpoch
 
 LOGGER = logging.getLogger(__name__)
 

--- a/databuilder/extractor/dashboard/tableau/tableau_dashboard_last_modified_extractor.py
+++ b/databuilder/extractor/dashboard/tableau/tableau_dashboard_last_modified_extractor.py
@@ -2,21 +2,22 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import logging
-from typing import Any, Dict, Iterator, List
+from typing import (
+    Any, Dict, Iterator, List,
+)
 
 from pyhocon import ConfigFactory, ConfigTree
 
 import databuilder.extractor.dashboard.tableau.tableau_dashboard_constants as const
 from databuilder import Scoped
 from databuilder.extractor.base_extractor import Extractor
-from databuilder.extractor.dashboard.tableau.tableau_dashboard_utils import TableauGraphQLApiExtractor,\
-    TableauDashboardUtils
+from databuilder.extractor.dashboard.tableau.tableau_dashboard_utils import (
+    TableauDashboardUtils, TableauGraphQLApiExtractor,
+)
 from databuilder.extractor.restapi.rest_api_extractor import STATIC_RECORD_DICT
-from databuilder.transformer.base_transformer import ChainedTransformer
-from databuilder.transformer.base_transformer import Transformer
-from databuilder.transformer.dict_to_model import DictToModel, MODEL_CLASS
-from databuilder.transformer.timestamp_string_to_epoch import TimestampStringToEpoch, FIELD_NAME
-
+from databuilder.transformer.base_transformer import ChainedTransformer, Transformer
+from databuilder.transformer.dict_to_model import MODEL_CLASS, DictToModel
+from databuilder.transformer.timestamp_string_to_epoch import FIELD_NAME, TimestampStringToEpoch
 
 LOGGER = logging.getLogger(__name__)
 

--- a/databuilder/extractor/dashboard/tableau/tableau_dashboard_query_extractor.py
+++ b/databuilder/extractor/dashboard/tableau/tableau_dashboard_query_extractor.py
@@ -2,18 +2,21 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import logging
-from typing import Any, Dict, Iterator
+from typing import (
+    Any, Dict, Iterator,
+)
 
 from pyhocon import ConfigFactory, ConfigTree
 
 import databuilder.extractor.dashboard.tableau.tableau_dashboard_constants as const
 from databuilder import Scoped
 from databuilder.extractor.base_extractor import Extractor
-from databuilder.extractor.dashboard.tableau.tableau_dashboard_utils import TableauGraphQLApiExtractor,\
-    TableauDashboardUtils
+from databuilder.extractor.dashboard.tableau.tableau_dashboard_utils import (
+    TableauDashboardUtils, TableauGraphQLApiExtractor,
+)
 from databuilder.extractor.restapi.rest_api_extractor import STATIC_RECORD_DICT
 from databuilder.transformer.base_transformer import ChainedTransformer
-from databuilder.transformer.dict_to_model import DictToModel, MODEL_CLASS
+from databuilder.transformer.dict_to_model import MODEL_CLASS, DictToModel
 
 LOGGER = logging.getLogger(__name__)
 

--- a/databuilder/extractor/dashboard/tableau/tableau_dashboard_table_extractor.py
+++ b/databuilder/extractor/dashboard/tableau/tableau_dashboard_table_extractor.py
@@ -2,20 +2,22 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import logging
-from typing import Any, Dict, Iterator
+from typing import (
+    Any, Dict, Iterator,
+)
 
 from pyhocon import ConfigFactory, ConfigTree
 
 import databuilder.extractor.dashboard.tableau.tableau_dashboard_constants as const
 from databuilder import Scoped
 from databuilder.extractor.base_extractor import Extractor
-from databuilder.extractor.dashboard.tableau.tableau_dashboard_utils import TableauGraphQLApiExtractor,\
-    TableauDashboardUtils
+from databuilder.extractor.dashboard.tableau.tableau_dashboard_utils import (
+    TableauDashboardUtils, TableauGraphQLApiExtractor,
+)
 from databuilder.extractor.restapi.rest_api_extractor import STATIC_RECORD_DICT
-from databuilder.transformer.base_transformer import ChainedTransformer
-from databuilder.transformer.dict_to_model import DictToModel, MODEL_CLASS
-
 from databuilder.models.table_metadata import TableMetadata
+from databuilder.transformer.base_transformer import ChainedTransformer
+from databuilder.transformer.dict_to_model import MODEL_CLASS, DictToModel
 
 LOGGER = logging.getLogger(__name__)
 

--- a/databuilder/extractor/dashboard/tableau/tableau_dashboard_utils.py
+++ b/databuilder/extractor/dashboard/tableau/tableau_dashboard_utils.py
@@ -169,10 +169,7 @@ class TableauDashboardAuth:
         See https://help.tableau.com/current/api/rest_api/en-us/REST/rest_api_concepts_versions.htm
         for details or ask your Tableau server administrator.
         """
-        self._auth_url = "{api_base_url}/api/{api_version}/auth/signin".format(
-            api_base_url=self._api_base_url,
-            api_version=self._api_version
-        )
+        self._auth_url = f"{self._api_base_url}/api/{self._api_version}/auth/signin"
 
         payload = json.dumps({
             'credentials': {

--- a/databuilder/extractor/dashboard/tableau/tableau_dashboard_utils.py
+++ b/databuilder/extractor/dashboard/tableau/tableau_dashboard_utils.py
@@ -2,10 +2,12 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import json
-import requests
 import re
-from typing import Any, Dict, Iterator, Optional
+from typing import (
+    Any, Dict, Iterator, Optional,
+)
 
+import requests
 from pyhocon import ConfigTree
 
 import databuilder.extractor.dashboard.tableau.tableau_dashboard_constants as const

--- a/databuilder/extractor/dashboard/tableau/tableau_external_table_extractor.py
+++ b/databuilder/extractor/dashboard/tableau/tableau_external_table_extractor.py
@@ -2,17 +2,20 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import logging
-from typing import Any, Dict, Iterator
+from typing import (
+    Any, Dict, Iterator,
+)
 
 from pyhocon import ConfigFactory, ConfigTree
 
 import databuilder.extractor.dashboard.tableau.tableau_dashboard_constants as const
 from databuilder import Scoped
 from databuilder.extractor.base_extractor import Extractor
-from databuilder.extractor.dashboard.tableau.tableau_dashboard_utils import TableauGraphQLApiExtractor,\
-    TableauDashboardUtils
+from databuilder.extractor.dashboard.tableau.tableau_dashboard_utils import (
+    TableauDashboardUtils, TableauGraphQLApiExtractor,
+)
 from databuilder.transformer.base_transformer import ChainedTransformer
-from databuilder.transformer.dict_to_model import DictToModel, MODEL_CLASS
+from databuilder.transformer.dict_to_model import MODEL_CLASS, DictToModel
 
 LOGGER = logging.getLogger(__name__)
 

--- a/databuilder/extractor/db2_metadata_extractor.py
+++ b/databuilder/extractor/db2_metadata_extractor.py
@@ -3,15 +3,17 @@
 
 import logging
 from collections import namedtuple
+from itertools import groupby
+from typing import (
+    Any, Dict, Iterator, Union,
+)
 
 from pyhocon import ConfigFactory, ConfigTree
-from typing import Iterator, Union, Dict, Any
 
 from databuilder import Scoped
 from databuilder.extractor.base_extractor import Extractor
 from databuilder.extractor.sql_alchemy_extractor import SQLAlchemyExtractor
-from databuilder.models.table_metadata import TableMetadata, ColumnMetadata
-from itertools import groupby
+from databuilder.models.table_metadata import ColumnMetadata, TableMetadata
 
 TableKey = namedtuple('TableKey', ['schema', 'table_name'])
 

--- a/databuilder/extractor/db2_metadata_extractor.py
+++ b/databuilder/extractor/db2_metadata_extractor.py
@@ -54,9 +54,9 @@ class Db2MetadataExtractor(Extractor):
 
     def init(self, conf: ConfigTree) -> None:
         conf = conf.with_fallback(Db2MetadataExtractor.DEFAULT_CONFIG)
-        self._cluster = '{}'.format(conf.get_string(Db2MetadataExtractor.CLUSTER_KEY))
+        self._cluster = conf.get_string(Db2MetadataExtractor.CLUSTER_KEY)
 
-        cluster_source = "'{}'".format(self._cluster)
+        cluster_source = f"'{self._cluster}'"
 
         self._database = conf.get_string(Db2MetadataExtractor.DATABASE_KEY, default='db2')
 
@@ -71,7 +71,7 @@ class Db2MetadataExtractor(Extractor):
 
         self.sql_stmt = sql_alch_conf.get_string(SQLAlchemyExtractor.EXTRACT_SQL)
 
-        LOGGER.info('SQL for Db2 metadata: {}'.format(self.sql_stmt))
+        LOGGER.info('SQL for Db2 metadata: %s', self.sql_stmt)
 
         self._alchemy_extractor.init(sql_alch_conf)
         self._extract_iter: Union[None, Iterator] = None

--- a/databuilder/extractor/db_api_extractor.py
+++ b/databuilder/extractor/db_api_extractor.py
@@ -47,7 +47,7 @@ class DBAPIExtractor(Extractor):
         Use cursor to execute the {sql}
         :return:
         """
-        LOGGER.info('Executing query: \n{}'.format(self.sql))
+        LOGGER.info('Executing query: \n%s', self.sql)
         self.cursor.execute(self.sql)
         return self.cursor.fetchall()
 

--- a/databuilder/extractor/db_api_extractor.py
+++ b/databuilder/extractor/db_api_extractor.py
@@ -3,12 +3,11 @@
 
 import importlib
 import logging
-from typing import Iterable, Any
+from typing import Any, Iterable
 
 from pyhocon import ConfigTree
 
 from databuilder.extractor.base_extractor import Extractor
-
 
 LOGGER = logging.getLogger(__name__)
 

--- a/databuilder/extractor/delta_lake_metadata_extractor.py
+++ b/databuilder/extractor/delta_lake_metadata_extractor.py
@@ -5,7 +5,9 @@ import concurrent.futures
 import logging
 from collections import namedtuple
 from datetime import datetime
-from typing import Iterator, Union, List, Dict, Optional  # noqa: F401
+from typing import (  # noqa: F401
+    Dict, Iterator, List, Optional, Union,
+)
 
 from pyhocon import ConfigFactory, ConfigTree  # noqa: F401
 from pyspark.sql import SparkSession
@@ -14,7 +16,7 @@ from pyspark.sql.utils import AnalysisException
 
 from databuilder.extractor.base_extractor import Extractor
 from databuilder.models.table_last_updated import TableLastUpdated
-from databuilder.models.table_metadata import TableMetadata, ColumnMetadata
+from databuilder.models.table_metadata import ColumnMetadata, TableMetadata
 
 TableKey = namedtuple('TableKey', ['schema', 'table_name'])
 

--- a/databuilder/extractor/delta_lake_metadata_extractor.py
+++ b/databuilder/extractor/delta_lake_metadata_extractor.py
@@ -1,18 +1,20 @@
 # Copyright Contributors to the Amundsen project.
 # SPDX-License-Identifier: Apache-2.0
-from datetime import datetime
+
+import concurrent.futures
 import logging
 from collections import namedtuple
+from datetime import datetime
+from typing import Iterator, Union, List, Dict, Optional  # noqa: F401
 
-from databuilder.extractor.base_extractor import Extractor
-from databuilder.models.table_last_updated import TableLastUpdated
-from databuilder.models.table_metadata import TableMetadata, ColumnMetadata
 from pyhocon import ConfigFactory, ConfigTree  # noqa: F401
 from pyspark.sql import SparkSession
 from pyspark.sql.catalog import Table
 from pyspark.sql.utils import AnalysisException
-from typing import Iterator, Union, List, Dict, Optional  # noqa: F401
-import concurrent.futures
+
+from databuilder.extractor.base_extractor import Extractor
+from databuilder.models.table_last_updated import TableLastUpdated
+from databuilder.models.table_metadata import TableMetadata, ColumnMetadata
 
 TableKey = namedtuple('TableKey', ['schema', 'table_name'])
 
@@ -35,15 +37,15 @@ class ScrapedColumnMetadata(object):
     def __eq__(self, other: object) -> bool:
         if not isinstance(other, ScrapedColumnMetadata):
             return False
-        return self.name == other.name and \
-            self.data_type == other.data_type and \
-            self.description == other.description and \
-            self.sort_order == other.sort_order and \
-            self.is_partition == other.is_partition and \
-            self.attributes == other.attributes
+        return (self.name == other.name and
+                self.data_type == other.data_type and
+                self.description == other.description and
+                self.sort_order == other.sort_order and
+                self.is_partition == other.is_partition and
+                self.attributes == other.attributes)
 
     def __repr__(self) -> str:
-        return "{0}:{1}".format(self.name, self.data_type)
+        return f'{self.name}:{self.data_type}'
 
 
 # TODO consider deprecating this for using TableMetadata directly
@@ -108,7 +110,7 @@ class ScrapedTableMetadata(object):
             return False
 
     def __repr__(self) -> str:
-        return "{schema}.{table}".format(schema=self.schema, table=self.table)
+        return f'{self.schema}.{self.table}'
 
 
 class DeltaLakeMetadataExtractor(Extractor):
@@ -164,13 +166,13 @@ class DeltaLakeMetadataExtractor(Extractor):
          - last updated information
         """
         if self.schema_list:
-            LOGGER.info("working on {}".format(self.schema_list))
+            LOGGER.info("working on %s", self.schema_list)
             tables = self.get_all_tables(self.schema_list)
         else:
             LOGGER.info("fetching all schemas")
-            LOGGER.info("Excluding: {}".format(self.exclude_list))
+            LOGGER.info("Excluding: %s", self.exclude_list)
             schemas = self.get_schemas(self.exclude_list)
-            LOGGER.info("working on {}".format(schemas))
+            LOGGER.info("working on %s", schemas)
             tables = self.get_all_tables(schemas)
         # TODO add the programmatic information as well?
         # TODO add watermarks
@@ -179,7 +181,7 @@ class DeltaLakeMetadataExtractor(Extractor):
             if not scraped_table:
                 continue
             if self.delta_tables_only and not scraped_table.is_delta_table():
-                LOGGER.info("Skipping none delta table {}".format(scraped_table.table))
+                LOGGER.info("Skipping none delta table %s", scraped_table.table)
                 continue
             else:
                 yield self.create_table_metadata(scraped_table)
@@ -245,7 +247,7 @@ class DeltaLakeMetadataExtractor(Extractor):
 
     def scrape_table_detail(self, table_name: str) -> Optional[Dict]:
         try:
-            table_details_df = self.spark.sql("describe detail {0}".format(table_name))
+            table_details_df = self.spark.sql(f"describe detail {table_name}")
             table_detail = table_details_df.collect()[0]
             return table_detail.asDict()
         except Exception as e:
@@ -256,8 +258,7 @@ class DeltaLakeMetadataExtractor(Extractor):
         # TODO the blanket try catches need to be changed
         describeExtendedOutput = []
         try:
-            describeExtendedOutput = self.spark.sql("describe extended {view_name}"
-                                                    .format(view_name=view_name)).collect()
+            describeExtendedOutput = self.spark.sql(f"describe extended {view_name}").collect()
         except Exception as e:
             LOGGER.error(e)
             return None
@@ -277,7 +278,7 @@ class DeltaLakeMetadataExtractor(Extractor):
         in the general case cannot rely on spark.catalog.listColumns.'''
         raw_columns = []
         try:
-            raw_columns = self.spark.sql("describe {0}.{1}".format(schema, table)).collect()
+            raw_columns = self.spark.sql(f"describe {schema}.{table}").collect()
         except AnalysisException as e:
             LOGGER.error(e)
             return raw_columns
@@ -301,10 +302,10 @@ class DeltaLakeMetadataExtractor(Extractor):
                 sort_order += 1
             else:
                 if row['data_type'] in parsed_columns:
-                    LOGGER.debug("Adding partition column table for {0}".format(row['data_type']))
+                    LOGGER.debug(f"Adding partition column table for {row['data_type']}")
                     parsed_columns[row['data_type']].set_is_partition(True)
                 elif row['col_name'] in parsed_columns:
-                    LOGGER.debug("Adding partition column table for {0}".format(row['col_name']))
+                    LOGGER.debug(f"Adding partition column table for {row['col_name']}")
                     parsed_columns[row['col_name']].set_is_partition(True)
         return list(parsed_columns.values())
 

--- a/databuilder/extractor/dremio_metadata_extractor.py
+++ b/databuilder/extractor/dremio_metadata_extractor.py
@@ -108,7 +108,7 @@ class DremioMetadataExtractor(Extractor):
             where_stmt=where_stmt
         )
 
-        LOGGER.info('SQL for Dremio metadata: {}'.format(self.sql_stmt))
+        LOGGER.info('SQL for Dremio metadata: %s', self.sql_stmt)
 
         self._pyodbc_cursor = connect(
             conf.get_string(DremioMetadataExtractor.DREMIO_DRIVER_KEY),

--- a/databuilder/extractor/dremio_metadata_extractor.py
+++ b/databuilder/extractor/dremio_metadata_extractor.py
@@ -2,17 +2,18 @@
 # SPDX-License-Identifier: Apache-2.0
 
 
+import logging
 from collections import namedtuple
 from itertools import groupby
-import logging
-from typing import Iterator, Union, Dict, Any
+from typing import (
+    Any, Dict, Iterator, Union,
+)
 
 from pyhocon import ConfigFactory, ConfigTree
 from pyodbc import connect
 
 from databuilder.extractor.base_extractor import Extractor
-from databuilder.models.table_metadata import TableMetadata, ColumnMetadata
-
+from databuilder.models.table_metadata import ColumnMetadata, TableMetadata
 
 TableKey = namedtuple('TableKey', ['schema', 'table_name'])
 

--- a/databuilder/extractor/druid_metadata_extractor.py
+++ b/databuilder/extractor/druid_metadata_extractor.py
@@ -45,7 +45,7 @@ class DruidMetadataExtractor(Extractor):
 
     def init(self, conf: ConfigTree) -> None:
         conf = conf.with_fallback(DruidMetadataExtractor.DEFAULT_CONFIG)
-        self._cluster = '{}'.format(conf.get_string(DruidMetadataExtractor.CLUSTER_KEY))
+        self._cluster = conf.get_string(DruidMetadataExtractor.CLUSTER_KEY)
 
         self.sql_stmt = DruidMetadataExtractor.SQL_STATEMENT.format(
             where_clause_suffix=conf.get_string(DruidMetadataExtractor.WHERE_CLAUSE_SUFFIX_KEY,

--- a/databuilder/extractor/druid_metadata_extractor.py
+++ b/databuilder/extractor/druid_metadata_extractor.py
@@ -2,18 +2,19 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import logging
-from collections import namedtuple
 import textwrap
+from collections import namedtuple
+from itertools import groupby
+from typing import (
+    Any, Dict, Iterator, Union,
+)
 
 from pyhocon import ConfigFactory, ConfigTree
-from typing import Iterator, Union, Dict, Any
 
 from databuilder import Scoped
 from databuilder.extractor.base_extractor import Extractor
 from databuilder.extractor.sql_alchemy_extractor import SQLAlchemyExtractor
-from databuilder.models.table_metadata import TableMetadata, ColumnMetadata
-from itertools import groupby
-
+from databuilder.models.table_metadata import ColumnMetadata, TableMetadata
 
 TableKey = namedtuple('TableKey', ['schema', 'table_name'])
 

--- a/databuilder/extractor/feast_extractor.py
+++ b/databuilder/extractor/feast_extractor.py
@@ -1,8 +1,8 @@
 # Copyright Contributors to the Amundsen project.
 # SPDX-License-Identifier: Apache-2.0
 
-from typing import Iterator, Union
 from datetime import datetime
+from typing import Iterator, Union
 
 import yaml
 from feast import Client
@@ -10,7 +10,7 @@ from feast.feature_table import FeatureTable
 from pyhocon import ConfigFactory, ConfigTree
 
 from databuilder.extractor.base_extractor import Extractor
-from databuilder.models.table_metadata import TableMetadata, ColumnMetadata
+from databuilder.models.table_metadata import ColumnMetadata, TableMetadata
 
 
 class FeastExtractor(Extractor):

--- a/databuilder/extractor/generic_extractor.py
+++ b/databuilder/extractor/generic_extractor.py
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import importlib
-from typing import Iterable, Any
+from typing import Any, Iterable
 
 from pyhocon import ConfigTree
 

--- a/databuilder/extractor/glue_extractor.py
+++ b/databuilder/extractor/glue_extractor.py
@@ -1,13 +1,15 @@
 # Copyright Contributors to the Amundsen project.
 # SPDX-License-Identifier: Apache-2.0
 
-import boto3
+from typing import (
+    Any, Dict, Iterator, List, Union,
+)
 
+import boto3
 from pyhocon import ConfigFactory, ConfigTree
-from typing import Iterator, Union, Dict, Any, List
 
 from databuilder.extractor.base_extractor import Extractor
-from databuilder.models.table_metadata import TableMetadata, ColumnMetadata
+from databuilder.models.table_metadata import ColumnMetadata, TableMetadata
 
 
 class GlueExtractor(Extractor):

--- a/databuilder/extractor/glue_extractor.py
+++ b/databuilder/extractor/glue_extractor.py
@@ -21,7 +21,7 @@ class GlueExtractor(Extractor):
 
     def init(self, conf: ConfigTree) -> None:
         conf = conf.with_fallback(GlueExtractor.DEFAULT_CONFIG)
-        self._cluster = '{}'.format(conf.get_string(GlueExtractor.CLUSTER_KEY))
+        self._cluster = conf.get_string(GlueExtractor.CLUSTER_KEY)
         self._filters = conf.get(GlueExtractor.FILTER_KEY)
         self._glue = boto3.client('glue')
         self._extract_iter: Union[None, Iterator] = None

--- a/databuilder/extractor/hive_table_last_updated_extractor.py
+++ b/databuilder/extractor/hive_table_last_updated_extractor.py
@@ -6,9 +6,6 @@ import time
 from datetime import datetime
 from functools import wraps
 from multiprocessing.pool import ThreadPool
-
-from pyhocon import ConfigFactory, ConfigTree
-from pytz import UTC
 from typing import Iterator, Union, Any, List
 
 from databuilder import Scoped
@@ -16,6 +13,8 @@ from databuilder.extractor.base_extractor import Extractor
 from databuilder.extractor.sql_alchemy_extractor import SQLAlchemyExtractor
 from databuilder.filesystem.filesystem import FileSystem, is_client_side_error
 from databuilder.models.table_last_updated import TableLastUpdated
+from pyhocon import ConfigFactory, ConfigTree
+from pytz import UTC
 
 LOGGER = logging.getLogger(__name__)
 OLDEST_TIMESTAMP = datetime.fromtimestamp(0, UTC)
@@ -36,10 +35,10 @@ def fs_error_handler(f: Any) -> Any:
             return f(*args, **kwargs)
         except Exception as e:
             if is_client_side_error(e):
-                LOGGER.info('Invalid metadata. Skipping. args: {}, kwargs: {}. error: {}'.format(args, kwargs, e))
+                LOGGER.info('Invalid metadata. Skipping. args: %s, kwargs: %s. error: %s', args, kwargs, e)
                 return None
             else:
-                LOGGER.exception('Unknown exception while processing args: {}, kwargs: {}'.format(args, kwargs))
+                LOGGER.exception('Unknown exception while processing args: %s, kwargs: %s', args, kwargs)
                 return None
 
     return wrapper
@@ -109,12 +108,12 @@ class HiveTableLastUpdatedExtractor(Extractor):
         self._conf = conf.with_fallback(HiveTableLastUpdatedExtractor.DEFAULT_CONFIG)
 
         pool_size = self._conf.get_int(HiveTableLastUpdatedExtractor.FS_WORKER_POOL_SIZE)
-        LOGGER.info('Using thread pool size: {}'.format(pool_size))
+        LOGGER.info('Using thread pool size: %s', pool_size)
         self._fs_worker_pool = ThreadPool(processes=pool_size)
         self._fs_worker_timeout = self._conf.get_int(HiveTableLastUpdatedExtractor.FS_WORKER_TIMEOUT_SEC)
-        LOGGER.info('Using thread timeout: {} seconds'.format(self._fs_worker_timeout))
+        LOGGER.info('Using thread timeout: %s seconds', self._fs_worker_timeout)
 
-        self._cluster = '{}'.format(self._conf.get_string(HiveTableLastUpdatedExtractor.CLUSTER_KEY))
+        self._cluster = self._conf.get_string(HiveTableLastUpdatedExtractor.CLUSTER_KEY)
 
         self._partitioned_table_extractor = self._get_partitioned_table_sql_alchemy_extractor()
         self._non_partitioned_table_extractor = self._get_non_partitioned_table_sql_alchemy_extractor()
@@ -134,7 +133,7 @@ class HiveTableLastUpdatedExtractor(Extractor):
             where_clause_suffix=self._conf.get_string(
                 HiveTableLastUpdatedExtractor.PARTITIONED_TABLE_WHERE_CLAUSE_SUFFIX_KEY, ' '))
 
-        LOGGER.info('SQL for partitioned table against Hive metastore: {}'.format(sql_stmt))
+        LOGGER.info('SQL for partitioned table against Hive metastore: %s', sql_stmt)
 
         sql_alchemy_extractor = SQLAlchemyExtractor()
         sql_alchemy_conf = Scoped.get_scoped_conf(self._conf, sql_alchemy_extractor.get_scope()) \
@@ -162,7 +161,7 @@ class HiveTableLastUpdatedExtractor(Extractor):
         sql_stmt = HiveTableLastUpdatedExtractor.NON_PARTITIONED_TABLE_SQL_STATEMENT.format(
             where_clause_suffix=where_clause_suffix)
 
-        LOGGER.info('SQL for non-partitioned table against Hive metastore: {}'.format(sql_stmt))
+        LOGGER.info('SQL for non-partitioned table against Hive metastore: %s', sql_stmt)
 
         sql_alchemy_extractor = SQLAlchemyExtractor()
         sql_alchemy_conf = Scoped.get_scoped_conf(self._conf, sql_alchemy_extractor.get_scope()) \
@@ -211,10 +210,10 @@ class HiveTableLastUpdatedExtractor(Extractor):
         while non_partitioned_tbl_row:
             count += 1
             if count % 10 == 0:
-                LOGGER.info('Processed {} non-partitioned tables'.format(count))
+                LOGGER.info('Processed %i non-partitioned tables', count)
 
             if not non_partitioned_tbl_row['location']:
-                LOGGER.warning('Skipping as no storage location available. {}'.format(non_partitioned_tbl_row))
+                LOGGER.warning('Skipping as no storage location available. %s', non_partitioned_tbl_row)
                 non_partitioned_tbl_row = self._non_partitioned_table_extractor.extract()
                 continue
 
@@ -223,7 +222,7 @@ class HiveTableLastUpdatedExtractor(Extractor):
                 table=non_partitioned_tbl_row['table_name'],
                 schema=non_partitioned_tbl_row['schema'],
                 storage_location=non_partitioned_tbl_row['location'])
-            LOGGER.info('Elapsed: {} seconds'.format(time.time() - start))
+            LOGGER.info(f'Elapsed: %i seconds', time.time() - start)
 
             if table_last_updated:
                 yield table_last_updated
@@ -247,41 +246,35 @@ class HiveTableLastUpdatedExtractor(Extractor):
         """
 
         if LOGGER.isEnabledFor(logging.DEBUG):
-            LOGGER.debug('Getting last updated datetime for {}.{} in {}'.format(schema, table, storage_location))
+            LOGGER.debug(f'Getting last updated datetime for {schema}.{table} in {storage_location}')
 
         last_updated = OLDEST_TIMESTAMP
 
         paths = self._ls(storage_location)
         if not paths:
-            LOGGER.info('{schema}.{table} does not have any file in path {path}. Skipping'
-                        .format(schema=schema, table=table, path=storage_location))
+            LOGGER.info(f'{schema}.{table} does not have any file in path {storage_location}. Skipping')
             return None
 
-        LOGGER.info('Fetching metadata for {schema}.{table} of {num_files} files'
-                    .format(schema=schema, table=table, num_files=len(paths)))
+        LOGGER.info(f'Fetching metadata for {schema}.{table} of {len(paths)} files')
 
-        if self._last_updated_filecheck_threshold > 0 and len(paths) > self._last_updated_filecheck_threshold:
-            LOGGER.info('Skipping {schema}.{table} due to too many files. {len_files} files exist in {location}'
-                        .format(schema=schema, table=table, len_files=len(paths), location=storage_location))
+        if 0 < self._last_updated_filecheck_threshold < len(paths):
+            LOGGER.info(f'Skipping {schema}.{table} due to too many files. '
+                        f'{len(paths)} files exist in {storage_location}')
             return None
 
         time_stamp_futures = \
-            [self._fs_worker_pool.apply_async(self._get_timestamp, (path, schema, table, storage_location)) for path in
-             paths]
+            [self._fs_worker_pool.apply_async(self._get_timestamp, (path, schema, table, storage_location))
+             for path in paths]
         for time_stamp_future in time_stamp_futures:
             try:
                 time_stamp = time_stamp_future.get(timeout=self._fs_worker_timeout)
                 if time_stamp:
                     last_updated = max(time_stamp, last_updated)
-            except Exception as e:
-                if e.__class__.__name__ == 'TimeoutError':
-                    LOGGER.warning('Timed out on paths {} . Skipping'.format(paths))
-                else:
-                    raise e
+            except TimeoutError:
+                LOGGER.warning('Timed out on paths %s . Skipping', paths)
 
         if last_updated == OLDEST_TIMESTAMP:
-            LOGGER.info('No timestamp was derived on {schema}.{table} from location: {location} . Skipping'.format(
-                schema=schema, table=table, location=storage_location))
+            LOGGER.info(f'No timestamp was derived on {schema}.{table} from location: {storage_location} . Skipping')
             return None
 
         result = TableLastUpdated(table_name=table,
@@ -317,8 +310,7 @@ class HiveTableLastUpdatedExtractor(Extractor):
         :return:
         """
         if not path:
-            LOGGER.info('Empty path {path} on {schema}.{table} in storage location {location} . Skipping'
-                        .format(path=path, schema=schema, table=table, location=storage_location))
+            LOGGER.info(f'Empty path {path} on {schema}.{table} in storage location {storage_location} . Skipping')
             return None
 
         if not self._fs.is_file(path):

--- a/databuilder/extractor/hive_table_last_updated_extractor.py
+++ b/databuilder/extractor/hive_table_last_updated_extractor.py
@@ -6,15 +6,18 @@ import time
 from datetime import datetime
 from functools import wraps
 from multiprocessing.pool import ThreadPool
-from typing import Iterator, Union, Any, List
+from typing import (
+    Any, Iterator, List, Union,
+)
+
+from pyhocon import ConfigFactory, ConfigTree
+from pytz import UTC
 
 from databuilder import Scoped
 from databuilder.extractor.base_extractor import Extractor
 from databuilder.extractor.sql_alchemy_extractor import SQLAlchemyExtractor
 from databuilder.filesystem.filesystem import FileSystem, is_client_side_error
 from databuilder.models.table_last_updated import TableLastUpdated
-from pyhocon import ConfigFactory, ConfigTree
-from pytz import UTC
 
 LOGGER = logging.getLogger(__name__)
 OLDEST_TIMESTAMP = datetime.fromtimestamp(0, UTC)

--- a/databuilder/extractor/hive_table_metadata_extractor.py
+++ b/databuilder/extractor/hive_table_metadata_extractor.py
@@ -4,15 +4,18 @@
 import logging
 from collections import namedtuple
 from itertools import groupby
-from typing import Iterator, Union, Dict, Any
+from typing import (
+    Any, Dict, Iterator, Union,
+)
+
+from pyhocon import ConfigFactory, ConfigTree
+from sqlalchemy.engine.url import make_url
 
 from databuilder import Scoped
 from databuilder.extractor.base_extractor import Extractor
 from databuilder.extractor.sql_alchemy_extractor import SQLAlchemyExtractor
 from databuilder.extractor.table_metadata_constants import PARTITION_BADGE
-from databuilder.models.table_metadata import TableMetadata, ColumnMetadata
-from pyhocon import ConfigFactory, ConfigTree
-from sqlalchemy.engine.url import make_url
+from databuilder.models.table_metadata import ColumnMetadata, TableMetadata
 
 TableKey = namedtuple('TableKey', ['schema', 'table_name'])
 

--- a/databuilder/extractor/hive_table_metadata_extractor.py
+++ b/databuilder/extractor/hive_table_metadata_extractor.py
@@ -3,18 +3,16 @@
 
 import logging
 from collections import namedtuple
-
-from pyhocon import ConfigFactory, ConfigTree
+from itertools import groupby
 from typing import Iterator, Union, Dict, Any
-from sqlalchemy.engine.url import make_url
 
 from databuilder import Scoped
-from databuilder.extractor.table_metadata_constants import PARTITION_BADGE
 from databuilder.extractor.base_extractor import Extractor
 from databuilder.extractor.sql_alchemy_extractor import SQLAlchemyExtractor
+from databuilder.extractor.table_metadata_constants import PARTITION_BADGE
 from databuilder.models.table_metadata import TableMetadata, ColumnMetadata
-from itertools import groupby
-
+from pyhocon import ConfigFactory, ConfigTree
+from sqlalchemy.engine.url import make_url
 
 TableKey = namedtuple('TableKey', ['schema', 'table_name'])
 
@@ -94,7 +92,7 @@ class HiveTableMetadataExtractor(Extractor):
 
     def init(self, conf: ConfigTree) -> None:
         conf = conf.with_fallback(HiveTableMetadataExtractor.DEFAULT_CONFIG)
-        self._cluster = '{}'.format(conf.get_string(HiveTableMetadataExtractor.CLUSTER_KEY))
+        self._cluster = conf.get_string(HiveTableMetadataExtractor.CLUSTER_KEY)
 
         self._alchemy_extractor = SQLAlchemyExtractor()
 
@@ -104,7 +102,7 @@ class HiveTableMetadataExtractor(Extractor):
 
         self.sql_stmt = conf.get_string(HiveTableMetadataExtractor.EXTRACT_SQL, default=default_sql)
 
-        LOGGER.info('SQL for hive metastore: {}'.format(self.sql_stmt))
+        LOGGER.info('SQL for hive metastore: %i', self.sql_stmt)
 
         sql_alch_conf = sql_alch_conf.with_fallback(ConfigFactory.from_dict(
             {SQLAlchemyExtractor.EXTRACT_SQL: self.sql_stmt}))

--- a/databuilder/extractor/kafka_source_extractor.py
+++ b/databuilder/extractor/kafka_source_extractor.py
@@ -1,19 +1,20 @@
 # Copyright Contributors to the Amundsen project.
 # SPDX-License-Identifier: Apache-2.0
 
-from datetime import datetime, timedelta
 import importlib
 import logging
-
-from confluent_kafka import Consumer, KafkaException, KafkaError
-from pyhocon import ConfigTree
+from datetime import datetime, timedelta
 from typing import Any
+
+from confluent_kafka import (
+    Consumer, KafkaError, KafkaException,
+)
+from pyhocon import ConfigTree
 
 from databuilder import Scoped
 from databuilder.callback.call_back import Callback
 from databuilder.extractor.base_extractor import Extractor
 from databuilder.transformer.base_transformer import Transformer
-
 
 LOGGER = logging.getLogger(__name__)
 

--- a/databuilder/extractor/mssql_metadata_extractor.py
+++ b/databuilder/extractor/mssql_metadata_extractor.py
@@ -4,13 +4,16 @@
 import logging
 from collections import namedtuple
 from itertools import groupby
-from typing import Iterator, Union, Dict, Any
+from typing import (
+    Any, Dict, Iterator, Union,
+)
+
+from pyhocon import ConfigFactory, ConfigTree
 
 from databuilder import Scoped
 from databuilder.extractor.base_extractor import Extractor
 from databuilder.extractor.sql_alchemy_extractor import SQLAlchemyExtractor
-from databuilder.models.table_metadata import TableMetadata, ColumnMetadata
-from pyhocon import ConfigFactory, ConfigTree
+from databuilder.models.table_metadata import ColumnMetadata, TableMetadata
 
 TableKey = namedtuple('TableKey', ['schema_name', 'table_name'])
 

--- a/databuilder/extractor/mssql_metadata_extractor.py
+++ b/databuilder/extractor/mssql_metadata_extractor.py
@@ -3,15 +3,14 @@
 
 import logging
 from collections import namedtuple
-
-from pyhocon import ConfigFactory, ConfigTree
+from itertools import groupby
 from typing import Iterator, Union, Dict, Any
 
 from databuilder import Scoped
 from databuilder.extractor.base_extractor import Extractor
 from databuilder.extractor.sql_alchemy_extractor import SQLAlchemyExtractor
 from databuilder.models.table_metadata import TableMetadata, ColumnMetadata
-from itertools import groupby
+from pyhocon import ConfigFactory, ConfigTree
 
 TableKey = namedtuple('TableKey', ['schema_name', 'table_name'])
 
@@ -76,13 +75,12 @@ class MSSQLMetadataExtractor(Extractor):
     def init(self, conf: ConfigTree) -> None:
         conf = conf.with_fallback(MSSQLMetadataExtractor.DEFAULT_CONFIG)
 
-        self._cluster = '{}'.format(
-            conf.get_string(MSSQLMetadataExtractor.CLUSTER_KEY))
+        self._cluster = conf.get_string(MSSQLMetadataExtractor.CLUSTER_KEY)
 
         if conf.get_bool(MSSQLMetadataExtractor.USE_CATALOG_AS_CLUSTER_NAME):
             cluster_source = "DB_NAME()"
         else:
-            cluster_source = "'{}'".format(self._cluster)
+            cluster_source = f"'{self._cluster}'"
 
         self._database = conf.get_string(
             MSSQLMetadataExtractor.DATABASE_KEY,
@@ -91,11 +89,11 @@ class MSSQLMetadataExtractor(Extractor):
         config_where_clause = conf.get_string(
             MSSQLMetadataExtractor.WHERE_CLAUSE_SUFFIX_KEY)
 
-        logging.info("Crawling for Schemas %s", config_where_clause)
+        LOGGER.info("Crawling for Schemas %s", config_where_clause)
 
-        if len(config_where_clause) > 0:
-            where_clause_suffix = MSSQLMetadataExtractor\
-                .DEFAULT_WHERE_CLAUSE_VALUE\
+        if config_where_clause:
+            where_clause_suffix = MSSQLMetadataExtractor \
+                .DEFAULT_WHERE_CLAUSE_VALUE \
                 .format(schemas=config_where_clause)
         else:
             where_clause_suffix = ''
@@ -105,15 +103,12 @@ class MSSQLMetadataExtractor(Extractor):
             cluster_source=cluster_source
         )
 
-        LOGGER.info('SQL for MS SQL Metadata: {}'.format(self.sql_stmt))
+        LOGGER.info('SQL for MS SQL Metadata: %s', self.sql_stmt)
 
         self._alchemy_extractor = SQLAlchemyExtractor()
-        sql_alch_conf = Scoped\
+        sql_alch_conf = Scoped \
             .get_scoped_conf(conf, self._alchemy_extractor.get_scope()) \
-            .with_fallback(
-                ConfigFactory.from_dict({
-                    SQLAlchemyExtractor.EXTRACT_SQL: self.sql_stmt})
-            )
+            .with_fallback(ConfigFactory.from_dict({SQLAlchemyExtractor.EXTRACT_SQL: self.sql_stmt}))
 
         self._alchemy_extractor.init(sql_alch_conf)
         self._extract_iter: Union[None, Iterator] = None

--- a/databuilder/extractor/mysql_metadata_extractor.py
+++ b/databuilder/extractor/mysql_metadata_extractor.py
@@ -3,16 +3,14 @@
 
 import logging
 from collections import namedtuple
-
-from pyhocon import ConfigFactory, ConfigTree
+from itertools import groupby
 from typing import Iterator, Union, Dict, Any
 
 from databuilder import Scoped
 from databuilder.extractor.base_extractor import Extractor
 from databuilder.extractor.sql_alchemy_extractor import SQLAlchemyExtractor
 from databuilder.models.table_metadata import TableMetadata, ColumnMetadata
-from itertools import groupby
-
+from pyhocon import ConfigFactory, ConfigTree
 
 TableKey = namedtuple('TableKey', ['schema', 'table_name'])
 
@@ -60,12 +58,12 @@ class MysqlMetadataExtractor(Extractor):
 
     def init(self, conf: ConfigTree) -> None:
         conf = conf.with_fallback(MysqlMetadataExtractor.DEFAULT_CONFIG)
-        self._cluster = '{}'.format(conf.get_string(MysqlMetadataExtractor.CLUSTER_KEY))
+        self._cluster = conf.get_string(MysqlMetadataExtractor.CLUSTER_KEY)
 
         if conf.get_bool(MysqlMetadataExtractor.USE_CATALOG_AS_CLUSTER_NAME):
             cluster_source = "c.table_catalog"
         else:
-            cluster_source = "'{}'".format(self._cluster)
+            cluster_source = f"'{self._cluster}'"
 
         self._database = conf.get_string(MysqlMetadataExtractor.DATABASE_KEY, default='mysql')
 
@@ -75,12 +73,12 @@ class MysqlMetadataExtractor(Extractor):
         )
 
         self._alchemy_extractor = SQLAlchemyExtractor()
-        sql_alch_conf = Scoped.get_scoped_conf(conf, self._alchemy_extractor.get_scope())\
+        sql_alch_conf = Scoped.get_scoped_conf(conf, self._alchemy_extractor.get_scope()) \
             .with_fallback(ConfigFactory.from_dict({SQLAlchemyExtractor.EXTRACT_SQL: self.sql_stmt}))
 
         self.sql_stmt = sql_alch_conf.get_string(SQLAlchemyExtractor.EXTRACT_SQL)
 
-        LOGGER.info('SQL for mysql metadata: {}'.format(self.sql_stmt))
+        LOGGER.info('SQL for mysql metadata: %s', self.sql_stmt)
 
         self._alchemy_extractor.init(sql_alch_conf)
         self._extract_iter: Union[None, Iterator] = None

--- a/databuilder/extractor/mysql_metadata_extractor.py
+++ b/databuilder/extractor/mysql_metadata_extractor.py
@@ -4,13 +4,16 @@
 import logging
 from collections import namedtuple
 from itertools import groupby
-from typing import Iterator, Union, Dict, Any
+from typing import (
+    Any, Dict, Iterator, Union,
+)
+
+from pyhocon import ConfigFactory, ConfigTree
 
 from databuilder import Scoped
 from databuilder.extractor.base_extractor import Extractor
 from databuilder.extractor.sql_alchemy_extractor import SQLAlchemyExtractor
-from databuilder.models.table_metadata import TableMetadata, ColumnMetadata
-from pyhocon import ConfigFactory, ConfigTree
+from databuilder.models.table_metadata import ColumnMetadata, TableMetadata
 
 TableKey = namedtuple('TableKey', ['schema', 'table_name'])
 

--- a/databuilder/extractor/neo4j_extractor.py
+++ b/databuilder/extractor/neo4j_extractor.py
@@ -3,11 +3,13 @@
 
 import importlib
 import logging
-from typing import Any, Iterator, Union
+from typing import (
+    Any, Iterator, Union,
+)
 
-from pyhocon import ConfigTree, ConfigFactory
-from neo4j import GraphDatabase
 import neo4j
+from neo4j import GraphDatabase
+from pyhocon import ConfigFactory, ConfigTree
 
 from databuilder.extractor.base_extractor import Extractor
 

--- a/databuilder/extractor/neo4j_extractor.py
+++ b/databuilder/extractor/neo4j_extractor.py
@@ -78,7 +78,7 @@ class Neo4jExtractor(Extractor):
         """
         Create an iterator to execute sql.
         """
-        LOGGER.info('Executing query {}'.format(self.cypher_query))
+        LOGGER.info('Executing query %s', self.cypher_query)
         result = tx.run(self.cypher_query)
         return result
 

--- a/databuilder/extractor/neo4j_search_data_extractor.py
+++ b/databuilder/extractor/neo4j_search_data_extractor.py
@@ -4,12 +4,11 @@
 import textwrap
 from typing import Any
 
-from pyhocon import ConfigTree
-
 from databuilder import Scoped
 from databuilder.extractor.base_extractor import Extractor
 from databuilder.extractor.neo4j_extractor import Neo4jExtractor
 from databuilder.publisher.neo4j_csv_publisher import JOB_PUBLISH_TAG
+from pyhocon import ConfigTree
 
 
 class Neo4jSearchDataExtractor(Extractor):
@@ -171,6 +170,5 @@ class Neo4jSearchDataExtractor(Extractor):
         else:
             if not hasattr(self, 'entity'):
                 self.entity = 'table'
-            publish_tag_filter = """WHERE {entity}.published_tag = '{tag}'""".format(entity=self.entity,
-                                                                                     tag=publish_tag)
+            publish_tag_filter = f"WHERE {self.entity}.published_tag = '{publish_tag}'"
         return cypher_query.format(publish_tag_filter=publish_tag_filter)

--- a/databuilder/extractor/neo4j_search_data_extractor.py
+++ b/databuilder/extractor/neo4j_search_data_extractor.py
@@ -4,11 +4,12 @@
 import textwrap
 from typing import Any
 
+from pyhocon import ConfigTree
+
 from databuilder import Scoped
 from databuilder.extractor.base_extractor import Extractor
 from databuilder.extractor.neo4j_extractor import Neo4jExtractor
 from databuilder.publisher.neo4j_csv_publisher import JOB_PUBLISH_TAG
-from pyhocon import ConfigTree
 
 
 class Neo4jSearchDataExtractor(Extractor):

--- a/databuilder/extractor/postgres_metadata_extractor.py
+++ b/databuilder/extractor/postgres_metadata_extractor.py
@@ -1,10 +1,10 @@
 # Copyright Contributors to the Amundsen project.
 # SPDX-License-Identifier: Apache-2.0
 
-from pyhocon import ConfigFactory, ConfigTree  # noqa: F401
 from typing import Iterator, Union, Dict, Any  # noqa: F401
 
 from databuilder.extractor.base_postgres_metadata_extractor import BasePostgresMetadataExtractor
+from pyhocon import ConfigFactory, ConfigTree  # noqa: F401
 
 
 class PostgresMetadataExtractor(BasePostgresMetadataExtractor):
@@ -12,12 +12,11 @@ class PostgresMetadataExtractor(BasePostgresMetadataExtractor):
     Extracts Postgres table and column metadata from underlying meta store database using SQLAlchemyExtractor
     """
 
-    def get_sql_statement(self, use_catalog_as_cluster_name, where_clause_suffix):
-        # type: (bool, str) -> str
+    def get_sql_statement(self, use_catalog_as_cluster_name: bool, where_clause_suffix: str) -> str:
         if use_catalog_as_cluster_name:
             cluster_source = "c.table_catalog"
         else:
-            cluster_source = "'{}'".format(self._cluster)
+            cluster_source = f"'{self._cluster}'"
 
         return """
         SELECT
@@ -38,6 +37,5 @@ class PostgresMetadataExtractor(BasePostgresMetadataExtractor):
             where_clause_suffix=where_clause_suffix,
         )
 
-    def get_scope(self):
-        # type: () -> str
+    def get_scope(self) -> str:
         return 'extractor.postgres_metadata'

--- a/databuilder/extractor/postgres_metadata_extractor.py
+++ b/databuilder/extractor/postgres_metadata_extractor.py
@@ -1,10 +1,13 @@
 # Copyright Contributors to the Amundsen project.
 # SPDX-License-Identifier: Apache-2.0
 
-from typing import Iterator, Union, Dict, Any  # noqa: F401
+from typing import (  # noqa: F401
+    Any, Dict, Iterator, Union,
+)
+
+from pyhocon import ConfigFactory, ConfigTree  # noqa: F401
 
 from databuilder.extractor.base_postgres_metadata_extractor import BasePostgresMetadataExtractor
-from pyhocon import ConfigFactory, ConfigTree  # noqa: F401
 
 
 class PostgresMetadataExtractor(BasePostgresMetadataExtractor):

--- a/databuilder/extractor/presto_view_metadata_extractor.py
+++ b/databuilder/extractor/presto_view_metadata_extractor.py
@@ -4,15 +4,16 @@
 import base64
 import json
 import logging
+from typing import (
+    Iterator, List, Union,
+)
 
 from pyhocon import ConfigFactory, ConfigTree
-from typing import Iterator, List, Union
 
 from databuilder import Scoped
 from databuilder.extractor.base_extractor import Extractor
 from databuilder.extractor.sql_alchemy_extractor import SQLAlchemyExtractor
-from databuilder.models.table_metadata import TableMetadata, ColumnMetadata
-
+from databuilder.models.table_metadata import ColumnMetadata, TableMetadata
 
 LOGGER = logging.getLogger(__name__)
 

--- a/databuilder/extractor/presto_view_metadata_extractor.py
+++ b/databuilder/extractor/presto_view_metadata_extractor.py
@@ -47,12 +47,12 @@ class PrestoViewMetadataExtractor(Extractor):
 
     def init(self, conf: ConfigTree) -> None:
         conf = conf.with_fallback(PrestoViewMetadataExtractor.DEFAULT_CONFIG)
-        self._cluster = '{}'.format(conf.get_string(PrestoViewMetadataExtractor.CLUSTER_KEY))
+        self._cluster = conf.get_string(PrestoViewMetadataExtractor.CLUSTER_KEY)
 
         self.sql_stmt = PrestoViewMetadataExtractor.SQL_STATEMENT.format(
             where_clause_suffix=conf.get_string(PrestoViewMetadataExtractor.WHERE_CLAUSE_SUFFIX_KEY))
 
-        LOGGER.info('SQL for hive metastore: {}'.format(self.sql_stmt))
+        LOGGER.info('SQL for hive metastore: %s', self.sql_stmt)
 
         self._alchemy_extractor = SQLAlchemyExtractor()
         sql_alch_conf = Scoped.get_scoped_conf(conf, self._alchemy_extractor.get_scope())\

--- a/databuilder/extractor/redshift_metadata_extractor.py
+++ b/databuilder/extractor/redshift_metadata_extractor.py
@@ -1,7 +1,9 @@
 # Copyright Contributors to the Amundsen project.
 # SPDX-License-Identifier: Apache-2.0
 
-from typing import Iterator, Union, Dict, Any  # noqa: F401
+from typing import (  # noqa: F401
+    Any, Dict, Iterator, Union,
+)
 
 from pyhocon import ConfigFactory, ConfigTree  # noqa: F401
 

--- a/databuilder/extractor/redshift_metadata_extractor.py
+++ b/databuilder/extractor/redshift_metadata_extractor.py
@@ -1,8 +1,9 @@
 # Copyright Contributors to the Amundsen project.
 # SPDX-License-Identifier: Apache-2.0
 
-from pyhocon import ConfigFactory, ConfigTree  # noqa: F401
 from typing import Iterator, Union, Dict, Any  # noqa: F401
+
+from pyhocon import ConfigFactory, ConfigTree  # noqa: F401
 
 from databuilder.extractor.base_postgres_metadata_extractor import BasePostgresMetadataExtractor
 
@@ -15,12 +16,11 @@ class RedshiftMetadataExtractor(BasePostgresMetadataExtractor):
     we need to join the INFORMATION_SCHEMA data against the function PG_GET_LATE_BINDING_VIEW_COLS().
     """
 
-    def get_sql_statement(self, use_catalog_as_cluster_name, where_clause_suffix):
-        # type: (bool, str) -> str
+    def get_sql_statement(self, use_catalog_as_cluster_name: bool, where_clause_suffix: str) -> str:
         if use_catalog_as_cluster_name:
             cluster_source = "CURRENT_DATABASE()"
         else:
-            cluster_source = "'{}'".format(self._cluster)
+            cluster_source = f"'{self._cluster}'"
 
         return """
         SELECT
@@ -66,6 +66,5 @@ class RedshiftMetadataExtractor(BasePostgresMetadataExtractor):
             where_clause_suffix=where_clause_suffix,
         )
 
-    def get_scope(self):
-        # type: () -> str
+    def get_scope(self) -> str:
         return 'extractor.redshift_metadata'

--- a/databuilder/extractor/restapi/rest_api_extractor.py
+++ b/databuilder/extractor/restapi/rest_api_extractor.py
@@ -33,7 +33,7 @@ class RestAPIExtractor(Extractor):
         self._restapi_query: BaseRestApiQuery = conf.get(REST_API_QUERY)
         self._iterator: Optional[Iterator[Dict[str, Any]]] = None
         self._static_dict = conf.get(STATIC_RECORD_DICT, dict())
-        LOGGER.info('static record: {}'.format(self._static_dict))
+        LOGGER.info('static record: %s', self._static_dict)
 
         model_class = conf.get(MODEL_CLASS, None)
         if model_class:

--- a/databuilder/extractor/restapi/rest_api_extractor.py
+++ b/databuilder/extractor/restapi/rest_api_extractor.py
@@ -1,15 +1,16 @@
 # Copyright Contributors to the Amundsen project.
 # SPDX-License-Identifier: Apache-2.0
 
-import logging
 import importlib
-from typing import Any, Iterator, Dict, Optional
+import logging
+from typing import (
+    Any, Dict, Iterator, Optional,
+)
 
 from pyhocon import ConfigTree
 
 from databuilder.extractor.base_extractor import Extractor
 from databuilder.rest_api.base_rest_api_query import BaseRestApiQuery
-
 
 REST_API_QUERY = 'restapi_query'
 MODEL_CLASS = 'model_class'

--- a/databuilder/extractor/snowflake_metadata_extractor.py
+++ b/databuilder/extractor/snowflake_metadata_extractor.py
@@ -4,17 +4,15 @@
 
 import logging
 from collections import namedtuple
-
-from pyhocon import ConfigFactory, ConfigTree
+from itertools import groupby
 from typing import Iterator, Union, Dict, Any
-from unidecode import unidecode
 
 from databuilder import Scoped
 from databuilder.extractor.base_extractor import Extractor
 from databuilder.extractor.sql_alchemy_extractor import SQLAlchemyExtractor
 from databuilder.models.table_metadata import TableMetadata, ColumnMetadata
-from itertools import groupby
-
+from pyhocon import ConfigFactory, ConfigTree
+from unidecode import unidecode
 
 TableKey = namedtuple('TableKey', ['schema', 'table_name'])
 
@@ -77,12 +75,12 @@ class SnowflakeMetadataExtractor(Extractor):
 
     def init(self, conf: ConfigTree) -> None:
         conf = conf.with_fallback(SnowflakeMetadataExtractor.DEFAULT_CONFIG)
-        self._cluster = '{}'.format(conf.get_string(SnowflakeMetadataExtractor.CLUSTER_KEY))
+        self._cluster = conf.get_string(SnowflakeMetadataExtractor.CLUSTER_KEY)
 
         if conf.get_bool(SnowflakeMetadataExtractor.USE_CATALOG_AS_CLUSTER_NAME):
             cluster_source = "c.table_catalog"
         else:
-            cluster_source = "'{}'".format(self._cluster)
+            cluster_source = f"'{self._cluster}'"
 
         self._database = conf.get_string(SnowflakeMetadataExtractor.DATABASE_KEY)
         self._schema = conf.get_string(SnowflakeMetadataExtractor.DATABASE_KEY)
@@ -96,10 +94,10 @@ class SnowflakeMetadataExtractor(Extractor):
             schema=self._snowflake_schema
         )
 
-        LOGGER.info('SQL for snowflake metadata: {}'.format(self.sql_stmt))
+        LOGGER.info('SQL for snowflake metadata: %s', self.sql_stmt)
 
         self._alchemy_extractor = SQLAlchemyExtractor()
-        sql_alch_conf = Scoped.get_scoped_conf(conf, self._alchemy_extractor.get_scope())\
+        sql_alch_conf = Scoped.get_scoped_conf(conf, self._alchemy_extractor.get_scope()) \
             .with_fallback(ConfigFactory.from_dict({SQLAlchemyExtractor.EXTRACT_SQL: self.sql_stmt}))
 
         self._alchemy_extractor.init(sql_alch_conf)
@@ -127,11 +125,11 @@ class SnowflakeMetadataExtractor(Extractor):
             for row in group:
                 last_row = row
                 columns.append(ColumnMetadata(
-                               row['col_name'],
-                               unidecode(row['col_description']) if row['col_description'] else None,
-                               row['col_type'],
-                               row['col_sort_order'])
-                               )
+                    row['col_name'],
+                    unidecode(row['col_description']) if row['col_description'] else None,
+                    row['col_type'],
+                    row['col_sort_order'])
+                )
 
             yield TableMetadata(self._database, last_row['cluster'],
                                 last_row['schema'],

--- a/databuilder/extractor/snowflake_metadata_extractor.py
+++ b/databuilder/extractor/snowflake_metadata_extractor.py
@@ -5,14 +5,17 @@
 import logging
 from collections import namedtuple
 from itertools import groupby
-from typing import Iterator, Union, Dict, Any
+from typing import (
+    Any, Dict, Iterator, Union,
+)
+
+from pyhocon import ConfigFactory, ConfigTree
+from unidecode import unidecode
 
 from databuilder import Scoped
 from databuilder.extractor.base_extractor import Extractor
 from databuilder.extractor.sql_alchemy_extractor import SQLAlchemyExtractor
-from databuilder.models.table_metadata import TableMetadata, ColumnMetadata
-from pyhocon import ConfigFactory, ConfigTree
-from unidecode import unidecode
+from databuilder.models.table_metadata import ColumnMetadata, TableMetadata
 
 TableKey = namedtuple('TableKey', ['schema', 'table_name'])
 

--- a/databuilder/extractor/snowflake_table_last_updated_extractor.py
+++ b/databuilder/extractor/snowflake_table_last_updated_extractor.py
@@ -4,11 +4,12 @@
 import logging
 from typing import Iterator, Union
 
+from pyhocon import ConfigFactory, ConfigTree
+
 from databuilder import Scoped
 from databuilder.extractor.base_extractor import Extractor
 from databuilder.extractor.sql_alchemy_extractor import SQLAlchemyExtractor
 from databuilder.models.table_last_updated import TableLastUpdated
-from pyhocon import ConfigFactory, ConfigTree
 
 LOGGER = logging.getLogger(__name__)
 

--- a/databuilder/extractor/snowflake_table_last_updated_extractor.py
+++ b/databuilder/extractor/snowflake_table_last_updated_extractor.py
@@ -2,14 +2,13 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import logging
-
-from pyhocon import ConfigFactory, ConfigTree
 from typing import Iterator, Union
 
 from databuilder import Scoped
 from databuilder.extractor.base_extractor import Extractor
 from databuilder.extractor.sql_alchemy_extractor import SQLAlchemyExtractor
 from databuilder.models.table_last_updated import TableLastUpdated
+from pyhocon import ConfigFactory, ConfigTree
 
 LOGGER = logging.getLogger(__name__)
 
@@ -57,11 +56,12 @@ class SnowflakeTableLastUpdatedExtractor(Extractor):
 
     def init(self, conf: ConfigTree) -> None:
         conf = conf.with_fallback(SnowflakeTableLastUpdatedExtractor.DEFAULT_CONFIG)
+        self._cluster = conf.get_string(SnowflakeTableLastUpdatedExtractor.CLUSTER_KEY)
 
         if conf.get_bool(SnowflakeTableLastUpdatedExtractor.USE_CATALOG_AS_CLUSTER_NAME):
             cluster_source = "t.table_catalog"
         else:
-            cluster_source = "'{}'".format(conf.get_string(SnowflakeTableLastUpdatedExtractor.CLUSTER_KEY))
+            cluster_source = f"'{self._cluster}'"
 
         self._database = conf.get_string(SnowflakeTableLastUpdatedExtractor.DATABASE_KEY)
         self._snowflake_database = conf.get_string(SnowflakeTableLastUpdatedExtractor.SNOWFLAKE_DATABASE_KEY)
@@ -72,7 +72,7 @@ class SnowflakeTableLastUpdatedExtractor(Extractor):
             database=self._snowflake_database
         )
 
-        LOGGER.info('SQL for snowflake table last updated timestamp: {}'.format(self.sql_stmt))
+        LOGGER.info('SQL for snowflake table last updated timestamp: %s', self.sql_stmt)
 
         # use an sql_alchemy_extractor to execute sql
         self._alchemy_extractor = SQLAlchemyExtractor()

--- a/databuilder/extractor/sql_alchemy_extractor.py
+++ b/databuilder/extractor/sql_alchemy_extractor.py
@@ -2,10 +2,10 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import importlib
-from sqlalchemy import create_engine
+from typing import Any
 
 from pyhocon import ConfigTree
-from typing import Any
+from sqlalchemy import create_engine
 
 from databuilder.extractor.base_extractor import Extractor
 

--- a/databuilder/extractor/user/bamboohr/bamboohr_user_extractor.py
+++ b/databuilder/extractor/user/bamboohr/bamboohr_user_extractor.py
@@ -2,11 +2,12 @@
 # SPDX-License-Identifier: Apache-2.0
 
 
-from pyhocon import ConfigTree
-import requests
-from requests.auth import HTTPBasicAuth
 from typing import Iterator, Optional
 from xml.etree import ElementTree
+
+import requests
+from pyhocon import ConfigTree
+from requests.auth import HTTPBasicAuth
 
 from databuilder.extractor.base_extractor import Extractor
 from databuilder.models.user import User
@@ -32,9 +33,7 @@ class BamboohrUserExtractor(Extractor):
             return None
 
     def _employee_directory_uri(self) -> str:
-        return 'https://api.bamboohr.com/api/gateway.php/{subdomain}/v1/employees/directory'.format(
-            subdomain=self._subdomain
-        )
+        return f'https://api.bamboohr.com/api/gateway.php/{self._subdomain}/v1/employees/directory'
 
     def _get_extract_iter(self) -> Iterator[User]:
         response = requests.get(
@@ -46,7 +45,7 @@ class BamboohrUserExtractor(Extractor):
         for user in root.findall('./employees/employee'):
 
             def get_field(name: str) -> str:
-                field = user.find('./field[@id=\'{name}\']'.format(name=name))
+                field = user.find(f"./field[@id='{name}']")
                 if field is not None and field.text is not None:
                     return field.text
                 else:

--- a/databuilder/filesystem/filesystem.py
+++ b/databuilder/filesystem/filesystem.py
@@ -2,10 +2,10 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import logging
+from typing import List
 
 from pyhocon import ConfigFactory, ConfigTree
 from retrying import retry
-from typing import List
 
 from databuilder import Scoped
 from databuilder.filesystem.metadata import FileMetadata

--- a/databuilder/filesystem/metadata.py
+++ b/databuilder/filesystem/metadata.py
@@ -16,5 +16,4 @@ class FileMetadata(object):
         self.size = size
 
     def __repr__(self) -> str:
-        return """FileMetadata(path={!r}, last_updated={!r}, size={!r})""" \
-            .format(self.path, self.last_updated, self.size)
+        return f'FileMetadata(path={self.path!r}, last_updated={self.last_updated!r}, size={self.size!r})'

--- a/databuilder/job/job.py
+++ b/databuilder/job/job.py
@@ -39,8 +39,8 @@ class DefaultJob(Job):
         self.scoped_conf = Scoped.get_scoped_conf(self.conf,
                                                   self.get_scope())
         if self.scoped_conf.get_bool(DefaultJob.IS_STATSD_ENABLED, False):
-            prefix = 'amundsen.databuilder.job.{}'.format(self.scoped_conf.get_string(DefaultJob.JOB_IDENTIFIER))
-            LOGGER.info('Setting statsd for job metrics with prefix: {}'.format(prefix))
+            prefix = f'amundsen.databuilder.job.{self.scoped_conf.get_string(DefaultJob.JOB_IDENTIFIER)}'
+            LOGGER.info('Setting statsd for job metrics with prefix: %s', prefix)
             self.statsd = StatsClient(prefix=prefix)
         else:
             self.statsd = None

--- a/databuilder/job/job.py
+++ b/databuilder/job/job.py
@@ -8,8 +8,7 @@ from statsd import StatsClient
 
 from databuilder import Scoped
 from databuilder.job.base_job import Job
-from databuilder.publisher.base_publisher import NoopPublisher
-from databuilder.publisher.base_publisher import Publisher
+from databuilder.publisher.base_publisher import NoopPublisher, Publisher
 from databuilder.task.base_task import Task
 
 LOGGER = logging.getLogger(__name__)

--- a/databuilder/loader/base_loader.py
+++ b/databuilder/loader/base_loader.py
@@ -2,11 +2,11 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import abc
+from typing import Any
 
 from pyhocon import ConfigTree
 
 from databuilder import Scoped
-from typing import Any
 
 
 class Loader(Scoped):

--- a/databuilder/loader/file_system_csv_loader.py
+++ b/databuilder/loader/file_system_csv_loader.py
@@ -3,11 +3,12 @@
 
 import csv
 import logging
-
-from pyhocon import ConfigTree
 from typing import Any
 
 from databuilder.loader.base_loader import Loader
+from pyhocon import ConfigTree
+
+LOGGER = logging.getLogger(__name__)
 
 
 class FileSystemCSVLoader(Loader):
@@ -52,8 +53,7 @@ class FileSystemCSVLoader(Loader):
             if self.file_handler:
                 self.file_handler.close()
         except Exception as e:
-            logging.warning("Failed trying to close a file handler! %s",
-                            str(e))
+            LOGGER.warning("Failed trying to close a file handler! %s", e)
 
     def get_scope(self) -> str:
         return "loader.filesystem.csv"

--- a/databuilder/loader/file_system_csv_loader.py
+++ b/databuilder/loader/file_system_csv_loader.py
@@ -5,8 +5,9 @@ import csv
 import logging
 from typing import Any
 
-from databuilder.loader.base_loader import Loader
 from pyhocon import ConfigTree
+
+from databuilder.loader.base_loader import Loader
 
 LOGGER = logging.getLogger(__name__)
 

--- a/databuilder/loader/file_system_neo4j_csv_loader.py
+++ b/databuilder/loader/file_system_neo4j_csv_loader.py
@@ -72,19 +72,19 @@ class FsNeo4jCSVLoader(Loader):
         """
         if os.path.exists(path):
             if self._force_create_dir:
-                LOGGER.info('Directory exist. Deleting directory {}'.format(path))
+                LOGGER.info('Directory exist. Deleting directory %s', path)
                 shutil.rmtree(path)
             else:
-                raise RuntimeError('Directory should not exist: {}'.format(path))
+                raise RuntimeError(f'Directory should not exist: {path}')
 
         os.makedirs(path)
 
         def _delete_dir() -> None:
             if not self._delete_created_dir:
-                LOGGER.warn('Skip Deleting directory {}'.format(path))
+                LOGGER.warning('Skip Deleting directory %s', path)
                 return
 
-            LOGGER.info('Deleting directory {}'.format(path))
+            LOGGER.info('Deleting directory %s', path)
             shutil.rmtree(path)
 
         # Directory should be deleted after publish is finished
@@ -128,7 +128,7 @@ class FsNeo4jCSVLoader(Loader):
                     relation.type,
                     self._make_key(relation_dict))
 
-            file_suffix = '{}_{}_{}'.format(key2[0], key2[1], key2[2])
+            file_suffix = f'{key2[0]}_{key2[1]}_{key2[2]}'
             relation_writer = self._get_writer(relation_dict,
                                                self._relation_file_mapping,
                                                key2,
@@ -159,14 +159,14 @@ class FsNeo4jCSVLoader(Loader):
         if writer:
             return writer
 
-        LOGGER.info('Creating file for {}'.format(key))
+        LOGGER.info('Creating file for %s', key)
 
-        file_out = open('{}/{}.csv'.format(dir_path, file_suffix), 'w', encoding='utf8')
+        file_out = open(f'{dir_path}/{file_suffix}.csv', 'w', encoding='utf8')
         writer = csv.DictWriter(file_out, fieldnames=csv_record_dict.keys(),
                                 quoting=csv.QUOTE_NONNUMERIC)
 
         def file_out_close() -> None:
-            LOGGER.info('Closing file IO {}'.format(file_out))
+            LOGGER.info('Closing file IO %s', file_out)
             file_out.close()
         self._closer.register(file_out_close)
 

--- a/databuilder/loader/file_system_neo4j_csv_loader.py
+++ b/databuilder/loader/file_system_neo4j_csv_loader.py
@@ -6,16 +6,17 @@ import logging
 import os
 import shutil
 from csv import DictWriter
+from typing import (
+    Any, Dict, FrozenSet,
+)
 
-from pyhocon import ConfigTree, ConfigFactory
-from typing import Dict, Any, FrozenSet
+from pyhocon import ConfigFactory, ConfigTree
 
 from databuilder.job.base_job import Job
 from databuilder.loader.base_loader import Loader
 from databuilder.models.graph_serializable import GraphSerializable
-from databuilder.utils.closer import Closer
 from databuilder.serializers import neo4_serializer
-
+from databuilder.utils.closer import Closer
 
 LOGGER = logging.getLogger(__name__)
 

--- a/databuilder/loader/generic_loader.py
+++ b/databuilder/loader/generic_loader.py
@@ -2,9 +2,9 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import logging
+from typing import Any, Optional
 
 from pyhocon import ConfigTree
-from typing import Optional, Any
 
 from databuilder.loader.base_loader import Loader
 

--- a/databuilder/loader/generic_loader.py
+++ b/databuilder/loader/generic_loader.py
@@ -19,7 +19,7 @@ def log_call_back(record: Optional[Any]) -> None:
     :param record:
     :return:
     """
-    LOGGER.info('record: {}'.format(record))
+    LOGGER.info('record: %s', record)
 
 
 class GenericLoader(Loader):

--- a/databuilder/models/application.py
+++ b/databuilder/models/application.py
@@ -3,11 +3,10 @@
 
 from typing import List, Union
 
-from databuilder.models.graph_serializable import GraphSerializable
-
-from databuilder.models.table_metadata import TableMetadata
 from databuilder.models.graph_node import GraphNode
 from databuilder.models.graph_relationship import GraphRelationship
+from databuilder.models.graph_serializable import GraphSerializable
+from databuilder.models.table_metadata import TableMetadata
 
 
 class Application(GraphSerializable):

--- a/databuilder/models/badge.py
+++ b/databuilder/models/badge.py
@@ -1,12 +1,12 @@
 # Copyright Contributors to the Amundsen project.
 # SPDX-License-Identifier: Apache-2.0
 
-from typing import List, Optional
 import re
+from typing import List, Optional
 
-from databuilder.models.graph_serializable import GraphSerializable
 from databuilder.models.graph_node import GraphNode
 from databuilder.models.graph_relationship import GraphRelationship
+from databuilder.models.graph_serializable import GraphSerializable
 
 
 class Badge:
@@ -15,8 +15,7 @@ class Badge:
         self.category = category
 
     def __repr__(self) -> str:
-        return 'Badge({!r}, {!r})'.format(self.name,
-                                          self.category)
+        return f'Badge({self.name!r}, {self.category!r})'
 
 
 class BadgeMetadata(GraphSerializable):
@@ -59,8 +58,7 @@ class BadgeMetadata(GraphSerializable):
         self._relation_iter = iter(self.create_relation())
 
     def __repr__(self) -> str:
-        return 'BadgeMetadata({!r}, {!r})'.format(self.start_label,
-                                                  self.start_key)
+        return f'BadgeMetadata({self.start_label!r}, {self.start_key!r})'
 
     def create_next_node(self) -> Optional[GraphNode]:
         # return the string representation of the data

--- a/databuilder/models/column_usage_model.py
+++ b/databuilder/models/column_usage_model.py
@@ -1,14 +1,16 @@
 # Copyright Contributors to the Amundsen project.
 # SPDX-License-Identifier: Apache-2.0
 
-from typing import Union, Iterable, List
+from typing import (
+    Iterable, List, Union,
+)
 
 from databuilder.models.graph_node import GraphNode
 from databuilder.models.graph_relationship import GraphRelationship
 from databuilder.models.graph_serializable import GraphSerializable
 from databuilder.models.table_metadata import TableMetadata
 from databuilder.models.usage.usage_constants import (
-    READ_RELATION_TYPE, READ_REVERSE_RELATION_TYPE, READ_RELATION_COUNT_PROPERTY
+    READ_RELATION_COUNT_PROPERTY, READ_RELATION_TYPE, READ_REVERSE_RELATION_TYPE,
 )
 from databuilder.models.user import User
 

--- a/databuilder/models/column_usage_model.py
+++ b/databuilder/models/column_usage_model.py
@@ -3,18 +3,17 @@
 
 from typing import Union, Iterable, List
 
+from databuilder.models.graph_node import GraphNode
+from databuilder.models.graph_relationship import GraphRelationship
 from databuilder.models.graph_serializable import GraphSerializable
+from databuilder.models.table_metadata import TableMetadata
 from databuilder.models.usage.usage_constants import (
     READ_RELATION_TYPE, READ_REVERSE_RELATION_TYPE, READ_RELATION_COUNT_PROPERTY
 )
-from databuilder.models.table_metadata import TableMetadata
 from databuilder.models.user import User
-from databuilder.models.graph_node import GraphNode
-from databuilder.models.graph_relationship import GraphRelationship
 
 
 class ColumnUsageModel(GraphSerializable):
-
     """
     A model represents user <--> column graph model
     Currently it only support to serialize to table level
@@ -93,10 +92,5 @@ class ColumnUsageModel(GraphSerializable):
         return User.get_user_model_key(email=email)
 
     def __repr__(self) -> str:
-        return 'TableColumnUsage({!r}, {!r}, {!r}, {!r}, {!r}, {!r}, {!r})'.format(self.database,
-                                                                                   self.cluster,
-                                                                                   self.schema,
-                                                                                   self.table_name,
-                                                                                   self.column_name,
-                                                                                   self.user_email,
-                                                                                   self.read_count)
+        return f'TableColumnUsage({self.database!r}, {self.cluster!r}, {self.schema!r}, ' \
+               f'{self.table_name!r}, {self.column_name!r}, {self.user_email!r}, {self.read_count!r})'

--- a/databuilder/models/dashboard/dashboard_chart.py
+++ b/databuilder/models/dashboard/dashboard_chart.py
@@ -4,13 +4,11 @@
 import logging
 from typing import Optional, Any, Union, Iterator
 
-
 from databuilder.models.dashboard.dashboard_query import DashboardQuery
-from databuilder.models.graph_serializable import (
-    GraphSerializable)
-
 from databuilder.models.graph_node import GraphNode
 from databuilder.models.graph_relationship import GraphRelationship
+from databuilder.models.graph_serializable import (
+    GraphSerializable)
 
 LOGGER = logging.getLogger(__name__)
 
@@ -111,14 +109,6 @@ class DashboardChart(GraphSerializable):
         )
 
     def __repr__(self) -> str:
-        return 'DashboardChart({!r}, {!r}, {!r}, {!r}, {!r}, {!r}, {!r}, {!r}, {!r})'.format(
-            self._dashboard_group_id,
-            self._dashboard_id,
-            self._query_id,
-            self._chart_id,
-            self._chart_name,
-            self._chart_type,
-            self._chart_url,
-            self._product,
-            self._cluster
-        )
+        return f'DashboardChart({self._dashboard_group_id!r}, {self._dashboard_id!r}, ' \
+               f'{self._query_id!r}, {self._chart_id!r}, {self._chart_name!r}, {self._chart_type!r}, ' \
+               f'{self._chart_url!r}, {self._product!r}, {self._cluster!r})'

--- a/databuilder/models/dashboard/dashboard_chart.py
+++ b/databuilder/models/dashboard/dashboard_chart.py
@@ -2,13 +2,14 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import logging
-from typing import Optional, Any, Union, Iterator
+from typing import (
+    Any, Iterator, Optional, Union,
+)
 
 from databuilder.models.dashboard.dashboard_query import DashboardQuery
 from databuilder.models.graph_node import GraphNode
 from databuilder.models.graph_relationship import GraphRelationship
-from databuilder.models.graph_serializable import (
-    GraphSerializable)
+from databuilder.models.graph_serializable import GraphSerializable
 
 LOGGER = logging.getLogger(__name__)
 

--- a/databuilder/models/dashboard/dashboard_execution.py
+++ b/databuilder/models/dashboard/dashboard_execution.py
@@ -2,12 +2,14 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import logging
-from typing import Optional, Any, Union, Iterator
+from typing import (
+    Any, Iterator, Optional, Union,
+)
 
 from databuilder.models.dashboard.dashboard_metadata import DashboardMetadata
 from databuilder.models.graph_node import GraphNode
 from databuilder.models.graph_relationship import GraphRelationship
-from databuilder.models.graph_serializable import (GraphSerializable)
+from databuilder.models.graph_serializable import GraphSerializable
 
 LOGGER = logging.getLogger(__name__)
 

--- a/databuilder/models/dashboard/dashboard_execution.py
+++ b/databuilder/models/dashboard/dashboard_execution.py
@@ -2,14 +2,12 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import logging
-
 from typing import Optional, Any, Union, Iterator
 
 from databuilder.models.dashboard.dashboard_metadata import DashboardMetadata
-from databuilder.models.graph_serializable import (GraphSerializable)
-
 from databuilder.models.graph_node import GraphNode
 from databuilder.models.graph_relationship import GraphRelationship
+from databuilder.models.graph_serializable import (GraphSerializable)
 
 LOGGER = logging.getLogger(__name__)
 
@@ -97,12 +95,6 @@ class DashboardExecution(GraphSerializable):
         )
 
     def __repr__(self) -> str:
-        return 'DashboardExecution({!r}, {!r}, {!r}, {!r}, {!r}, {!r}, {!r})'.format(
-            self._dashboard_group_id,
-            self._dashboard_id,
-            self._execution_timestamp,
-            self._execution_state,
-            self._execution_id,
-            self._product,
-            self._cluster
-        )
+        return f'DashboardExecution({self._dashboard_group_id!r}, {self._dashboard_id!r}, ' \
+               f'{self._execution_timestamp!r}, {self._execution_state!r}, ' \
+               f'{self._execution_id!r}, {self._product!r}, {self._cluster!r})'

--- a/databuilder/models/dashboard/dashboard_last_modified.py
+++ b/databuilder/models/dashboard/dashboard_last_modified.py
@@ -2,13 +2,14 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import logging
-from typing import Optional, Any, Union, Iterator
+from typing import (
+    Any, Iterator, Optional, Union,
+)
 
 from databuilder.models.dashboard.dashboard_metadata import DashboardMetadata
 from databuilder.models.graph_node import GraphNode
 from databuilder.models.graph_relationship import GraphRelationship
-from databuilder.models.graph_serializable import (
-    GraphSerializable)
+from databuilder.models.graph_serializable import GraphSerializable
 from databuilder.models.timestamp import timestamp_constants
 
 LOGGER = logging.getLogger(__name__)

--- a/databuilder/models/dashboard/dashboard_last_modified.py
+++ b/databuilder/models/dashboard/dashboard_last_modified.py
@@ -2,16 +2,14 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import logging
-
 from typing import Optional, Any, Union, Iterator
 
 from databuilder.models.dashboard.dashboard_metadata import DashboardMetadata
+from databuilder.models.graph_node import GraphNode
+from databuilder.models.graph_relationship import GraphRelationship
 from databuilder.models.graph_serializable import (
     GraphSerializable)
 from databuilder.models.timestamp import timestamp_constants
-
-from databuilder.models.graph_node import GraphNode
-from databuilder.models.graph_relationship import GraphRelationship
 
 LOGGER = logging.getLogger(__name__)
 
@@ -90,10 +88,5 @@ class DashboardLastModifiedTimestamp(GraphSerializable):
         )
 
     def __repr__(self) -> str:
-        return 'DashboardLastModifiedTimestamp({!r}, {!r}, {!r}, {!r}, {!r})'.format(
-            self._dashboard_group_id,
-            self._dashboard_id,
-            self._last_modified_timestamp,
-            self._product,
-            self._cluster
-        )
+        return f'DashboardLastModifiedTimestamp({self._dashboard_group_id!r}, {self._dashboard_id!r}, ' \
+               f'{self._last_modified_timestamp!r}, {self._product!r}, {self._cluster!r})'

--- a/databuilder/models/dashboard/dashboard_metadata.py
+++ b/databuilder/models/dashboard/dashboard_metadata.py
@@ -4,14 +4,13 @@
 from typing import Any, Iterator, List, Optional, Set, Union, Dict
 
 from databuilder.models.cluster import cluster_constants
+from databuilder.models.graph_node import GraphNode
+from databuilder.models.graph_relationship import GraphRelationship
 from databuilder.models.graph_serializable import (
     GraphSerializable
 )
 # TODO: We could separate TagMetadata from table_metadata to own module
 from databuilder.models.table_metadata import TagMetadata
-
-from databuilder.models.graph_node import GraphNode
-from databuilder.models.graph_relationship import GraphRelationship
 
 
 class DashboardMetadata(GraphSerializable):
@@ -91,18 +90,10 @@ class DashboardMetadata(GraphSerializable):
         self._relation_iterator = self._create_next_relation()
 
     def __repr__(self) -> str:
-        return 'DashboardMetadata({!r}, {!r}, {!r}, {!r}, {!r}, {!r}, {!r}, {!r}, {!r}, {!r})' \
-            .format(self.dashboard_group,
-                    self.dashboard_name,
-                    self.description,
-                    self.tags,
-                    self.dashboard_group_id,
-                    self.dashboard_id,
-                    self.dashboard_group_description,
-                    self.created_timestamp,
-                    self.dashboard_group_url,
-                    self.dashboard_url,
-                    )
+        return f'DashboardMetadata(' \
+               f'{self.dashboard_group!r}, {self.dashboard_name!r}, {self.description!r}, {self.tags!r}, ' \
+               f'{self.dashboard_group_id!r}, {self.dashboard_id!r}, {self.dashboard_group_description!r}, ' \
+               f'{self.created_timestamp!r}, {self.dashboard_group_url!r}, {self.dashboard_url!r})'
 
     def _get_cluster_key(self) -> str:
         return DashboardMetadata.CLUSTER_KEY_FORMAT.format(cluster=self.cluster,

--- a/databuilder/models/dashboard/dashboard_metadata.py
+++ b/databuilder/models/dashboard/dashboard_metadata.py
@@ -1,14 +1,14 @@
 # Copyright Contributors to the Amundsen project.
 # SPDX-License-Identifier: Apache-2.0
 
-from typing import Any, Iterator, List, Optional, Set, Union, Dict
+from typing import (
+    Any, Dict, Iterator, List, Optional, Set, Union,
+)
 
 from databuilder.models.cluster import cluster_constants
 from databuilder.models.graph_node import GraphNode
 from databuilder.models.graph_relationship import GraphRelationship
-from databuilder.models.graph_serializable import (
-    GraphSerializable
-)
+from databuilder.models.graph_serializable import GraphSerializable
 # TODO: We could separate TagMetadata from table_metadata to own module
 from databuilder.models.table_metadata import TagMetadata
 

--- a/databuilder/models/dashboard/dashboard_owner.py
+++ b/databuilder/models/dashboard/dashboard_owner.py
@@ -70,10 +70,5 @@ class DashboardOwner(GraphSerializable):
         yield relationship
 
     def __repr__(self) -> str:
-        return 'DashboardOwner({!r}, {!r}, {!r}, {!r}, {!r})'.format(
-            self._dashboard_group_id,
-            self._dashboard_id,
-            self._email,
-            self._product,
-            self._cluster
-        )
+        return f'DashboardOwner({self._dashboard_group_id!r}, {self._dashboard_id!r}, ' \
+               f'{self._email!r}, {self._product!r}, {self._cluster!r})'

--- a/databuilder/models/dashboard/dashboard_owner.py
+++ b/databuilder/models/dashboard/dashboard_owner.py
@@ -2,17 +2,16 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import logging
-
-from typing import Optional, Any, Union, Iterator
+from typing import (
+    Any, Iterator, Optional, Union,
+)
 
 from databuilder.models.dashboard.dashboard_metadata import DashboardMetadata
-from databuilder.models.graph_serializable import (
-    GraphSerializable)
-from databuilder.models.owner_constants import OWNER_OF_OBJECT_RELATION_TYPE, OWNER_RELATION_TYPE
-from databuilder.models.user import User
-
 from databuilder.models.graph_node import GraphNode
 from databuilder.models.graph_relationship import GraphRelationship
+from databuilder.models.graph_serializable import GraphSerializable
+from databuilder.models.owner_constants import OWNER_OF_OBJECT_RELATION_TYPE, OWNER_RELATION_TYPE
+from databuilder.models.user import User
 
 LOGGER = logging.getLogger(__name__)
 

--- a/databuilder/models/dashboard/dashboard_query.py
+++ b/databuilder/models/dashboard/dashboard_query.py
@@ -2,15 +2,13 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import logging
-
 from typing import Optional, Any, Union, Iterator
 
 from databuilder.models.dashboard.dashboard_metadata import DashboardMetadata
-from databuilder.models.graph_serializable import (
-    GraphSerializable)
-
 from databuilder.models.graph_node import GraphNode
 from databuilder.models.graph_relationship import GraphRelationship
+from databuilder.models.graph_serializable import (
+    GraphSerializable)
 
 LOGGER = logging.getLogger(__name__)
 
@@ -106,13 +104,5 @@ class DashboardQuery(GraphSerializable):
         )
 
     def __repr__(self) -> str:
-        return 'DashboardQuery({!r}, {!r}, {!r}, {!r}, {!r}, {!r}, {!r}, {!r})'.format(
-            self._dashboard_group_id,
-            self._dashboard_id,
-            self._query_name,
-            self._query_id,
-            self._url,
-            self._query_text,
-            self._product,
-            self._cluster
-        )
+        return f'DashboardQuery({self._dashboard_group_id!r}, {self._dashboard_id!r}, {self._query_name!r}, ' \
+               f'{self._query_id!r}, {self._url!r}, {self._query_text!r}, {self._product!r}, {self._cluster!r})'

--- a/databuilder/models/dashboard/dashboard_query.py
+++ b/databuilder/models/dashboard/dashboard_query.py
@@ -2,13 +2,14 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import logging
-from typing import Optional, Any, Union, Iterator
+from typing import (
+    Any, Iterator, Optional, Union,
+)
 
 from databuilder.models.dashboard.dashboard_metadata import DashboardMetadata
 from databuilder.models.graph_node import GraphNode
 from databuilder.models.graph_relationship import GraphRelationship
-from databuilder.models.graph_serializable import (
-    GraphSerializable)
+from databuilder.models.graph_serializable import GraphSerializable
 
 LOGGER = logging.getLogger(__name__)
 

--- a/databuilder/models/dashboard/dashboard_table.py
+++ b/databuilder/models/dashboard/dashboard_table.py
@@ -3,13 +3,14 @@
 
 import logging
 import re
-from typing import Optional, Any, List, Union, Iterator
+from typing import (
+    Any, Iterator, List, Optional, Union,
+)
 
 from databuilder.models.dashboard.dashboard_metadata import DashboardMetadata
 from databuilder.models.graph_node import GraphNode
 from databuilder.models.graph_relationship import GraphRelationship
-from databuilder.models.graph_serializable import (
-    GraphSerializable)
+from databuilder.models.graph_serializable import GraphSerializable
 from databuilder.models.table_metadata import TableMetadata
 
 LOGGER = logging.getLogger(__name__)

--- a/databuilder/models/dashboard/dashboard_table.py
+++ b/databuilder/models/dashboard/dashboard_table.py
@@ -3,15 +3,14 @@
 
 import logging
 import re
-
 from typing import Optional, Any, List, Union, Iterator
 
 from databuilder.models.dashboard.dashboard_metadata import DashboardMetadata
+from databuilder.models.graph_node import GraphNode
+from databuilder.models.graph_relationship import GraphRelationship
 from databuilder.models.graph_serializable import (
     GraphSerializable)
 from databuilder.models.table_metadata import TableMetadata
-from databuilder.models.graph_node import GraphNode
-from databuilder.models.graph_relationship import GraphRelationship
 
 LOGGER = logging.getLogger(__name__)
 
@@ -56,7 +55,7 @@ class DashboardTable(GraphSerializable):
 
     def _create_relation_iterator(self) -> Iterator[GraphRelationship]:
         for table_id in self._table_ids:
-            m = re.match('([^./]+)://([^./]+)\.([^./]+)\/([^./]+)', table_id)
+            m = re.match(r'([^./]+)://([^./]+)\.([^./]+)\/([^./]+)', table_id)
             if m:
                 relationship = GraphRelationship(
                     start_label=DashboardMetadata.DASHBOARD_NODE_LABEL,
@@ -80,10 +79,5 @@ class DashboardTable(GraphSerializable):
                 yield relationship
 
     def __repr__(self) -> str:
-        return 'DashboardTable({!r}, {!r}, {!r}, {!r}, ({!r}))'.format(
-            self._dashboard_group_id,
-            self._dashboard_id,
-            self._product,
-            self._cluster,
-            ','.join(self._table_ids),
-        )
+        return f'DashboardTable({self._dashboard_group_id!r}, {self._dashboard_id!r}, ' \
+               f'{self._product!r}, {self._cluster!r}, ({",".join(self._table_ids)!r}))'

--- a/databuilder/models/dashboard/dashboard_usage.py
+++ b/databuilder/models/dashboard/dashboard_usage.py
@@ -2,16 +2,16 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import logging
-from typing import Optional, Any, Union, Iterator
+from typing import (
+    Any, Iterator, Optional, Union,
+)
 
 from databuilder.models.dashboard.dashboard_metadata import DashboardMetadata
 from databuilder.models.graph_node import GraphNode
 from databuilder.models.graph_relationship import GraphRelationship
-from databuilder.models.graph_serializable import (
-    GraphSerializable
-)
+from databuilder.models.graph_serializable import GraphSerializable
 from databuilder.models.usage.usage_constants import (
-    READ_RELATION_TYPE, READ_REVERSE_RELATION_TYPE, READ_RELATION_COUNT_PROPERTY
+    READ_RELATION_COUNT_PROPERTY, READ_RELATION_TYPE, READ_REVERSE_RELATION_TYPE,
 )
 from databuilder.models.user import User
 

--- a/databuilder/models/dashboard/dashboard_usage.py
+++ b/databuilder/models/dashboard/dashboard_usage.py
@@ -2,10 +2,11 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import logging
-
 from typing import Optional, Any, Union, Iterator
 
 from databuilder.models.dashboard.dashboard_metadata import DashboardMetadata
+from databuilder.models.graph_node import GraphNode
+from databuilder.models.graph_relationship import GraphRelationship
 from databuilder.models.graph_serializable import (
     GraphSerializable
 )
@@ -13,8 +14,6 @@ from databuilder.models.usage.usage_constants import (
     READ_RELATION_TYPE, READ_REVERSE_RELATION_TYPE, READ_RELATION_COUNT_PROPERTY
 )
 from databuilder.models.user import User
-from databuilder.models.graph_node import GraphNode
-from databuilder.models.graph_relationship import GraphRelationship
 
 LOGGER = logging.getLogger(__name__)
 
@@ -90,12 +89,6 @@ class DashboardUsage(GraphSerializable):
         yield relationship
 
     def __repr__(self) -> str:
-        return 'DashboardUsage({!r}, {!r}, {!r}, {!r}, {!r}, {!r}, {!r})'.format(
-            self._dashboard_group_id,
-            self._dashboard_id,
-            self._email,
-            self._view_count,
-            self._should_create_user_node,
-            self._product,
-            self._cluster
-        )
+        return f'DashboardUsage({self._dashboard_group_id!r}, {self._dashboard_id!r}, ' \
+               f'{self._email!r}, {self._view_count!r}, {self._should_create_user_node!r}, ' \
+               f'{self._product!r}, {self._cluster!r})'

--- a/databuilder/models/dashboard_elasticsearch_document.py
+++ b/databuilder/models/dashboard_elasticsearch_document.py
@@ -1,7 +1,9 @@
 # Copyright Contributors to the Amundsen project.
 # SPDX-License-Identifier: Apache-2.0
 
-from typing import List, Optional, Union
+from typing import (
+    List, Optional, Union,
+)
 
 from databuilder.models.elasticsearch_document import ElasticsearchDocument
 

--- a/databuilder/models/graph_serializable.py
+++ b/databuilder/models/graph_serializable.py
@@ -2,8 +2,8 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import abc
-
 from typing import Union  # noqa: F401
+
 from databuilder.models.graph_node import GraphNode
 from databuilder.models.graph_relationship import GraphRelationship
 
@@ -25,6 +25,7 @@ class GraphSerializable(object, metaclass=abc.ABCMeta):
 
     Any model class that needs to be pushed to a graph database should inherit this class.
     """
+
     def __init__(self) -> None:
         pass
 
@@ -68,10 +69,10 @@ class GraphSerializable(object, metaclass=abc.ABCMeta):
         node_id, node_label, _ = node
 
         if node_id is None:
-            RuntimeError('Required header missing. Required attributes id and label , Missing: id')
+            raise RuntimeError('Required header missing. Required attributes id and label , Missing: id')
 
         if node_label is None:
-            RuntimeError('Required header missing. Required attributes id and label , Missing: label')
+            raise RuntimeError('Required header missing. Required attributes id and label , Missing: label')
 
         self._validate_label_value(node_label)
 
@@ -82,9 +83,9 @@ class GraphSerializable(object, metaclass=abc.ABCMeta):
         self._validate_relation_type_value(relation.reverse_type)
 
     def _validate_relation_type_value(self, value: str) -> None:
-        if not value == value.upper():
-            raise RuntimeError('TYPE needs to be upper case: {}'.format(value))
+        if not value.isupper():
+            raise RuntimeError(f'TYPE needs to be upper case: {value}')
 
     def _validate_label_value(self, value: str) -> None:
         if not value.istitle():
-            raise RuntimeError('LABEL should only have upper case character on its first one: {}'.format(value))
+            raise RuntimeError(f'LABEL should only have upper case character on its first one: {value}')

--- a/databuilder/models/neo4j_es_last_updated.py
+++ b/databuilder/models/neo4j_es_last_updated.py
@@ -3,9 +3,9 @@
 
 from typing import List, Union
 
-from databuilder.models.graph_serializable import GraphSerializable
-from databuilder.models.graph_relationship import GraphRelationship
 from databuilder.models.graph_node import GraphNode
+from databuilder.models.graph_relationship import GraphRelationship
+from databuilder.models.graph_serializable import GraphSerializable
 
 
 class Neo4jESLastUpdated(GraphSerializable):

--- a/databuilder/models/schema/schema.py
+++ b/databuilder/models/schema/schema.py
@@ -54,7 +54,7 @@ class SchemaModel(GraphSerializable):
 
     def _get_description_node_key(self) -> str:
         desc = self._description.get_description_id() if self._description is not None else ''
-        return '{}/{}'.format(self._schema_key, desc)
+        return f'{self._schema_key}/{desc}'
 
     def _create_relation_iterator(self) -> Iterator[GraphRelationship]:
         if self._description:

--- a/databuilder/models/schema/schema.py
+++ b/databuilder/models/schema/schema.py
@@ -1,13 +1,15 @@
 # Copyright Contributors to the Amundsen project.
 # SPDX-License-Identifier: Apache-2.0
 
-from typing import Any, Union, Iterator
+from typing import (
+    Any, Iterator, Union,
+)
 
-from databuilder.models.graph_serializable import (GraphSerializable)
-from databuilder.models.schema.schema_constant import SCHEMA_NODE_LABEL, SCHEMA_NAME_ATTR
-from databuilder.models.table_metadata import DescriptionMetadata
 from databuilder.models.graph_node import GraphNode
 from databuilder.models.graph_relationship import GraphRelationship
+from databuilder.models.graph_serializable import GraphSerializable
+from databuilder.models.schema.schema_constant import SCHEMA_NAME_ATTR, SCHEMA_NODE_LABEL
+from databuilder.models.table_metadata import DescriptionMetadata
 
 
 class SchemaModel(GraphSerializable):

--- a/databuilder/models/table_column_usage.py
+++ b/databuilder/models/table_column_usage.py
@@ -3,13 +3,13 @@
 
 from typing import Iterable, Union, Iterator
 
+from databuilder.models.graph_node import GraphNode
+from databuilder.models.graph_relationship import GraphRelationship
 from databuilder.models.graph_serializable import (
     GraphSerializable
 )
 from databuilder.models.table_metadata import TableMetadata
 from databuilder.models.user import User
-from databuilder.models.graph_node import GraphNode
-from databuilder.models.graph_relationship import GraphRelationship
 
 
 class ColumnReader(object):
@@ -35,9 +35,9 @@ class ColumnReader(object):
         self.read_count = int(read_count)
 
     def __repr__(self) -> str:
-        return """\
-ColumnReader(database={!r}, cluster={!r}, schema={!r}, table={!r}, column={!r}, user_email={!r}, read_count={!r})"""\
-            .format(self.database, self.cluster, self.schema, self.table, self.column, self.user_email, self.read_count)
+        return f"ColumnReader(database={self.database!r}, cluster={self.cluster!r}, " \
+               f"schema={self.schema!r}, table={self.table!r}, column={self.column!r}, " \
+               f"user_email={self.user_email!r}, read_count={self.read_count!r})"
 
 
 class TableColumnUsage(GraphSerializable):
@@ -54,12 +54,10 @@ class TableColumnUsage(GraphSerializable):
     # Property key for relationship read, readby relationship
     READ_RELATION_COUNT = 'read_count'
 
-    def __init__(self,
-                 col_readers: Iterable[ColumnReader],
-                 ) -> None:
+    def __init__(self, col_readers: Iterable[ColumnReader]) -> None:
         for col_reader in col_readers:
             if col_reader.column != '*':
-                raise NotImplementedError('Column is not supported yet {}'.format(col_readers))
+                raise NotImplementedError(f'Column is not supported yet {col_readers}')
 
         self.col_readers = col_readers
         self._node_iterator = self._create_node_iterator()
@@ -108,4 +106,4 @@ class TableColumnUsage(GraphSerializable):
         return User.get_user_model_key(email=email)
 
     def __repr__(self) -> str:
-        return 'TableColumnUsage(col_readers={!r})'.format(self.col_readers)
+        return f'TableColumnUsage(col_readers={self.col_readers!r})'

--- a/databuilder/models/table_column_usage.py
+++ b/databuilder/models/table_column_usage.py
@@ -1,13 +1,13 @@
 # Copyright Contributors to the Amundsen project.
 # SPDX-License-Identifier: Apache-2.0
 
-from typing import Iterable, Union, Iterator
+from typing import (
+    Iterable, Iterator, Union,
+)
 
 from databuilder.models.graph_node import GraphNode
 from databuilder.models.graph_relationship import GraphRelationship
-from databuilder.models.graph_serializable import (
-    GraphSerializable
-)
+from databuilder.models.graph_serializable import GraphSerializable
 from databuilder.models.table_metadata import TableMetadata
 from databuilder.models.user import User
 

--- a/databuilder/models/table_elasticsearch_document.py
+++ b/databuilder/models/table_elasticsearch_document.py
@@ -33,7 +33,7 @@ class TableESDocument(ElasticsearchDocument):
         self.cluster = cluster
         self.schema = schema
         self.name = name
-        self.display_name = display_name if display_name else '{schema}.{table}'.format(schema=schema, table=name)
+        self.display_name = display_name if display_name else f'{schema}.{name}'
         self.key = key
         self.description = description
         # todo: use last_updated_timestamp to match the record in metadata

--- a/databuilder/models/table_last_updated.py
+++ b/databuilder/models/table_last_updated.py
@@ -3,12 +3,11 @@
 
 from typing import List, Union
 
-from databuilder.models.graph_serializable import GraphSerializable
-
-from databuilder.models.table_metadata import TableMetadata
-from databuilder.models.timestamp import timestamp_constants
 from databuilder.models.graph_node import GraphNode
 from databuilder.models.graph_relationship import GraphRelationship
+from databuilder.models.graph_serializable import GraphSerializable
+from databuilder.models.table_metadata import TableMetadata
+from databuilder.models.timestamp import timestamp_constants
 
 
 class TableLastUpdated(GraphSerializable):

--- a/databuilder/models/table_last_updated.py
+++ b/databuilder/models/table_last_updated.py
@@ -38,9 +38,8 @@ class TableLastUpdated(GraphSerializable):
         self._relation_iter = iter(self.create_relation())
 
     def __repr__(self) -> str:
-        return \
-            """TableLastUpdated(table_name={!r}, last_updated_time={!r}, schema={!r}, db={!r}, cluster={!r})"""\
-            .format(self.table_name, self.last_updated_time, self.schema, self.db, self.cluster)
+        return f"TableLastUpdated(table_name={self.table_name!r}, last_updated_time={self.last_updated_time!r}, " \
+               f"schema={self.schema!r}, db={self.db!r}, cluster={self.cluster!r})"
 
     def create_next_node(self) -> Union[GraphNode, None]:
         # creates new node

--- a/databuilder/models/table_lineage.py
+++ b/databuilder/models/table_lineage.py
@@ -4,11 +4,10 @@
 import re
 from typing import List, Union
 
-from databuilder.models.graph_serializable import GraphSerializable
-
-from databuilder.models.table_metadata import TableMetadata
 from databuilder.models.graph_node import GraphNode
 from databuilder.models.graph_relationship import GraphRelationship
+from databuilder.models.graph_serializable import GraphSerializable
+from databuilder.models.table_metadata import TableMetadata
 
 
 class TableLineage(GraphSerializable):
@@ -56,10 +55,7 @@ class TableLineage(GraphSerializable):
                             schema: str,
                             table: str
                             ) -> str:
-        return '{db}://{cluster}.{schema}/{table}'.format(db=db,
-                                                          cluster=cluster,
-                                                          schema=schema,
-                                                          table=table)
+        return f'{db}://{cluster}.{schema}/{table}'
 
     def create_nodes(self) -> List[Union[GraphNode, None]]:
         """
@@ -103,7 +99,4 @@ class TableLineage(GraphSerializable):
         return results
 
     def __repr__(self) -> str:
-        return 'TableLineage({!r}, {!r}, {!r}, {!r})'.format(self.db,
-                                                             self.cluster,
-                                                             self.schema,
-                                                             self.table)
+        return f'TableLineage({self.db!r}, {self.cluster!r}, {self.schema!r}, {self.table!r})'

--- a/databuilder/models/table_metadata.py
+++ b/databuilder/models/table_metadata.py
@@ -2,9 +2,11 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import copy
-from typing import Any, Dict, Iterable, Iterator, List, Optional, Set, Union
+from typing import (
+    Any, Dict, Iterable, Iterator, List, Optional, Set, Union,
+)
 
-from databuilder.models.badge import BadgeMetadata, Badge
+from databuilder.models.badge import Badge, BadgeMetadata
 from databuilder.models.cluster import cluster_constants
 from databuilder.models.graph_node import GraphNode
 from databuilder.models.graph_relationship import GraphRelationship

--- a/databuilder/models/table_metadata.py
+++ b/databuilder/models/table_metadata.py
@@ -2,16 +2,14 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import copy
-
 from typing import Any, Dict, Iterable, Iterator, List, Optional, Set, Union
 
-from databuilder.models.cluster import cluster_constants
-from databuilder.models.graph_serializable import GraphSerializable
-from databuilder.models.schema import schema_constant
 from databuilder.models.badge import BadgeMetadata, Badge
-
+from databuilder.models.cluster import cluster_constants
 from databuilder.models.graph_node import GraphNode
 from databuilder.models.graph_relationship import GraphRelationship
+from databuilder.models.graph_serializable import GraphSerializable
+from databuilder.models.schema import schema_constant
 
 DESCRIPTION_NODE_LABEL_VAL = 'Description'
 DESCRIPTION_NODE_LABEL = DESCRIPTION_NODE_LABEL_VAL
@@ -117,7 +115,7 @@ class DescriptionMetadata:
             return "_" + self._source + "_description"
 
     def __repr__(self) -> str:
-        return 'DescriptionMetadata({!r}, {!r})'.format(self._source, self._text)
+        return f'DescriptionMetadata({self._source!r}, {self._text!r})'
 
     def get_node(self, node_key: str) -> GraphNode:
         node = GraphNode(
@@ -177,11 +175,8 @@ class ColumnMetadata:
             self.badges = []
 
     def __repr__(self) -> str:
-        return 'ColumnMetadata({!r}, {!r}, {!r}, {!r}, {!r})'.format(self.name,
-                                                                     self.description,
-                                                                     self.type,
-                                                                     self.sort_order,
-                                                                     self.badges)
+        return f'ColumnMetadata({self.name!r}, {self.description!r}, {self.type!r}, ' \
+               f'{self.sort_order!r}, {self.badges!r})'
 
 
 class TableMetadata(GraphSerializable):
@@ -269,15 +264,8 @@ class TableMetadata(GraphSerializable):
         self._relation_iterator = self._create_next_relation()
 
     def __repr__(self) -> str:
-        return 'TableMetadata({!r}, {!r}, {!r}, {!r} ' \
-               '{!r}, {!r}, {!r}, {!r})'.format(self.database,
-                                                self.cluster,
-                                                self.schema,
-                                                self.name,
-                                                self.description,
-                                                self.columns,
-                                                self.is_view,
-                                                self.tags)
+        return f'TableMetadata({self.database!r}, {self.cluster!r}, {self.schema!r}, {self.name!r} ' \
+               f'{self.description!r}, {self.columns!r}, {self.is_view!r}, {self.tags!r})'
 
     def _get_table_key(self) -> str:
         return TableMetadata.TABLE_KEY_FORMAT.format(db=self.database,

--- a/databuilder/models/table_owner.py
+++ b/databuilder/models/table_owner.py
@@ -1,12 +1,14 @@
 # Copyright Contributors to the Amundsen project.
 # SPDX-License-Identifier: Apache-2.0
 
-from typing import List, Optional, Union
+from typing import (
+    List, Optional, Union,
+)
 
 from databuilder.models.graph_node import GraphNode
 from databuilder.models.graph_relationship import GraphRelationship
 from databuilder.models.graph_serializable import GraphSerializable
-from databuilder.models.owner_constants import OWNER_RELATION_TYPE, OWNER_OF_OBJECT_RELATION_TYPE
+from databuilder.models.owner_constants import OWNER_OF_OBJECT_RELATION_TYPE, OWNER_RELATION_TYPE
 from databuilder.models.user import User
 
 

--- a/databuilder/models/table_owner.py
+++ b/databuilder/models/table_owner.py
@@ -3,11 +3,11 @@
 
 from typing import List, Optional, Union
 
+from databuilder.models.graph_node import GraphNode
+from databuilder.models.graph_relationship import GraphRelationship
 from databuilder.models.graph_serializable import GraphSerializable
 from databuilder.models.owner_constants import OWNER_RELATION_TYPE, OWNER_OF_OBJECT_RELATION_TYPE
 from databuilder.models.user import User
-from databuilder.models.graph_node import GraphNode
-from databuilder.models.graph_relationship import GraphRelationship
 
 
 class TableOwner(GraphSerializable):
@@ -52,10 +52,7 @@ class TableOwner(GraphSerializable):
         return User.USER_NODE_KEY_FORMAT.format(email=owner)
 
     def get_metadata_model_key(self) -> str:
-        return '{db}://{cluster}.{schema}/{table}'.format(db=self.db,
-                                                          cluster=self.cluster,
-                                                          schema=self.schema,
-                                                          table=self.table)
+        return f'{self.db}://{self.cluster}.{self.schema}/{self.table}'
 
     def create_nodes(self) -> List[GraphNode]:
         """
@@ -96,8 +93,4 @@ class TableOwner(GraphSerializable):
         return results
 
     def __repr__(self) -> str:
-        return 'TableOwner({!r}, {!r}, {!r}, {!r}, {!r})'.format(self.db,
-                                                                 self.cluster,
-                                                                 self.schema,
-                                                                 self.table,
-                                                                 self.owners)
+        return f'TableOwner({self.db!r}, {self.cluster!r}, {self.schema!r}, {self.table!r}, {self.owners!r})'

--- a/databuilder/models/table_source.py
+++ b/databuilder/models/table_source.py
@@ -3,11 +3,10 @@
 
 from typing import List, Optional
 
-from databuilder.models.graph_serializable import GraphSerializable
-
-from databuilder.models.table_metadata import TableMetadata
 from databuilder.models.graph_node import GraphNode
 from databuilder.models.graph_relationship import GraphRelationship
+from databuilder.models.graph_serializable import GraphSerializable
+from databuilder.models.table_metadata import TableMetadata
 
 
 class TableSource(GraphSerializable):
@@ -25,7 +24,7 @@ class TableSource(GraphSerializable):
                  table_name: str,
                  cluster: str,
                  source: str,
-                 source_type: str='github',
+                 source_type: str = 'github',
                  ) -> None:
         self.db = db_name
         self.schema = schema
@@ -58,10 +57,7 @@ class TableSource(GraphSerializable):
                                              tbl=self.table)
 
     def get_metadata_model_key(self) -> str:
-        return '{db}://{cluster}.{schema}/{table}'.format(db=self.db,
-                                                          cluster=self.cluster,
-                                                          schema=self.schema,
-                                                          table=self.table)
+        return f'{self.db}://{self.cluster}.{self.schema}/{self.table}'
 
     def create_nodes(self) -> List[GraphNode]:
         """
@@ -97,8 +93,4 @@ class TableSource(GraphSerializable):
         return results
 
     def __repr__(self) -> str:
-        return 'TableSource({!r}, {!r}, {!r}, {!r}, {!r})'.format(self.db,
-                                                                  self.cluster,
-                                                                  self.schema,
-                                                                  self.table,
-                                                                  self.source)
+        return f'TableSource({self.db!r}, {self.cluster!r}, {self.schema!r}, {self.table!r}, {self.source!r})'

--- a/databuilder/models/table_stats.py
+++ b/databuilder/models/table_stats.py
@@ -2,10 +2,10 @@
 # SPDX-License-Identifier: Apache-2.0
 from typing import List, Optional
 
-from databuilder.models.graph_serializable import GraphSerializable
-from databuilder.models.table_metadata import ColumnMetadata
 from databuilder.models.graph_node import GraphNode
 from databuilder.models.graph_relationship import GraphRelationship
+from databuilder.models.graph_serializable import GraphSerializable
+from databuilder.models.table_metadata import ColumnMetadata
 
 
 class TableColumnStats(GraphSerializable):

--- a/databuilder/models/user.py
+++ b/databuilder/models/user.py
@@ -2,7 +2,9 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import copy
-from typing import Any, List, Optional
+from typing import (
+    Any, List, Optional,
+)
 
 from databuilder.models.graph_node import GraphNode
 from databuilder.models.graph_relationship import GraphRelationship

--- a/databuilder/models/user.py
+++ b/databuilder/models/user.py
@@ -2,12 +2,11 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import copy
-
 from typing import Any, List, Optional
 
-from databuilder.models.graph_serializable import GraphSerializable
 from databuilder.models.graph_node import GraphNode
 from databuilder.models.graph_relationship import GraphRelationship
+from databuilder.models.graph_serializable import GraphSerializable
 
 
 class User(GraphSerializable):
@@ -109,7 +108,7 @@ class User(GraphSerializable):
 
     @classmethod
     def get_user_model_key(cls,
-                           email: str=None
+                           email: str = None
                            ) -> str:
         if not email:
             return ''
@@ -124,16 +123,15 @@ class User(GraphSerializable):
         node_attributes = {
             User.USER_NODE_EMAIL: self.email,
             User.USER_NODE_IS_ACTIVE: self.is_active,
+            User.USER_NODE_FIRST_NAME: self.first_name or '',
+            User.USER_NODE_LAST_NAME: self.last_name or '',
+            User.USER_NODE_FULL_NAME: self.name or '',
+            User.USER_NODE_GITHUB_NAME: self.github_username or '',
+            User.USER_NODE_TEAM: self.team_name or '',
+            User.USER_NODE_EMPLOYEE_TYPE: self.employee_type or '',
+            User.USER_NODE_SLACK_ID: self.slack_id or '',
+            User.USER_NODE_ROLE_NAME: self.role_name or ''
         }
-
-        node_attributes[User.USER_NODE_FIRST_NAME] = self.first_name if self.first_name else ''
-        node_attributes[User.USER_NODE_LAST_NAME] = self.last_name if self.last_name else ''
-        node_attributes[User.USER_NODE_FULL_NAME] = self.name if self.name else ''
-        node_attributes[User.USER_NODE_GITHUB_NAME] = self.github_username if self.github_username else ''
-        node_attributes[User.USER_NODE_TEAM] = self.team_name if self.team_name else ''
-        node_attributes[User.USER_NODE_EMPLOYEE_TYPE] = self.employee_type if self.employee_type else ''
-        node_attributes[User.USER_NODE_SLACK_ID] = self.slack_id if self.slack_id else ''
-        node_attributes[User.USER_NODE_ROLE_NAME] = self.role_name if self.role_name else ''
 
         if self.updated_at:
             node_attributes[User.USER_NODE_UPDATED_AT] = self.updated_at
@@ -174,16 +172,6 @@ class User(GraphSerializable):
         return []
 
     def __repr__(self) -> str:
-        return 'User({!r}, {!r}, {!r}, {!r}, {!r}, ' \
-               '{!r}, {!r}, {!r}, {!r}, {!r}, {!r}, {!r})'.format(self.first_name,
-                                                                  self.last_name,
-                                                                  self.name,
-                                                                  self.email,
-                                                                  self.github_username,
-                                                                  self.team_name,
-                                                                  self.slack_id,
-                                                                  self.manager_email,
-                                                                  self.employee_type,
-                                                                  self.is_active,
-                                                                  self.updated_at,
-                                                                  self.role_name)
+        return f'User({self.first_name!r}, {self.last_name!r}, {self.name!r}, {self.email!r}, ' \
+               f'{self.github_username!r}, {self.team_name!r}, {self.slack_id!r}, {self.manager_email!r}, ' \
+               f'{self.employee_type!r}, {self.is_active!r}, {self.updated_at!r}, {self.role_name!r})'

--- a/databuilder/models/watermark.py
+++ b/databuilder/models/watermark.py
@@ -1,7 +1,9 @@
 # Copyright Contributors to the Amundsen project.
 # SPDX-License-Identifier: Apache-2.0
 
-from typing import List, Union, Tuple
+from typing import (
+    List, Tuple, Union,
+)
 
 from databuilder.models.graph_node import GraphNode
 from databuilder.models.graph_relationship import GraphRelationship

--- a/databuilder/models/watermark.py
+++ b/databuilder/models/watermark.py
@@ -3,9 +3,9 @@
 
 from typing import List, Union, Tuple
 
-from databuilder.models.graph_serializable import GraphSerializable
 from databuilder.models.graph_node import GraphNode
 from databuilder.models.graph_relationship import GraphRelationship
+from databuilder.models.graph_serializable import GraphSerializable
 
 
 class Watermark(GraphSerializable):
@@ -67,10 +67,7 @@ class Watermark(GraphSerializable):
                                            part_type=self.part_type)
 
     def get_metadata_model_key(self) -> str:
-        return '{database}://{cluster}.{schema}/{table}'.format(database=self.database,
-                                                                cluster=self.cluster,
-                                                                schema=self.schema,
-                                                                table=self.table)
+        return f'{self.database}://{self.cluster}.{self.schema}/{self.table}'
 
     def create_nodes(self) -> List[GraphNode]:
         """

--- a/databuilder/publisher/base_publisher.py
+++ b/databuilder/publisher/base_publisher.py
@@ -2,9 +2,9 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import abc
+from typing import List
 
 from pyhocon import ConfigTree
-from typing import List
 
 from databuilder import Scoped
 from databuilder.callback import call_back

--- a/databuilder/publisher/elasticsearch_publisher.py
+++ b/databuilder/publisher/elasticsearch_publisher.py
@@ -3,10 +3,10 @@
 
 import json
 import logging
+from typing import List
 
 from elasticsearch.exceptions import NotFoundError
 from pyhocon import ConfigTree
-from typing import List
 
 from databuilder.publisher.base_publisher import Publisher
 from databuilder.publisher.elasticsearch_constants import TABLE_ELASTICSEARCH_INDEX_MAPPING
@@ -99,7 +99,7 @@ class ElasticsearchPublisher(Publisher):
             cnt += 1
             if cnt == self.elasticsearch_batch_size:
                 self.elasticsearch_client.bulk(bulk_actions)
-                LOGGER.info('Publish {} of records to ES'.format(str(cnt)))
+                LOGGER.info('Publish %i of records to ES', cnt)
                 cnt = 0
                 bulk_actions = []
 

--- a/databuilder/publisher/neo4j_csv_publisher.py
+++ b/databuilder/publisher/neo4j_csv_publisher.py
@@ -8,15 +8,14 @@ import time
 from io import open
 from os import listdir
 from os.path import isfile, join
-from typing import Set, List
+from typing import List, Set
 
 import neo4j
 import pandas
 from jinja2 import Template
 from neo4j import GraphDatabase, Transaction
 from neo4j.exceptions import CypherError, TransientError
-from pyhocon import ConfigFactory
-from pyhocon import ConfigTree
+from pyhocon import ConfigFactory, ConfigTree
 
 from databuilder.publisher.base_publisher import Publisher
 from databuilder.publisher.neo4j_preprocessor import NoopRelationPreprocessor

--- a/databuilder/publisher/neo4j_csv_publisher.py
+++ b/databuilder/publisher/neo4j_csv_publisher.py
@@ -1,26 +1,25 @@
 # Copyright Contributors to the Amundsen project.
 # SPDX-License-Identifier: Apache-2.0
 
-import pandas
 import csv
 import ctypes
-from io import open
 import logging
 import time
+from io import open
 from os import listdir
 from os.path import isfile, join
-from jinja2 import Template
+from typing import Set, List
 
-from neo4j import GraphDatabase, Transaction
 import neo4j
+import pandas
+from jinja2 import Template
+from neo4j import GraphDatabase, Transaction
 from neo4j.exceptions import CypherError, TransientError
 from pyhocon import ConfigFactory
 from pyhocon import ConfigTree
-from typing import Set, List
 
 from databuilder.publisher.base_publisher import Publisher
 from databuilder.publisher.neo4j_preprocessor import NoopRelationPreprocessor
-
 
 # Setting field_size_limit to solve the error below
 # _csv.Error: field larger than field limit (131072)
@@ -154,12 +153,11 @@ class Neo4jCsvPublisher(Publisher):
         self.labels: Set[str] = set()
         self.publish_tag: str = conf.get_string(JOB_PUBLISH_TAG)
         if not self.publish_tag:
-            raise Exception('{} should not be empty'.format(JOB_PUBLISH_TAG))
+            raise Exception(f'{JOB_PUBLISH_TAG} should not be empty')
 
         self._relation_preprocessor = conf.get(RELATION_PREPROCESSOR)
 
-        LOGGER.info('Publishing Node csv files {}, and Relation CSV files {}'
-                    .format(self._node_files, self._relation_files))
+        LOGGER.info('Publishing Node csv files %s, and Relation CSV files %s', self._node_files, self._relation_files)
 
     def _list_files(self, conf: ConfigTree, path_key: str) -> List[str]:
         """
@@ -182,11 +180,11 @@ class Neo4jCsvPublisher(Publisher):
 
         start = time.time()
 
-        LOGGER.info('Creating indices using Node files: {}'.format(self._node_files))
+        LOGGER.info('Creating indices using Node files: %s', self._node_files)
         for node_file in self._node_files:
             self._create_indices(node_file=node_file)
 
-        LOGGER.info('Publishing Node files: {}'.format(self._node_files))
+        LOGGER.info('Publishing Node files: %s', self._node_files)
         try:
             tx = self._session.begin_transaction()
             while True:
@@ -196,7 +194,7 @@ class Neo4jCsvPublisher(Publisher):
                 except StopIteration:
                     break
 
-            LOGGER.info('Publishing Relationship files: {}'.format(self._relation_files))
+            LOGGER.info('Publishing Relationship files: %s', self._relation_files)
             while True:
                 try:
                     relation_file = next(self._relation_files_iter)
@@ -205,10 +203,10 @@ class Neo4jCsvPublisher(Publisher):
                     break
 
             tx.commit()
-            LOGGER.info('Committed total {} statements'.format(self._count))
+            LOGGER.info('Committed total %i statements', self._count)
 
             # TODO: Add statsd support
-            LOGGER.info('Successfully published. Elapsed: {} seconds'.format(time.time() - start))
+            LOGGER.info('Successfully published. Elapsed: %i seconds', time.time() - start)
         except Exception as e:
             LOGGER.exception('Failed to publish. Rolling back.')
             if not tx.closed():
@@ -305,7 +303,7 @@ class Neo4jCsvPublisher(Publisher):
         """
 
         if self._relation_preprocessor.is_perform_preprocess():
-            LOGGER.info('Pre-processing relation with {}'.format(self._relation_preprocessor))
+            LOGGER.info('Pre-processing relation with %s', self._relation_preprocessor)
 
             count = 0
             with open(relation_file, 'r', encoding='utf8') as relation_csv:
@@ -323,7 +321,7 @@ class Neo4jCsvPublisher(Publisher):
                         tx = self._execute_statement(stmt, tx=tx, params=params)
                         count += 1
 
-            LOGGER.info('Executed pre-processing Cypher statement {} times'.format(count))
+            LOGGER.info('Executed pre-processing Cypher statement %i times', count)
 
         with open(relation_file, 'r', encoding='utf8') as relation_csv:
             for rel_record in pandas.read_csv(relation_csv, na_filter=False).to_dict(orient="records"):
@@ -337,7 +335,7 @@ class Neo4jCsvPublisher(Publisher):
                                                      expect_result=self._confirm_rel_created)
                         exception_exists = False
                     except TransientError as e:
-                        if rel_record[RELATION_START_LABEL] in self.deadlock_node_labels\
+                        if rel_record[RELATION_START_LABEL] in self.deadlock_node_labels \
                                 or rel_record[RELATION_END_LABEL] in self.deadlock_node_labels:
                             time.sleep(SLEEP_TIME)
                             retries_for_exception -= 1
@@ -378,8 +376,6 @@ class Neo4jCsvPublisher(Publisher):
         for k, v in record_dict.items():
             if k.endswith(UNQUOTED_SUFFIX):
                 k = k[:-len(UNQUOTED_SUFFIX)]
-            else:
-                v = '{val}'.format(val=v)
 
             params[k] = v
         return params
@@ -407,23 +403,18 @@ class Neo4jCsvPublisher(Publisher):
             if k.endswith(UNQUOTED_SUFFIX):
                 k = k[:-len(UNQUOTED_SUFFIX)]
 
-            props.append('{id}.{key} = {val}'.format(id=identifier, key=k, val=f'${k}'))
+            props.append(f'{identifier}.{k} = ${k}')
 
-        props.append("""{id}.{key} = '{val}'""".format(id=identifier,
-                                                       key=PUBLISHED_TAG_PROPERTY_NAME,
-                                                       val=self.publish_tag))
-
-        props.append("""{id}.{key} = {val}""".format(id=identifier,
-                                                     key=LAST_UPDATED_EPOCH_MS,
-                                                     val='timestamp()'))
+        props.append(f"{identifier}.{PUBLISHED_TAG_PROPERTY_NAME} = '{self.publish_tag}'")
+        props.append(f"{identifier}.{LAST_UPDATED_EPOCH_MS} = timestamp()")
 
         return ', '.join(props)
 
     def _execute_statement(self,
                            stmt: str,
                            tx: Transaction,
-                           params: dict=None,
-                           expect_result: bool=False) -> Transaction:
+                           params: dict = None,
+                           expect_result: bool = False) -> Transaction:
         """
         Executes statement against Neo4j. If execution fails, it rollsback and raise exception.
         If 'expect_result' flag is True, it confirms if result object is not null.
@@ -434,21 +425,20 @@ class Neo4jCsvPublisher(Publisher):
         :return:
         """
         try:
-            if LOGGER.isEnabledFor(logging.DEBUG):
-                LOGGER.debug('Executing statement: {} with params {}'.format(stmt, params))
+            LOGGER.debug('Executing statement: %s with params %s', stmt, params)
 
             result = tx.run(str(stmt).encode('utf-8', 'ignore'), parameters=params)
             if expect_result and not result.single():
-                raise RuntimeError('Failed to executed statement: {}'.format(stmt))
+                raise RuntimeError(f'Failed to executed statement: {stmt}')
 
             self._count += 1
             if self._count > 1 and self._count % self._transaction_size == 0:
                 tx.commit()
-                LOGGER.info('Committed {} statements so far'.format(self._count))
+                LOGGER.info(f'Committed {self._count} statements so far')
                 return self._session.begin_transaction()
 
             if self._count > 1 and self._count % self._progress_report_frequency == 0:
-                LOGGER.info('Processed {} statements so far'.format(self._count))
+                LOGGER.info(f'Processed {self._count} statements so far')
 
             return tx
         except Exception as e:
@@ -468,8 +458,7 @@ class Neo4jCsvPublisher(Publisher):
             CREATE CONSTRAINT ON (node:{{ LABEL }}) ASSERT node.key IS UNIQUE
         """).render(LABEL=label)
 
-        LOGGER.info('Trying to create index for label {label} if not exist: {stmt}'.format(label=label,
-                                                                                           stmt=stmt))
+        LOGGER.info(f'Trying to create index for label %s if not exist: %s', label, stmt)
         with self._driver.session() as session:
             try:
                 session.run(stmt)

--- a/databuilder/publisher/neo4j_preprocessor.py
+++ b/databuilder/publisher/neo4j_preprocessor.py
@@ -2,10 +2,11 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import abc
-
 import logging
-from typing import Dict, List, Tuple, Optional
 import textwrap
+from typing import (
+    Dict, List, Optional, Tuple,
+)
 
 LOGGER = logging.getLogger(__name__)
 

--- a/databuilder/publisher/neo4j_preprocessor.py
+++ b/databuilder/publisher/neo4j_preprocessor.py
@@ -170,7 +170,7 @@ class DeleteRelationPreprocessor(RelationPreprocessor):
         """
 
         if not (start_label or end_label or start_key or end_key):
-            raise Exception('all labels and keys are required: {}'.format(locals()))
+            raise Exception(f'all labels and keys are required: {locals()}')
 
         params = {'start_key': start_key, 'end_key': end_key}
         return DeleteRelationPreprocessor.RELATION_MERGE_TEMPLATE.format(start_label=start_label,

--- a/databuilder/rest_api/base_rest_api_query.py
+++ b/databuilder/rest_api/base_rest_api_query.py
@@ -3,8 +3,9 @@
 
 import abc
 import logging
-
-from typing import Iterable, Any, Dict, Iterator
+from typing import (
+    Any, Dict, Iterable, Iterator,
+)
 
 LOGGER = logging.getLogger(__name__)
 

--- a/databuilder/rest_api/mode_analytics/mode_paginated_rest_api_query.py
+++ b/databuilder/rest_api/mode_analytics/mode_paginated_rest_api_query.py
@@ -2,10 +2,10 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import logging
+from typing import Any, Dict
 
 import requests
 from jsonpath_rw import parse
-from typing import Any, Dict
 
 from databuilder.rest_api.rest_api_query import RestApiQuery
 
@@ -49,12 +49,10 @@ class ModePaginatedRestApiQuery(RestApiQuery):
         page_suffix = PAGE_SUFFIX_TEMPLATE.format(self._current_page)  # example: ?page=2
 
         # example: http://foo.bar/resources?page=2
-        self._url = self._original_url + '{page_suffix}'.format(page_suffix=page_suffix)
+        self._url = f"{self._original_url}{page_suffix}"
         return self._url.format(**record)
 
-    def _post_process(self,
-                      response: requests.Response,
-                      ) -> None:
+    def _post_process(self, response: requests.Response, ) -> None:
         """
         Updates trigger to pagination (self._more_pages) as well as current_page (self._current_page)
         Mode does not have explicit indicator that it just the number of records need to be certain number that

--- a/databuilder/rest_api/rest_api_failure_handlers.py
+++ b/databuilder/rest_api/rest_api_failure_handlers.py
@@ -2,7 +2,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import abc
-
 from typing import Iterable
 
 

--- a/databuilder/rest_api/rest_api_query.py
+++ b/databuilder/rest_api/rest_api_query.py
@@ -3,11 +3,11 @@
 
 import copy
 import logging
+from typing import List, Dict, Any, Union, Iterator, Callable
 
 import requests
 from jsonpath_rw import parse
 from retrying import retry
-from typing import List, Dict, Any, Union, Iterator, Callable
 
 from databuilder.rest_api.base_rest_api_query import BaseRestApiQuery
 
@@ -56,10 +56,10 @@ class RestApiQuery(BaseRestApiQuery):
                  params: Dict[str, Any],
                  json_path: str,
                  field_names: List[str],
-                 fail_no_result: bool=False,
-                 skip_no_result: bool=False,
-                 json_path_contains_or: bool=False,
-                 can_skip_failure: Callable=None,
+                 fail_no_result: bool = False,
+                 skip_no_result: bool = False,
+                 json_path_contains_or: bool = False,
+                 can_skip_failure: Callable = None,
                  **kwargs: Any
                  ) -> None:
         """
@@ -153,8 +153,8 @@ class RestApiQuery(BaseRestApiQuery):
                 result_list: List[Any] = [match.value for match in self._jsonpath_expr.find(response_json)]
 
                 if not result_list:
-                    log_msg = 'No result from URL: {url}, JSONPATH: {json_path} , response payload: {response}' \
-                        .format(url=self._url, json_path=self._json_path, response=response_json)
+                    log_msg = f'No result from URL: {self._url}, JSONPATH: {self._json_path} , ' \
+                              f'response payload: {response_json}'
                     LOGGER.info(log_msg)
 
                     self._post_process(response)
@@ -197,7 +197,7 @@ class RestApiQuery(BaseRestApiQuery):
         :param url:
         :return:
         """
-        LOGGER.info('Calling URL {}'.format(url))
+        LOGGER.info('Calling URL %s', url)
         response = requests.get(url, **self._params)
         response.raise_for_status()
         return response
@@ -206,7 +206,7 @@ class RestApiQuery(BaseRestApiQuery):
     def _compute_sub_records(cls,
                              result_list: List[Any],
                              field_names: List[str],
-                             json_path_contains_or: bool=False,
+                             json_path_contains_or: bool = False,
                              ) -> List[List[Any]]:
         """
         The behavior of JSONPATH is different when it's extracting multiple fields using AND(,) vs OR(|)

--- a/databuilder/rest_api/rest_api_query.py
+++ b/databuilder/rest_api/rest_api_query.py
@@ -3,7 +3,9 @@
 
 import copy
 import logging
-from typing import List, Dict, Any, Union, Iterator, Callable
+from typing import (
+    Any, Callable, Dict, Iterator, List, Union,
+)
 
 import requests
 from jsonpath_rw import parse

--- a/databuilder/serializers/neo4_serializer.py
+++ b/databuilder/serializers/neo4_serializer.py
@@ -1,19 +1,15 @@
 # Copyright Contributors to the Amundsen project.
 # SPDX-License-Identifier: Apache-2.0
 
-from typing import Dict, Any, Optional
+from typing import (
+    Any, Dict, Optional,
+)
 
 from databuilder.models.graph_node import GraphNode
 from databuilder.models.graph_relationship import GraphRelationship
 from databuilder.models.graph_serializable import (
-    NODE_LABEL,
-    NODE_KEY,
-    RELATION_END_KEY,
-    RELATION_END_LABEL,
-    RELATION_REVERSE_TYPE,
-    RELATION_START_KEY,
-    RELATION_START_LABEL,
-    RELATION_TYPE
+    NODE_KEY, NODE_LABEL, RELATION_END_KEY, RELATION_END_LABEL, RELATION_REVERSE_TYPE, RELATION_START_KEY,
+    RELATION_START_LABEL, RELATION_TYPE,
 )
 from databuilder.publisher.neo4j_csv_publisher import UNQUOTED_SUFFIX
 

--- a/databuilder/serializers/neo4_serializer.py
+++ b/databuilder/serializers/neo4_serializer.py
@@ -3,8 +3,8 @@
 
 from typing import Dict, Any, Optional
 
-from databuilder.models.graph_relationship import GraphRelationship
 from databuilder.models.graph_node import GraphNode
+from databuilder.models.graph_relationship import GraphRelationship
 from databuilder.models.graph_serializable import (
     NODE_LABEL,
     NODE_KEY,
@@ -28,10 +28,7 @@ def serialize_node(node: Optional[GraphNode]) -> Dict[str, Any]:
     }
     for key, value in node.attributes.items():
         key_suffix = _get_neo4j_suffix_value(value)
-        formatted_key = "{key}{suffix}".format(
-            key=key,
-            suffix=key_suffix
-        )
+        formatted_key = f'{key}{key_suffix}'
         node_dict[formatted_key] = value
     return node_dict
 
@@ -50,10 +47,7 @@ def serialize_relationship(relationship: Optional[GraphRelationship]) -> Dict[st
     }
     for key, value in relationship.attributes.items():
         key_suffix = _get_neo4j_suffix_value(value)
-        formatted_key = "{key}{suffix}".format(
-            key=key,
-            suffix=key_suffix
-        )
+        formatted_key = f'{key}{key_suffix}'
         relationship_dict[formatted_key] = value
 
     return relationship_dict

--- a/databuilder/task/neo4j_staleness_removal_task.py
+++ b/databuilder/task/neo4j_staleness_removal_task.py
@@ -4,7 +4,9 @@
 import logging
 import textwrap
 import time
-from typing import Any, Dict, Iterable
+from typing import (
+    Any, Dict, Iterable,
+)
 
 import neo4j
 from neo4j import GraphDatabase

--- a/databuilder/task/neo4j_staleness_removal_task.py
+++ b/databuilder/task/neo4j_staleness_removal_task.py
@@ -4,11 +4,11 @@
 import logging
 import textwrap
 import time
-
-from neo4j import GraphDatabase
-import neo4j
-from pyhocon import ConfigFactory, ConfigTree
 from typing import Any, Dict, Iterable
+
+import neo4j
+from neo4j import GraphDatabase
+from pyhocon import ConfigFactory, ConfigTree
 
 from databuilder import Scoped
 from databuilder.publisher.neo4j_csv_publisher import JOB_PUBLISH_TAG
@@ -80,13 +80,13 @@ class Neo4jStalenessRemovalTask(Task):
         self.staleness_pct_dict = conf.get(STALENESS_PCT_MAX_DICT)
 
         if JOB_PUBLISH_TAG in conf and MS_TO_EXPIRE in conf:
-            raise Exception('Cannot have both {} and {} in job config'.format(JOB_PUBLISH_TAG, MS_TO_EXPIRE))
+            raise Exception(f'Cannot have both {JOB_PUBLISH_TAG} and {MS_TO_EXPIRE} in job config')
 
         self.ms_to_expire = None
         if MS_TO_EXPIRE in conf:
             self.ms_to_expire = conf.get_int(MS_TO_EXPIRE)
             if self.ms_to_expire < conf.get_int(MIN_MS_TO_EXPIRE):
-                raise Exception('{} is too small'.format(MS_TO_EXPIRE))
+                raise Exception(f'{MS_TO_EXPIRE} is too small')
             self.marker = self.ms_to_expire
         else:
             self.marker = conf.get_string(JOB_PUBLISH_TAG)
@@ -139,13 +139,13 @@ class Neo4jStalenessRemovalTask(Task):
         :return:
         """
         if self.ms_to_expire:
-            return statement.format(textwrap.dedent("""
-            n.publisher_last_updated_epoch_ms < (timestamp() - ${marker})
-            OR NOT EXISTS(n.publisher_last_updated_epoch_ms)""".format(marker=MARKER_VAR_NAME)))
+            return statement.format(textwrap.dedent(f"""
+            n.publisher_last_updated_epoch_ms < (timestamp() - ${MARKER_VAR_NAME})
+            OR NOT EXISTS(n.publisher_last_updated_epoch_ms)"""))
 
-        return statement.format(textwrap.dedent("""
-        n.published_tag <> ${marker}
-        OR NOT EXISTS(n.published_tag)""".format(marker=MARKER_VAR_NAME)))
+        return statement.format(textwrap.dedent(f"""
+        n.published_tag <> ${MARKER_VAR_NAME}
+        OR NOT EXISTS(n.published_tag)"""))
 
     def _delete_stale_relations(self) -> None:
         statement = textwrap.dedent("""
@@ -168,7 +168,7 @@ class Neo4jStalenessRemovalTask(Task):
         :return:
         """
         for t in targets:
-            LOGGER.info('Deleting stale data of {} with batch size {}'.format(t, self.batch_size))
+            LOGGER.info('Deleting stale data of %s with batch size %i', t, self.batch_size)
             total_count = 0
             while True:
                 results = self._execute_cypher_query(statement=statement.format(type=t),
@@ -180,7 +180,7 @@ class Neo4jStalenessRemovalTask(Task):
                 total_count = total_count + count
                 if count == 0:
                     break
-            LOGGER.info('Deleted {} stale data of {}'.format(total_count, t))
+            LOGGER.info('Deleted %i stale data of %s', total_count, t)
 
     def _validate_staleness_pct(self,
                                 total_records: Iterable[Dict[str, Any]],
@@ -203,8 +203,8 @@ class Neo4jStalenessRemovalTask(Task):
 
             threshold = self.staleness_pct_dict.get(type_str, self.staleness_pct)
             if stale_pct >= threshold:
-                raise Exception('Staleness percentage of {} is {} %. Stopping due to over threshold {} %'
-                                .format(type_str, stale_pct, threshold))
+                raise Exception(f'Staleness percentage of {type_str} is {stale_pct} %. '
+                                f'Stopping due to over threshold {threshold} %')
 
     def _validate_node_staleness_pct(self) -> None:
         total_nodes_statement = textwrap.dedent("""
@@ -252,11 +252,10 @@ class Neo4jStalenessRemovalTask(Task):
 
     def _execute_cypher_query(self,
                               statement: str,
-                              param_dict: Dict[str, Any]={},
-                              dry_run: bool=False
+                              param_dict: Dict[str, Any] = {},
+                              dry_run: bool = False
                               ) -> Iterable[Dict[str, Any]]:
-        LOGGER.info('Executing Cypher query: {statement} with params {params}: '.format(statement=statement,
-                                                                                        params=param_dict))
+        LOGGER.info('Executing Cypher query: %s with params %s: ', statement, param_dict)
 
         if dry_run:
             LOGGER.info('Skipping for it is a dryrun')
@@ -268,5 +267,4 @@ class Neo4jStalenessRemovalTask(Task):
                 return session.run(statement, **param_dict)
 
         finally:
-            if LOGGER.isEnabledFor(logging.DEBUG):
-                LOGGER.debug('Cypher query execution elapsed for {} seconds'.format(time.time() - start))
+            LOGGER.debug('Cypher query execution elapsed for %i seconds', time.time() - start)

--- a/databuilder/task/task.py
+++ b/databuilder/task/task.py
@@ -9,11 +9,10 @@ from databuilder import Scoped
 from databuilder.extractor.base_extractor import Extractor
 from databuilder.loader.base_loader import Loader
 from databuilder.task.base_task import Task
-from databuilder.transformer.base_transformer import Transformer
 from databuilder.transformer.base_transformer \
     import NoopTransformer
+from databuilder.transformer.base_transformer import Transformer
 from databuilder.utils.closer import Closer
-
 
 LOGGER = logging.getLogger(__name__)
 
@@ -42,7 +41,7 @@ class DefaultTask(Task):
 
     def init(self, conf: ConfigTree) -> None:
         self._progress_report_frequency = \
-            conf.get_int('{}.{}'.format(self.get_scope(), DefaultTask.PROGRESS_REPORT_FREQUENCY), 500)
+            conf.get_int(f'{self.get_scope()}.{DefaultTask.PROGRESS_REPORT_FREQUENCY}', 500)
 
         self.extractor.init(Scoped.get_scoped_conf(conf, self.extractor.get_scope()))
         self.transformer.init(Scoped.get_scoped_conf(conf, self.transformer.get_scope()))
@@ -66,7 +65,7 @@ class DefaultTask(Task):
                 record = self.extractor.extract()
                 count += 1
                 if count > 0 and count % self._progress_report_frequency == 0:
-                    LOGGER.info('Extracted {} records so far'.format(count))
+                    LOGGER.info(f'Extracted %i records so far', count)
 
         finally:
             self._closer.close()

--- a/databuilder/task/task.py
+++ b/databuilder/task/task.py
@@ -9,9 +9,7 @@ from databuilder import Scoped
 from databuilder.extractor.base_extractor import Extractor
 from databuilder.loader.base_loader import Loader
 from databuilder.task.base_task import Task
-from databuilder.transformer.base_transformer \
-    import NoopTransformer
-from databuilder.transformer.base_transformer import Transformer
+from databuilder.transformer.base_transformer import NoopTransformer, Transformer
 from databuilder.utils.closer import Closer
 
 LOGGER = logging.getLogger(__name__)

--- a/databuilder/transformer/base_transformer.py
+++ b/databuilder/transformer/base_transformer.py
@@ -2,9 +2,11 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import abc
+from typing import (
+    Any, Iterable, Optional,
+)
 
 from pyhocon import ConfigTree
-from typing import Any, Iterable, Optional
 
 from databuilder import Scoped
 

--- a/databuilder/transformer/bigquery_usage_transformer.py
+++ b/databuilder/transformer/bigquery_usage_transformer.py
@@ -1,12 +1,13 @@
 # Copyright Contributors to the Amundsen project.
 # SPDX-License-Identifier: Apache-2.0
 
-from pyhocon import ConfigTree
 from typing import Optional, Tuple
 
-from databuilder.transformer.base_transformer import Transformer
-from databuilder.models.table_column_usage import ColumnReader, TableColumnUsage
+from pyhocon import ConfigTree
+
 from databuilder.extractor.bigquery_usage_extractor import TableColumnUsageTuple
+from databuilder.models.table_column_usage import ColumnReader, TableColumnUsage
+from databuilder.transformer.base_transformer import Transformer
 
 
 class BigqueryUsageTransformer(Transformer):

--- a/databuilder/transformer/dict_to_model.py
+++ b/databuilder/transformer/dict_to_model.py
@@ -3,9 +3,9 @@
 
 import importlib
 import logging
+from typing import Any, Dict
 
 from pyhocon import ConfigTree
-from typing import Any, Dict
 
 from databuilder.transformer.base_transformer import Transformer
 

--- a/databuilder/transformer/generic_transformer.py
+++ b/databuilder/transformer/generic_transformer.py
@@ -2,9 +2,9 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import logging
+from typing import Any, Dict
 
 from pyhocon import ConfigTree
-from typing import Any, Dict
 
 from databuilder.transformer.base_transformer import Transformer
 

--- a/databuilder/transformer/regex_str_replace_transformer.py
+++ b/databuilder/transformer/regex_str_replace_transformer.py
@@ -2,11 +2,11 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import logging
-from pyhocon import ConfigTree
 from typing import Any
 
-from databuilder.transformer.base_transformer import Transformer
+from pyhocon import ConfigTree
 
+from databuilder.transformer.base_transformer import Transformer
 
 LOGGER = logging.getLogger(__name__)
 

--- a/databuilder/transformer/table_tag_transformer.py
+++ b/databuilder/transformer/table_tag_transformer.py
@@ -1,11 +1,12 @@
 # Copyright Contributors to the Amundsen project.
 # SPDX-License-Identifier: Apache-2.0
 
-from pyhocon import ConfigFactory, ConfigTree
 from typing import Any
 
-from databuilder.transformer.base_transformer import Transformer
+from pyhocon import ConfigFactory, ConfigTree
+
 from databuilder.models.table_metadata import TableMetadata
+from databuilder.transformer.base_transformer import Transformer
 
 
 class TableTagTransformer(Transformer):

--- a/databuilder/transformer/template_variable_substitution_transformer.py
+++ b/databuilder/transformer/template_variable_substitution_transformer.py
@@ -2,9 +2,9 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import logging
+from typing import Any, Dict
 
 from pyhocon import ConfigTree
-from typing import Any, Dict
 
 from databuilder.transformer.base_transformer import Transformer
 

--- a/databuilder/transformer/timestamp_string_to_epoch.py
+++ b/databuilder/transformer/timestamp_string_to_epoch.py
@@ -3,10 +3,9 @@
 
 import logging
 from datetime import datetime
-
-from pyhocon import ConfigFactory
-from pyhocon import ConfigTree
 from typing import Any, Dict
+
+from pyhocon import ConfigFactory, ConfigTree
 
 from databuilder.transformer.base_transformer import Transformer
 

--- a/databuilder/utils/closer.py
+++ b/databuilder/utils/closer.py
@@ -27,8 +27,7 @@ class Closer(object):
         :return: None
         """
         if not callable(close_callable):
-            raise RuntimeError('Only callable can be registered: {}'.format(
-                close_callable))
+            raise RuntimeError(f'Only callable can be registered: {close_callable}')
 
         self._stack.append(close_callable)
 

--- a/databuilder/utils/closer.py
+++ b/databuilder/utils/closer.py
@@ -2,7 +2,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import atexit
-
 from typing import Callable, List
 
 

--- a/example/dags/postgres_sample_dag.py
+++ b/example/dags/postgres_sample_dag.py
@@ -1,28 +1,27 @@
 # Copyright Contributors to the Amundsen project.
 # SPDX-License-Identifier: Apache-2.0
 
-import textwrap
-from datetime import datetime, timedelta
 import uuid
+from datetime import datetime, timedelta
 
-from elasticsearch import Elasticsearch
 from airflow import DAG  # noqa
 from airflow import macros  # noqa
 from airflow.operators.python_operator import PythonOperator  # noqa
+from elasticsearch import Elasticsearch
 from pyhocon import ConfigFactory
+
+from databuilder.extractor.neo4j_extractor import Neo4jExtractor
 from databuilder.extractor.neo4j_search_data_extractor import Neo4jSearchDataExtractor
 from databuilder.extractor.postgres_metadata_extractor import PostgresMetadataExtractor
 from databuilder.extractor.sql_alchemy_extractor import SQLAlchemyExtractor
-from databuilder.publisher.elasticsearch_publisher import ElasticsearchPublisher
-from databuilder.extractor.neo4j_extractor import Neo4jExtractor
 from databuilder.job.job import DefaultJob
 from databuilder.loader.file_system_elasticsearch_json_loader import FSElasticsearchJSONLoader
 from databuilder.loader.file_system_neo4j_csv_loader import FsNeo4jCSVLoader
 from databuilder.publisher import neo4j_csv_publisher
+from databuilder.publisher.elasticsearch_publisher import ElasticsearchPublisher
 from databuilder.publisher.neo4j_csv_publisher import Neo4jCsvPublisher
 from databuilder.task.task import DefaultTask
 from databuilder.transformer.base_transformer import NoopTransformer
-
 
 dag_args = {
     'concurrency': 10,
@@ -76,37 +75,24 @@ def connection_string():
 
 
 def create_table_extract_job():
-    where_clause_suffix = textwrap.dedent("""
-        where table_schema in {schemas}
-    """).format(schemas=SUPPORTED_SCHEMA_SQL_IN_CLAUSE)
+    where_clause_suffix = f'where table_schema in {SUPPORTED_SCHEMA_SQL_IN_CLAUSE}'
 
     tmp_folder = '/var/tmp/amundsen/table_metadata'
-    node_files_folder = '{tmp_folder}/nodes/'.format(tmp_folder=tmp_folder)
-    relationship_files_folder = '{tmp_folder}/relationships/'.format(tmp_folder=tmp_folder)
+    node_files_folder = f'{tmp_folder}/nodes/'
+    relationship_files_folder = f'{tmp_folder}/relationships/'
 
     job_config = ConfigFactory.from_dict({
-        'extractor.postgres_metadata.{}'.format(PostgresMetadataExtractor.WHERE_CLAUSE_SUFFIX_KEY):
-            where_clause_suffix,
-        'extractor.postgres_metadata.{}'.format(PostgresMetadataExtractor.USE_CATALOG_AS_CLUSTER_NAME):
-            True,
-        'extractor.postgres_metadata.extractor.sqlalchemy.{}'.format(SQLAlchemyExtractor.CONN_STRING):
-            connection_string(),
-        'loader.filesystem_csv_neo4j.{}'.format(FsNeo4jCSVLoader.NODE_DIR_PATH):
-            node_files_folder,
-        'loader.filesystem_csv_neo4j.{}'.format(FsNeo4jCSVLoader.RELATION_DIR_PATH):
-            relationship_files_folder,
-        'publisher.neo4j.{}'.format(neo4j_csv_publisher.NODE_FILES_DIR):
-            node_files_folder,
-        'publisher.neo4j.{}'.format(neo4j_csv_publisher.RELATION_FILES_DIR):
-            relationship_files_folder,
-        'publisher.neo4j.{}'.format(neo4j_csv_publisher.NEO4J_END_POINT_KEY):
-            neo4j_endpoint,
-        'publisher.neo4j.{}'.format(neo4j_csv_publisher.NEO4J_USER):
-            neo4j_user,
-        'publisher.neo4j.{}'.format(neo4j_csv_publisher.NEO4J_PASSWORD):
-            neo4j_password,
-        'publisher.neo4j.{}'.format(neo4j_csv_publisher.JOB_PUBLISH_TAG):
-            'unique_tag',  # should use unique tag here like {ds}
+        f'extractor.postgres_metadata.{PostgresMetadataExtractor.WHERE_CLAUSE_SUFFIX_KEY}': where_clause_suffix,
+        f'extractor.postgres_metadata.{PostgresMetadataExtractor.USE_CATALOG_AS_CLUSTER_NAME}': True,
+        f'extractor.postgres_metadata.extractor.sqlalchemy.{SQLAlchemyExtractor.CONN_STRING}': connection_string(),
+        f'loader.filesystem_csv_neo4j.{FsNeo4jCSVLoader.NODE_DIR_PATH}': node_files_folder,
+        f'loader.filesystem_csv_neo4j.{FsNeo4jCSVLoader.RELATION_DIR_PATH}': relationship_files_folder,
+        f'publisher.neo4j.{neo4j_csv_publisher.NODE_FILES_DIR}': node_files_folder,
+        f'publisher.neo4j.{neo4j_csv_publisher.RELATION_FILES_DIR}': relationship_files_folder,
+        f'publisher.neo4j.{neo4j_csv_publisher.NEO4J_END_POINT_KEY}': neo4j_endpoint,
+        f'publisher.neo4j.{neo4j_csv_publisher.NEO4J_USER}': neo4j_user,
+        f'publisher.neo4j.{neo4j_csv_publisher.NEO4J_PASSWORD}': neo4j_password,
+        f'publisher.neo4j.{neo4j_csv_publisher.JOB_PUBLISH_TAG}': 'unique_tag',  # should use unique tag here like {ds}
     })
     job = DefaultJob(conf=job_config,
                      task=DefaultTask(extractor=PostgresMetadataExtractor(), loader=FsNeo4jCSVLoader()),
@@ -125,31 +111,29 @@ def create_es_publisher_sample_job():
     # elastic search client instance
     elasticsearch_client = es
     # unique name of new index in Elasticsearch
-    elasticsearch_new_index_key = 'tables' + str(uuid.uuid4())
+    elasticsearch_new_index_key = f'tables{uuid.uuid4()}'
     # related to mapping type from /databuilder/publisher/elasticsearch_publisher.py#L38
     elasticsearch_new_index_key_type = 'table'
     # alias for Elasticsearch used in amundsensearchlibrary/search_service/config.py as an index
     elasticsearch_index_alias = 'table_search_index'
 
     job_config = ConfigFactory.from_dict({
-        'extractor.search_data.extractor.neo4j.{}'.format(Neo4jExtractor.GRAPH_URL_CONFIG_KEY): neo4j_endpoint,
-        'extractor.search_data.extractor.neo4j.{}'.format(Neo4jExtractor.MODEL_CLASS_CONFIG_KEY):
+        f'extractor.search_data.extractor.neo4j.{Neo4jExtractor.GRAPH_URL_CONFIG_KEY}': neo4j_endpoint,
+        f'extractor.search_data.extractor.neo4j.{Neo4jExtractor.MODEL_CLASS_CONFIG_KEY}':
             'databuilder.models.table_elasticsearch_document.TableESDocument',
-        'extractor.search_data.extractor.neo4j.{}'.format(Neo4jExtractor.NEO4J_AUTH_USER): neo4j_user,
-        'extractor.search_data.extractor.neo4j.{}'.format(Neo4jExtractor.NEO4J_AUTH_PW): neo4j_password,
-        'loader.filesystem.elasticsearch.{}'.format(FSElasticsearchJSONLoader.FILE_PATH_CONFIG_KEY):
-            extracted_search_data_path,
-        'loader.filesystem.elasticsearch.{}'.format(FSElasticsearchJSONLoader.FILE_MODE_CONFIG_KEY): 'w',
-        'publisher.elasticsearch.{}'.format(ElasticsearchPublisher.FILE_PATH_CONFIG_KEY):
-            extracted_search_data_path,
-        'publisher.elasticsearch.{}'.format(ElasticsearchPublisher.FILE_MODE_CONFIG_KEY): 'r',
-        'publisher.elasticsearch.{}'.format(ElasticsearchPublisher.ELASTICSEARCH_CLIENT_CONFIG_KEY):
+        f'extractor.search_data.extractor.neo4j.{Neo4jExtractor.NEO4J_AUTH_USER}': neo4j_user,
+        f'extractor.search_data.extractor.neo4j.{Neo4jExtractor.NEO4J_AUTH_PW}': neo4j_password,
+        f'loader.filesystem.elasticsearch.{FSElasticsearchJSONLoader.FILE_PATH_CONFIG_KEY}': extracted_search_data_path,
+        f'loader.filesystem.elasticsearch.{FSElasticsearchJSONLoader.FILE_MODE_CONFIG_KEY}': 'w',
+        f'publisher.elasticsearch.{ElasticsearchPublisher.FILE_PATH_CONFIG_KEY}': extracted_search_data_path,
+        f'publisher.elasticsearch.{ElasticsearchPublisher.FILE_MODE_CONFIG_KEY}': 'r',
+        f'publisher.elasticsearch.{ElasticsearchPublisher.ELASTICSEARCH_CLIENT_CONFIG_KEY}':
             elasticsearch_client,
-        'publisher.elasticsearch.{}'.format(ElasticsearchPublisher.ELASTICSEARCH_NEW_INDEX_CONFIG_KEY):
+        f'publisher.elasticsearch.{ElasticsearchPublisher.ELASTICSEARCH_NEW_INDEX_CONFIG_KEY}':
             elasticsearch_new_index_key,
-        'publisher.elasticsearch.{}'.format(ElasticsearchPublisher.ELASTICSEARCH_DOC_TYPE_CONFIG_KEY):
+        f'publisher.elasticsearch.{ElasticsearchPublisher.ELASTICSEARCH_DOC_TYPE_CONFIG_KEY}':
             elasticsearch_new_index_key_type,
-        'publisher.elasticsearch.{}'.format(ElasticsearchPublisher.ELASTICSEARCH_ALIAS_CONFIG_KEY):
+        f'publisher.elasticsearch.{ElasticsearchPublisher.ELASTICSEARCH_ALIAS_CONFIG_KEY}':
             elasticsearch_index_alias
     })
 
@@ -160,7 +144,6 @@ def create_es_publisher_sample_job():
 
 
 with DAG('amundsen_databuilder', default_args=default_args, **dag_args) as dag:
-
     postgres_table_extract_job = PythonOperator(
         task_id='postgres_table_extract_job',
         python_callable=create_table_extract_job

--- a/example/dags/snowflake_sample_dag.py
+++ b/example/dags/snowflake_sample_dag.py
@@ -7,25 +7,25 @@ Neo4j and Elasticsearch
 """
 
 import textwrap
-from datetime import datetime, timedelta
 import uuid
+from datetime import datetime, timedelta
 
 from airflow import DAG  # noqa
 from airflow import macros  # noqa
 from airflow.operators.python_operator import PythonOperator  # noqa
+from elasticsearch import Elasticsearch
 from pyhocon import ConfigFactory
 
-from elasticsearch import Elasticsearch
-from databuilder.extractor.sql_alchemy_extractor import SQLAlchemyExtractor
+from databuilder.extractor.neo4j_extractor import Neo4jExtractor
+from databuilder.extractor.neo4j_search_data_extractor import Neo4jSearchDataExtractor
 from databuilder.extractor.snowflake_metadata_extractor import SnowflakeMetadataExtractor
+from databuilder.extractor.sql_alchemy_extractor import SQLAlchemyExtractor
 from databuilder.job.job import DefaultJob
+from databuilder.loader.file_system_elasticsearch_json_loader import FSElasticsearchJSONLoader
 from databuilder.loader.file_system_neo4j_csv_loader import FsNeo4jCSVLoader
 from databuilder.publisher import neo4j_csv_publisher
-from databuilder.publisher.neo4j_csv_publisher import Neo4jCsvPublisher
-from databuilder.extractor.neo4j_search_data_extractor import Neo4jSearchDataExtractor
-from databuilder.extractor.neo4j_extractor import Neo4jExtractor
-from databuilder.loader.file_system_elasticsearch_json_loader import FSElasticsearchJSONLoader
 from databuilder.publisher.elasticsearch_publisher import ElasticsearchPublisher
+from databuilder.publisher.neo4j_csv_publisher import Neo4jCsvPublisher
 from databuilder.task.task import DefaultTask
 from databuilder.transformer.base_transformer import NoopTransformer
 
@@ -63,7 +63,6 @@ es = Elasticsearch([
     {'host': 'elasticsearch'},
 ])
 
-
 # TODO: user provides a list of schema for indexing
 SUPPORTED_SCHEMAS = ['public']
 SUPPORTED_SCHEMA_SQL_IN_CLAUSE = "('{schemas}')".format(schemas="', '".join(SUPPORTED_SCHEMAS))
@@ -81,13 +80,7 @@ def connection_string():
     account = 'YourSnowflakeAccountHere'
     # specify a warehouse to connect to.
     warehouse = 'yourwarehouse'
-    return 'snowflake://{user}:{password}@{account}/{database}?warehouse={warehouse}'.format(
-        user=user,
-        password=password,
-        account=account,
-        database=SNOWFLAKE_DATABASE_KEY,
-        warehouse=warehouse,
-    )
+    return f'snowflake://{user}:{password}@{account}/{SNOWFLAKE_DATABASE_KEY}?warehouse={warehouse}'
 
 
 def create_snowflake_table_metadata_job():
@@ -102,32 +95,21 @@ def create_snowflake_table_metadata_job():
     """).format(schemas=SUPPORTED_SCHEMA_SQL_IN_CLAUSE)
 
     tmp_folder = '/var/tmp/amundsen/table_metadata'
-    node_files_folder = '{tmp_folder}/nodes/'.format(tmp_folder=tmp_folder)
-    relationship_files_folder = '{tmp_folder}/relationships/'.format(tmp_folder=tmp_folder)
+    node_files_folder = f'{tmp_folder}/nodes/'
+    relationship_files_folder = f'{tmp_folder}/relationships/'
 
     job_config = ConfigFactory.from_dict({
-        'extractor.snowflake.extractor.sqlalchemy.{}'.format(SQLAlchemyExtractor.CONN_STRING):
-            connection_string(),
-        'extractor.snowflake.{}'.format(SnowflakeMetadataExtractor.SNOWFLAKE_DATABASE_KEY):
-            SNOWFLAKE_DATABASE_KEY,
-        'extractor.snowflake.{}'.format(SnowflakeMetadataExtractor.WHERE_CLAUSE_SUFFIX_KEY):
-            where_clause_suffix,
-        'loader.filesystem_csv_neo4j.{}'.format(FsNeo4jCSVLoader.NODE_DIR_PATH):
-            node_files_folder,
-        'loader.filesystem_csv_neo4j.{}'.format(FsNeo4jCSVLoader.RELATION_DIR_PATH):
-            relationship_files_folder,
-        'publisher.neo4j.{}'.format(neo4j_csv_publisher.NODE_FILES_DIR):
-            node_files_folder,
-        'publisher.neo4j.{}'.format(neo4j_csv_publisher.RELATION_FILES_DIR):
-            relationship_files_folder,
-        'publisher.neo4j.{}'.format(neo4j_csv_publisher.NEO4J_END_POINT_KEY):
-            neo4j_endpoint,
-        'publisher.neo4j.{}'.format(neo4j_csv_publisher.NEO4J_USER):
-            neo4j_user,
-        'publisher.neo4j.{}'.format(neo4j_csv_publisher.NEO4J_PASSWORD):
-            neo4j_password,
-        'publisher.neo4j.{}'.format(neo4j_csv_publisher.JOB_PUBLISH_TAG):
-            'some_unique_tag'  # TO-DO unique tag must be added
+        f'extractor.snowflake.extractor.sqlalchemy.{SQLAlchemyExtractor.CONN_STRING}': connection_string(),
+        f'extractor.snowflake.{SnowflakeMetadataExtractor.SNOWFLAKE_DATABASE_KEY}': SNOWFLAKE_DATABASE_KEY,
+        f'extractor.snowflake.{SnowflakeMetadataExtractor.WHERE_CLAUSE_SUFFIX_KEY}': where_clause_suffix,
+        f'loader.filesystem_csv_neo4j.{FsNeo4jCSVLoader.NODE_DIR_PATH}': node_files_folder,
+        f'loader.filesystem_csv_neo4j.{FsNeo4jCSVLoader.RELATION_DIR_PATH}': relationship_files_folder,
+        f'publisher.neo4j.{neo4j_csv_publisher.NODE_FILES_DIR}': node_files_folder,
+        f'publisher.neo4j.{neo4j_csv_publisher.RELATION_FILES_DIR}': relationship_files_folder,
+        f'publisher.neo4j.{neo4j_csv_publisher.NEO4J_END_POINT_KEY}': neo4j_endpoint,
+        f'publisher.neo4j.{neo4j_csv_publisher.NEO4J_USER}': neo4j_user,
+        f'publisher.neo4j.{neo4j_csv_publisher.NEO4J_PASSWORD}': neo4j_password,
+        f'publisher.neo4j.{neo4j_csv_publisher.JOB_PUBLISH_TAG}': 'some_unique_tag'  # TO-DO unique tag must be added
     })
 
     job = DefaultJob(conf=job_config,
@@ -159,29 +141,22 @@ def create_snowflake_es_publisher_job():
     elasticsearch_index_alias = 'table_search_index'
 
     job_config = ConfigFactory.from_dict({
-        'extractor.search_data.extractor.neo4j.{}'.format(Neo4jExtractor.GRAPH_URL_CONFIG_KEY):
-            neo4j_endpoint,
-        'extractor.search_data.extractor.neo4j.{}'.format(Neo4jExtractor.MODEL_CLASS_CONFIG_KEY):
+        f'extractor.search_data.extractor.neo4j.{Neo4jExtractor.GRAPH_URL_CONFIG_KEY}': neo4j_endpoint,
+        f'extractor.search_data.extractor.neo4j.{Neo4jExtractor.MODEL_CLASS_CONFIG_KEY}':
             'databuilder.models.table_elasticsearch_document.TableESDocument',
-        'extractor.search_data.extractor.neo4j.{}'.format(Neo4jExtractor.NEO4J_AUTH_USER):
-            neo4j_user,
-        'extractor.search_data.extractor.neo4j.{}'.format(Neo4jExtractor.NEO4J_AUTH_PW):
-            neo4j_password,
-        'loader.filesystem.elasticsearch.{}'.format(FSElasticsearchJSONLoader.FILE_PATH_CONFIG_KEY):
-            extracted_search_data_path,
-        'loader.filesystem.elasticsearch.{}'.format(FSElasticsearchJSONLoader.FILE_MODE_CONFIG_KEY):
-            'w',
-        'publisher.elasticsearch.{}'.format(ElasticsearchPublisher.FILE_PATH_CONFIG_KEY):
-            extracted_search_data_path,
-        'publisher.elasticsearch.{}'.format(ElasticsearchPublisher.FILE_MODE_CONFIG_KEY):
-            'r',
-        'publisher.elasticsearch.{}'.format(ElasticsearchPublisher.ELASTICSEARCH_CLIENT_CONFIG_KEY):
+        f'extractor.search_data.extractor.neo4j.{Neo4jExtractor.NEO4J_AUTH_USER}': neo4j_user,
+        f'extractor.search_data.extractor.neo4j.{Neo4jExtractor.NEO4J_AUTH_PW}': neo4j_password,
+        f'loader.filesystem.elasticsearch.{FSElasticsearchJSONLoader.FILE_PATH_CONFIG_KEY}': extracted_search_data_path,
+        f'loader.filesystem.elasticsearch.{FSElasticsearchJSONLoader.FILE_MODE_CONFIG_KEY}': 'w',
+        f'publisher.elasticsearch.{ElasticsearchPublisher.FILE_PATH_CONFIG_KEY}': extracted_search_data_path,
+        f'publisher.elasticsearch.{ElasticsearchPublisher.FILE_MODE_CONFIG_KEY}': 'r',
+        f'publisher.elasticsearch.{ElasticsearchPublisher.ELASTICSEARCH_CLIENT_CONFIG_KEY}':
             elasticsearch_client,
-        'publisher.elasticsearch.{}'.format(ElasticsearchPublisher.ELASTICSEARCH_NEW_INDEX_CONFIG_KEY):
+        f'publisher.elasticsearch.{ElasticsearchPublisher.ELASTICSEARCH_NEW_INDEX_CONFIG_KEY}':
             elasticsearch_new_index_key,
-        'publisher.elasticsearch.{}'.format(ElasticsearchPublisher.ELASTICSEARCH_DOC_TYPE_CONFIG_KEY):
+        f'publisher.elasticsearch.{ElasticsearchPublisher.ELASTICSEARCH_DOC_TYPE_CONFIG_KEY}':
             elasticsearch_new_index_key_type,
-        'publisher.elasticsearch.{}'.format(ElasticsearchPublisher.ELASTICSEARCH_ALIAS_CONFIG_KEY):
+        f'publisher.elasticsearch.{ElasticsearchPublisher.ELASTICSEARCH_ALIAS_CONFIG_KEY}':
             elasticsearch_index_alias
     })
 
@@ -192,7 +167,6 @@ def create_snowflake_es_publisher_job():
 
 
 with DAG('amundsen_databuilder', default_args=default_args, **dag_args) as dag:
-
     snowflake_table_metadata_job = PythonOperator(
         task_id='snowflake_table_metadata_extract_job',
         python_callable=create_snowflake_table_metadata_job

--- a/example/scripts/sample_bigquery_metadata.py
+++ b/example/scripts/sample_bigquery_metadata.py
@@ -7,8 +7,9 @@ This is a example script for extracting BigQuery usage results
 
 import logging
 import os
-from pyhocon import ConfigFactory
 import sqlite3
+
+from pyhocon import ConfigFactory
 
 from databuilder.extractor.bigquery_metadata_extractor import BigQueryMetadataExtractor
 from databuilder.job.job import DefaultJob
@@ -21,7 +22,7 @@ from databuilder.transformer.base_transformer import NoopTransformer
 logging.basicConfig(level=logging.INFO)
 
 # set env NEO4J_HOST to override localhost
-NEO4J_ENDPOINT = 'bolt://{}:7687'.format(os.getenv('NEO4J_HOST', 'localhost'))
+NEO4J_ENDPOINT = f'bolt://{os.getenv("NEO4J_HOST", "localhost")}:7687'
 neo4j_endpoint = NEO4J_ENDPOINT
 
 neo4j_user = 'neo4j'
@@ -39,9 +40,9 @@ def create_connection(db_file):
 
 # todo: Add a second model
 def create_bq_job(metadata_type, gcloud_project):
-    tmp_folder = '/var/tmp/amundsen/{metadata_type}'.format(metadata_type=metadata_type)
-    node_files_folder = '{tmp_folder}/nodes'.format(tmp_folder=tmp_folder)
-    relationship_files_folder = '{tmp_folder}/relationships'.format(tmp_folder=tmp_folder)
+    tmp_folder = f'/var/tmp/amundsen/{metadata_type}'
+    node_files_folder = f'{tmp_folder}/nodes'
+    relationship_files_folder = f'{tmp_folder}/relationships'
 
     bq_meta_extractor = BigQueryMetadataExtractor()
     csv_loader = FsNeo4jCSVLoader()
@@ -51,26 +52,16 @@ def create_bq_job(metadata_type, gcloud_project):
                        transformer=NoopTransformer())
 
     job_config = ConfigFactory.from_dict({
-        'extractor.bigquery_table_metadata.{}'.format(BigQueryMetadataExtractor.PROJECT_ID_KEY):
-            gcloud_project,
-        'loader.filesystem_csv_neo4j.{}'.format(FsNeo4jCSVLoader.NODE_DIR_PATH):
-            node_files_folder,
-        'loader.filesystem_csv_neo4j.{}'.format(FsNeo4jCSVLoader.RELATION_DIR_PATH):
-            relationship_files_folder,
-        'loader.filesystem_csv_neo4j.{}'.format(FsNeo4jCSVLoader.SHOULD_DELETE_CREATED_DIR):
-            True,
-        'publisher.neo4j.{}'.format(neo4j_csv_publisher.NODE_FILES_DIR):
-            node_files_folder,
-        'publisher.neo4j.{}'.format(neo4j_csv_publisher.RELATION_FILES_DIR):
-            relationship_files_folder,
-        'publisher.neo4j.{}'.format(neo4j_csv_publisher.NEO4J_END_POINT_KEY):
-            neo4j_endpoint,
-        'publisher.neo4j.{}'.format(neo4j_csv_publisher.NEO4J_USER):
-            neo4j_user,
-        'publisher.neo4j.{}'.format(neo4j_csv_publisher.NEO4J_PASSWORD):
-            neo4j_password,
-        'publisher.neo4j.{}'.format(neo4j_csv_publisher.JOB_PUBLISH_TAG):
-            'unique_tag',  # should use unique tag here like {ds}
+        f'extractor.bigquery_table_metadata.{BigQueryMetadataExtractor.PROJECT_ID_KEY}': gcloud_project,
+        f'loader.filesystem_csv_neo4j.{FsNeo4jCSVLoader.NODE_DIR_PATH}': node_files_folder,
+        f'loader.filesystem_csv_neo4j.{FsNeo4jCSVLoader.RELATION_DIR_PATH}': relationship_files_folder,
+        f'loader.filesystem_csv_neo4j.{FsNeo4jCSVLoader.SHOULD_DELETE_CREATED_DIR}': True,
+        f'publisher.neo4j.{neo4j_csv_publisher.NODE_FILES_DIR}': node_files_folder,
+        f'publisher.neo4j.{neo4j_csv_publisher.RELATION_FILES_DIR}': relationship_files_folder,
+        f'publisher.neo4j.{neo4j_csv_publisher.NEO4J_END_POINT_KEY}': neo4j_endpoint,
+        f'publisher.neo4j.{neo4j_csv_publisher.NEO4J_USER}': neo4j_user,
+        f'publisher.neo4j.{neo4j_csv_publisher.NEO4J_PASSWORD}': neo4j_password,
+        f'publisher.neo4j.{neo4j_csv_publisher.JOB_PUBLISH_TAG}': 'unique_tag',  # should use unique tag here like {ds}
     })
     job = DefaultJob(conf=job_config,
                      task=task,

--- a/example/scripts/sample_bq_usage_loader.py
+++ b/example/scripts/sample_bq_usage_loader.py
@@ -7,8 +7,9 @@ This is a example script for extracting BigQuery usage results
 
 import logging
 import os
-from pyhocon import ConfigFactory
 import sqlite3
+
+from pyhocon import ConfigFactory
 
 from databuilder.extractor.bigquery_usage_extractor import BigQueryTableUsageExtractor
 from databuilder.job.job import DefaultJob
@@ -21,7 +22,7 @@ from databuilder.transformer.bigquery_usage_transformer import BigqueryUsageTran
 logging.basicConfig(level=logging.INFO)
 
 # set env NEO4J_HOST to override localhost
-NEO4J_ENDPOINT = 'bolt://{}:7687'.format(os.getenv('NEO4J_HOST', 'localhost'))
+NEO4J_ENDPOINT = f'bolt://{os.getenv("NEO4J_HOST", "localhost")}:7687'
 neo4j_endpoint = NEO4J_ENDPOINT
 
 neo4j_user = 'neo4j'
@@ -39,9 +40,9 @@ def create_connection(db_file):
 
 # todo: Add a second model
 def create_bq_job(metadata_type, gcloud_project):
-    tmp_folder = '/var/tmp/amundsen/{metadata_type}'.format(metadata_type=metadata_type)
-    node_files_folder = '{tmp_folder}/nodes'.format(tmp_folder=tmp_folder)
-    relationship_files_folder = '{tmp_folder}/relationships'.format(tmp_folder=tmp_folder)
+    tmp_folder = f'/var/tmp/amundsen/{metadata_type}'
+    node_files_folder = f'{tmp_folder}/nodes'
+    relationship_files_folder = f'{tmp_folder}/relationships'
 
     bq_usage_extractor = BigQueryTableUsageExtractor()
     csv_loader = FsNeo4jCSVLoader()
@@ -51,26 +52,16 @@ def create_bq_job(metadata_type, gcloud_project):
                        transformer=BigqueryUsageTransformer())
 
     job_config = ConfigFactory.from_dict({
-        'extractor.bigquery_table_usage.{}'.format(BigQueryTableUsageExtractor.PROJECT_ID_KEY):
-            gcloud_project,
-        'loader.filesystem_csv_neo4j.{}'.format(FsNeo4jCSVLoader.NODE_DIR_PATH):
-            node_files_folder,
-        'loader.filesystem_csv_neo4j.{}'.format(FsNeo4jCSVLoader.RELATION_DIR_PATH):
-            relationship_files_folder,
-        'loader.filesystem_csv_neo4j.{}'.format(FsNeo4jCSVLoader.SHOULD_DELETE_CREATED_DIR):
-            True,
-        'publisher.neo4j.{}'.format(neo4j_csv_publisher.NODE_FILES_DIR):
-            node_files_folder,
-        'publisher.neo4j.{}'.format(neo4j_csv_publisher.RELATION_FILES_DIR):
-            relationship_files_folder,
-        'publisher.neo4j.{}'.format(neo4j_csv_publisher.NEO4J_END_POINT_KEY):
-            neo4j_endpoint,
-        'publisher.neo4j.{}'.format(neo4j_csv_publisher.NEO4J_USER):
-            neo4j_user,
-        'publisher.neo4j.{}'.format(neo4j_csv_publisher.NEO4J_PASSWORD):
-            neo4j_password,
-        'publisher.neo4j.{}'.format(neo4j_csv_publisher.JOB_PUBLISH_TAG):
-            'unique_tag',  # should use unique tag here like {ds}
+        f'extractor.bigquery_table_usage.{BigQueryTableUsageExtractor.PROJECT_ID_KEY}': gcloud_project,
+        f'loader.filesystem_csv_neo4j.{FsNeo4jCSVLoader.NODE_DIR_PATH}': node_files_folder,
+        f'loader.filesystem_csv_neo4j.{FsNeo4jCSVLoader.RELATION_DIR_PATH}': relationship_files_folder,
+        f'loader.filesystem_csv_neo4j.{FsNeo4jCSVLoader.SHOULD_DELETE_CREATED_DIR}': True,
+        f'publisher.neo4j.{neo4j_csv_publisher.NODE_FILES_DIR}': node_files_folder,
+        f'publisher.neo4j.{neo4j_csv_publisher.RELATION_FILES_DIR}': relationship_files_folder,
+        f'publisher.neo4j.{neo4j_csv_publisher.NEO4J_END_POINT_KEY}': neo4j_endpoint,
+        f'publisher.neo4j.{neo4j_csv_publisher.NEO4J_USER}': neo4j_user,
+        f'publisher.neo4j.{neo4j_csv_publisher.NEO4J_PASSWORD}': neo4j_password,
+        f'publisher.neo4j.{neo4j_csv_publisher.JOB_PUBLISH_TAG}': 'unique_tag',  # should use unique tag here like {ds}
     })
     job = DefaultJob(conf=job_config,
                      task=task,

--- a/example/scripts/sample_data_loader.py
+++ b/example/scripts/sample_data_loader.py
@@ -29,21 +29,25 @@ from elasticsearch import Elasticsearch
 from pyhocon import ConfigFactory
 from sqlalchemy.ext.declarative import declarative_base
 
-from databuilder.extractor.csv_extractor import CsvTableBadgeExtractor, CsvTableColumnExtractor, CsvExtractor
+from databuilder.extractor.csv_extractor import (
+    CsvExtractor, CsvTableBadgeExtractor, CsvTableColumnExtractor,
+)
 from databuilder.extractor.neo4j_es_last_updated_extractor import Neo4jEsLastUpdatedExtractor
 from databuilder.extractor.neo4j_search_data_extractor import Neo4jSearchDataExtractor
 from databuilder.job.job import DefaultJob
 from databuilder.loader.file_system_elasticsearch_json_loader import FSElasticsearchJSONLoader
 from databuilder.loader.file_system_neo4j_csv_loader import FsNeo4jCSVLoader
-from databuilder.publisher.elasticsearch_constants import DASHBOARD_ELASTICSEARCH_INDEX_MAPPING, \
-    USER_ELASTICSEARCH_INDEX_MAPPING
+from databuilder.publisher.elasticsearch_constants import (
+    DASHBOARD_ELASTICSEARCH_INDEX_MAPPING, USER_ELASTICSEARCH_INDEX_MAPPING,
+)
 from databuilder.publisher.elasticsearch_publisher import ElasticsearchPublisher
 from databuilder.publisher.neo4j_csv_publisher import Neo4jCsvPublisher
 from databuilder.task.task import DefaultTask
-from databuilder.transformer.base_transformer import ChainedTransformer
-from databuilder.transformer.base_transformer import NoopTransformer
-from databuilder.transformer.dict_to_model import DictToModel, MODEL_CLASS
-from databuilder.transformer.generic_transformer import GenericTransformer, CALLBACK_FUNCTION, FIELD_NAME
+from databuilder.transformer.base_transformer import ChainedTransformer, NoopTransformer
+from databuilder.transformer.dict_to_model import MODEL_CLASS, DictToModel
+from databuilder.transformer.generic_transformer import (
+    CALLBACK_FUNCTION, FIELD_NAME, GenericTransformer,
+)
 
 es_host = os.getenv('CREDENTIALS_ELASTICSEARCH_PROXY_HOST', 'localhost')
 neo_host = os.getenv('CREDENTIALS_NEO4J_PROXY_HOST', 'localhost')

--- a/example/scripts/sample_data_loader.py
+++ b/example/scripts/sample_data_loader.py
@@ -61,7 +61,7 @@ es = Elasticsearch([
 
 Base = declarative_base()
 
-NEO4J_ENDPOINT = 'bolt://{}:{}'.format(neo_host, neo_port)
+NEO4J_ENDPOINT = f'bolt://{neo_host}:{neo_port}'
 
 neo4j_endpoint = NEO4J_ENDPOINT
 
@@ -72,9 +72,9 @@ LOGGER = logging.getLogger(__name__)
 
 
 def run_csv_job(file_loc, job_name, model):
-    tmp_folder = '/var/tmp/amundsen/{job_name}'.format(job_name=job_name)
-    node_files_folder = '{tmp_folder}/nodes'.format(tmp_folder=tmp_folder)
-    relationship_files_folder = '{tmp_folder}/relationships'.format(tmp_folder=tmp_folder)
+    tmp_folder = f'/var/tmp/amundsen/{job_name}'
+    node_files_folder = f'{tmp_folder}/nodes'
+    relationship_files_folder = f'{tmp_folder}/relationships'
 
     csv_extractor = CsvExtractor()
     csv_loader = FsNeo4jCSVLoader()
@@ -105,8 +105,8 @@ def run_csv_job(file_loc, job_name, model):
 
 def run_table_badge_job(table_path, badge_path):
     tmp_folder = '/var/tmp/amundsen/table_badge'
-    node_files_folder = '{tmp_folder}/nodes'.format(tmp_folder=tmp_folder)
-    relationship_files_folder = '{tmp_folder}/relationships'.format(tmp_folder=tmp_folder)
+    node_files_folder = f'{tmp_folder}/nodes'
+    relationship_files_folder = f'{tmp_folder}/relationships'
     extractor = CsvTableBadgeExtractor()
     csv_loader = FsNeo4jCSVLoader()
     task = DefaultTask(extractor=extractor,
@@ -134,8 +134,8 @@ def run_table_badge_job(table_path, badge_path):
 
 def run_table_column_job(table_path, column_path):
     tmp_folder = '/var/tmp/amundsen/table_column'
-    node_files_folder = '{tmp_folder}/nodes'.format(tmp_folder=tmp_folder)
-    relationship_files_folder = '{tmp_folder}/relationships'.format(tmp_folder=tmp_folder)
+    node_files_folder = f'{tmp_folder}/nodes'
+    relationship_files_folder = f'{tmp_folder}/relationships'
     extractor = CsvTableColumnExtractor()
     csv_loader = FsNeo4jCSVLoader()
     task = DefaultTask(extractor,
@@ -164,8 +164,8 @@ def run_table_column_job(table_path, column_path):
 def create_last_updated_job():
     # loader saves data to these folders and publisher reads it from here
     tmp_folder = '/var/tmp/amundsen/last_updated_data'
-    node_files_folder = '{tmp_folder}/nodes'.format(tmp_folder=tmp_folder)
-    relationship_files_folder = '{tmp_folder}/relationships'.format(tmp_folder=tmp_folder)
+    node_files_folder = f'{tmp_folder}/nodes'
+    relationship_files_folder = f'{tmp_folder}/relationships'
 
     task = DefaultTask(extractor=Neo4jEsLastUpdatedExtractor(),
                        loader=FsNeo4jCSVLoader())
@@ -197,8 +197,8 @@ def _str_to_list(str_val):
 def create_dashboard_tables_job():
     # loader saves data to these folders and publisher reads it from here
     tmp_folder = '/var/tmp/amundsen/dashboard_table'
-    node_files_folder = '{tmp_folder}/nodes'.format(tmp_folder=tmp_folder)
-    relationship_files_folder = '{tmp_folder}/relationships'.format(tmp_folder=tmp_folder)
+    node_files_folder = f'{tmp_folder}/nodes'
+    relationship_files_folder = f'{tmp_folder}/relationships'
 
     csv_extractor = CsvExtractor()
     csv_loader = FsNeo4jCSVLoader()
@@ -214,21 +214,21 @@ def create_dashboard_tables_job():
     publisher = Neo4jCsvPublisher()
 
     job_config = ConfigFactory.from_dict({
-        '{}.file_location'.format(csv_extractor.get_scope()): 'example/sample_data/sample_dashboard_table.csv',
-        '{}.{}.{}'.format(transformer.get_scope(), generic_transformer.get_scope(), FIELD_NAME): 'table_ids',
-        '{}.{}.{}'.format(transformer.get_scope(), generic_transformer.get_scope(), CALLBACK_FUNCTION): _str_to_list,
-        '{}.{}.{}'.format(transformer.get_scope(), dict_to_model_transformer.get_scope(), MODEL_CLASS):
+        f'{csv_extractor.get_scope()}.file_location': 'example/sample_data/sample_dashboard_table.csv',
+        f'{transformer.get_scope()}.{generic_transformer.get_scope()}.{FIELD_NAME}': 'table_ids',
+        f'{transformer.get_scope()}.{generic_transformer.get_scope()}.{CALLBACK_FUNCTION}': _str_to_list,
+        f'{transformer.get_scope()}.{dict_to_model_transformer.get_scope()}.{MODEL_CLASS}':
             'databuilder.models.dashboard.dashboard_table.DashboardTable',
-        '{}.node_dir_path'.format(csv_loader.get_scope()): node_files_folder,
-        '{}.relationship_dir_path'.format(csv_loader.get_scope()): relationship_files_folder,
-        '{}.delete_created_directories'.format(csv_loader.get_scope()): True,
-        '{}.node_files_directory'.format(publisher.get_scope()): node_files_folder,
-        '{}.relation_files_directory'.format(publisher.get_scope()): relationship_files_folder,
-        '{}.neo4j_endpoint'.format(publisher.get_scope()): neo4j_endpoint,
-        '{}.neo4j_user'.format(publisher.get_scope()): neo4j_user,
-        '{}.neo4j_password'.format(publisher.get_scope()): neo4j_password,
-        '{}.neo4j_encrypted'.format(publisher.get_scope()): False,
-        '{}.job_publish_tag'.format(publisher.get_scope()): 'unique_tag',  # should use unique tag here like {ds}
+        f'{csv_loader.get_scope()}.node_dir_path': node_files_folder,
+        f'{csv_loader.get_scope()}.relationship_dir_path': relationship_files_folder,
+        f'{csv_loader.get_scope()}.delete_created_directories': True,
+        f'{publisher.get_scope()}.node_files_directory': node_files_folder,
+        f'{publisher.get_scope()}.relation_files_directory': relationship_files_folder,
+        f'{publisher.get_scope()}.neo4j_endpoint': neo4j_endpoint,
+        f'{publisher.get_scope()}.neo4j_user': neo4j_user,
+        f'{publisher.get_scope()}.neo4j_password': neo4j_password,
+        f'{publisher.get_scope()}.neo4j_encrypted': False,
+        f'{publisher.get_scope()}.job_publish_tag': 'unique_tag',  # should use unique tag here like {ds}
     })
 
     return DefaultJob(conf=job_config,
@@ -262,7 +262,7 @@ def create_es_publisher_sample_job(elasticsearch_index_alias='table_search_index
     # elastic search client instance
     elasticsearch_client = es
     # unique name of new index in Elasticsearch
-    elasticsearch_new_index_key = '{}_'.format(elasticsearch_doc_type_key) + str(uuid.uuid4())
+    elasticsearch_new_index_key = f'{elasticsearch_doc_type_key}_{uuid.uuid4()}'
 
     job_config = ConfigFactory.from_dict({
         'extractor.search_data.entity_type': entity_type,
@@ -283,7 +283,7 @@ def create_es_publisher_sample_job(elasticsearch_index_alias='table_search_index
 
     # only optionally add these keys, so need to dynamically `put` them
     if elasticsearch_mapping:
-        job_config.put('publisher.elasticsearch.{}'.format(ElasticsearchPublisher.ELASTICSEARCH_MAPPING_CONFIG_KEY),
+        job_config.put(f'publisher.elasticsearch.{ElasticsearchPublisher.ELASTICSEARCH_MAPPING_CONFIG_KEY}',
                        elasticsearch_mapping)
 
     job = DefaultJob(conf=job_config,

--- a/example/scripts/sample_db2_data_loader.py
+++ b/example/scripts/sample_db2_data_loader.py
@@ -7,25 +7,24 @@ This is a example script which demo how to load data into neo4j without using Ai
 
 import logging
 import os
-from pyhocon import ConfigFactory
-
 import sys
 import uuid
 
-from databuilder.extractor.sql_alchemy_extractor import SQLAlchemyExtractor
+from elasticsearch import Elasticsearch
+from pyhocon import ConfigFactory
+
 from databuilder.extractor.db2_metadata_extractor import Db2MetadataExtractor
+from databuilder.extractor.neo4j_extractor import Neo4jExtractor
+from databuilder.extractor.neo4j_search_data_extractor import Neo4jSearchDataExtractor
+from databuilder.extractor.sql_alchemy_extractor import SQLAlchemyExtractor
 from databuilder.job.job import DefaultJob
+from databuilder.loader.file_system_elasticsearch_json_loader import FSElasticsearchJSONLoader
 from databuilder.loader.file_system_neo4j_csv_loader import FsNeo4jCSVLoader
 from databuilder.publisher import neo4j_csv_publisher
+from databuilder.publisher.elasticsearch_publisher import ElasticsearchPublisher
 from databuilder.publisher.neo4j_csv_publisher import Neo4jCsvPublisher
 from databuilder.task.task import DefaultTask
-
-from elasticsearch import Elasticsearch
-from databuilder.loader.file_system_elasticsearch_json_loader import FSElasticsearchJSONLoader
-from databuilder.extractor.neo4j_search_data_extractor import Neo4jSearchDataExtractor
 from databuilder.transformer.base_transformer import NoopTransformer
-from databuilder.extractor.neo4j_extractor import Neo4jExtractor
-from databuilder.publisher.elasticsearch_publisher import ElasticsearchPublisher
 
 LOGGER = logging.getLogger(__name__)
 LOGGER.setLevel(logging.INFO)
@@ -35,7 +34,7 @@ logging.getLogger("db2.connector.network").disabled = True
 DB2_CONN_STRING = 'db2+ibm_db://username:password@database.host.name:50000/DB;'
 
 # set env NEO4J_HOST to override localhost
-NEO4J_ENDPOINT = 'bolt://{}:7687'.format(os.getenv('NEO4J_HOST', 'localhost'))
+NEO4J_ENDPOINT = f'bolt://{os.getenv("NEO4J_HOST", "localhost")}:7687'
 neo4j_endpoint = NEO4J_ENDPOINT
 
 neo4j_user = 'neo4j'
@@ -56,12 +55,11 @@ IGNORED_SCHEMAS = ['\'SYSIBM\'', '\'SYSIBMTS\'', '\'SYSTOOLS\'', '\'SYSCAT\'', '
 
 
 def create_sample_db2_job():
+    where_clause = f"WHERE c.TABSCHEMA not in ({','.join(IGNORED_SCHEMAS)}) ;"
 
-    where_clause = "WHERE c.TABSCHEMA not in ({0}) ;".format(','.join(IGNORED_SCHEMAS))
-
-    tmp_folder = '/var/tmp/amundsen/{}'.format('tables')
-    node_files_folder = '{tmp_folder}/nodes'.format(tmp_folder=tmp_folder)
-    relationship_files_folder = '{tmp_folder}/relationships'.format(tmp_folder=tmp_folder)
+    tmp_folder = '/var/tmp/amundsen/tables'
+    node_files_folder = f'{tmp_folder}/nodes'
+    relationship_files_folder = f'{tmp_folder}/relationships'
 
     sql_extractor = Db2MetadataExtractor()
     csv_loader = FsNeo4jCSVLoader()
@@ -70,19 +68,19 @@ def create_sample_db2_job():
                        loader=csv_loader)
 
     job_config = ConfigFactory.from_dict({
-        'extractor.db2_metadata.extractor.sqlalchemy.{}'.format(SQLAlchemyExtractor.CONN_STRING): DB2_CONN_STRING,
-        'extractor.db2_metadata.{}'.format(Db2MetadataExtractor.DATABASE_KEY): 'DEMODB',
-        'extractor.db2_metadata.{}'.format(Db2MetadataExtractor.WHERE_CLAUSE_SUFFIX_KEY): where_clause,
-        'loader.filesystem_csv_neo4j.{}'.format(FsNeo4jCSVLoader.NODE_DIR_PATH): node_files_folder,
-        'loader.filesystem_csv_neo4j.{}'.format(FsNeo4jCSVLoader.RELATION_DIR_PATH): relationship_files_folder,
-        'loader.filesystem_csv_neo4j.{}'.format(FsNeo4jCSVLoader.SHOULD_DELETE_CREATED_DIR): True,
-        'loader.filesystem_csv_neo4j.{}'.format(FsNeo4jCSVLoader.FORCE_CREATE_DIR): True,
-        'publisher.neo4j.{}'.format(neo4j_csv_publisher.NODE_FILES_DIR): node_files_folder,
-        'publisher.neo4j.{}'.format(neo4j_csv_publisher.RELATION_FILES_DIR): relationship_files_folder,
-        'publisher.neo4j.{}'.format(neo4j_csv_publisher.NEO4J_END_POINT_KEY): neo4j_endpoint,
-        'publisher.neo4j.{}'.format(neo4j_csv_publisher.NEO4J_USER): neo4j_user,
-        'publisher.neo4j.{}'.format(neo4j_csv_publisher.NEO4J_PASSWORD): neo4j_password,
-        'publisher.neo4j.{}'.format(neo4j_csv_publisher.JOB_PUBLISH_TAG): 'unique_tag'
+        f'extractor.db2_metadata.extractor.sqlalchemy.{SQLAlchemyExtractor.CONN_STRING}': DB2_CONN_STRING,
+        f'extractor.db2_metadata.{Db2MetadataExtractor.DATABASE_KEY}': 'DEMODB',
+        f'extractor.db2_metadata.{Db2MetadataExtractor.WHERE_CLAUSE_SUFFIX_KEY}': where_clause,
+        f'loader.filesystem_csv_neo4j.{FsNeo4jCSVLoader.NODE_DIR_PATH}': node_files_folder,
+        f'loader.filesystem_csv_neo4j.{FsNeo4jCSVLoader.RELATION_DIR_PATH}': relationship_files_folder,
+        f'loader.filesystem_csv_neo4j.{FsNeo4jCSVLoader.SHOULD_DELETE_CREATED_DIR}': True,
+        f'loader.filesystem_csv_neo4j.{FsNeo4jCSVLoader.FORCE_CREATE_DIR}': True,
+        f'publisher.neo4j.{neo4j_csv_publisher.NODE_FILES_DIR}': node_files_folder,
+        f'publisher.neo4j.{neo4j_csv_publisher.RELATION_FILES_DIR}': relationship_files_folder,
+        f'publisher.neo4j.{neo4j_csv_publisher.NEO4J_END_POINT_KEY}': neo4j_endpoint,
+        f'publisher.neo4j.{neo4j_csv_publisher.NEO4J_USER}': neo4j_user,
+        f'publisher.neo4j.{neo4j_csv_publisher.NEO4J_PASSWORD}': neo4j_password,
+        f'publisher.neo4j.{neo4j_csv_publisher.JOB_PUBLISH_TAG}': 'unique_tag'
     })
     job = DefaultJob(conf=job_config,
                      task=task,
@@ -119,32 +117,29 @@ def create_es_publisher_sample_job(elasticsearch_index_alias='table_search_index
     elasticsearch_new_index_key = 'tables' + str(uuid.uuid4())
 
     job_config = ConfigFactory.from_dict({
-        'extractor.search_data.extractor.neo4j.{}'.format(Neo4jExtractor.GRAPH_URL_CONFIG_KEY): neo4j_endpoint,
-        'extractor.search_data.extractor.neo4j.{}'.format(Neo4jExtractor.MODEL_CLASS_CONFIG_KEY): model_name,
-        'extractor.search_data.extractor.neo4j.{}'.format(Neo4jExtractor.NEO4J_AUTH_USER): neo4j_user,
-        'extractor.search_data.extractor.neo4j.{}'.format(Neo4jExtractor.NEO4J_AUTH_PW): neo4j_password,
-        'loader.filesystem.elasticsearch.{}'.format(FSElasticsearchJSONLoader.FILE_PATH_CONFIG_KEY):
-            extracted_search_data_path,
-        'loader.filesystem.elasticsearch.{}'.format(FSElasticsearchJSONLoader.FILE_MODE_CONFIG_KEY): 'w',
-        'publisher.elasticsearch.{}'.format(ElasticsearchPublisher.FILE_PATH_CONFIG_KEY):
-            extracted_search_data_path,
-        'publisher.elasticsearch.{}'.format(ElasticsearchPublisher.FILE_MODE_CONFIG_KEY): 'r',
-        'publisher.elasticsearch.{}'.format(ElasticsearchPublisher.ELASTICSEARCH_CLIENT_CONFIG_KEY):
+        f'extractor.search_data.extractor.neo4j.{Neo4jExtractor.GRAPH_URL_CONFIG_KEY}': neo4j_endpoint,
+        f'extractor.search_data.extractor.neo4j.{Neo4jExtractor.MODEL_CLASS_CONFIG_KEY}': model_name,
+        f'extractor.search_data.extractor.neo4j.{Neo4jExtractor.NEO4J_AUTH_USER}': neo4j_user,
+        f'extractor.search_data.extractor.neo4j.{Neo4jExtractor.NEO4J_AUTH_PW}': neo4j_password,
+        f'loader.filesystem.elasticsearch.{FSElasticsearchJSONLoader.FILE_PATH_CONFIG_KEY}': extracted_search_data_path,
+        f'loader.filesystem.elasticsearch.{FSElasticsearchJSONLoader.FILE_MODE_CONFIG_KEY}': 'w',
+        f'publisher.elasticsearch.{ElasticsearchPublisher.FILE_PATH_CONFIG_KEY}': extracted_search_data_path,
+        f'publisher.elasticsearch.{ElasticsearchPublisher.FILE_MODE_CONFIG_KEY}': 'r',
+        f'publisher.elasticsearch.{ElasticsearchPublisher.ELASTICSEARCH_CLIENT_CONFIG_KEY}':
             elasticsearch_client,
-        'publisher.elasticsearch.{}'.format(ElasticsearchPublisher.ELASTICSEARCH_NEW_INDEX_CONFIG_KEY):
+        f'publisher.elasticsearch.{ElasticsearchPublisher.ELASTICSEARCH_NEW_INDEX_CONFIG_KEY}':
             elasticsearch_new_index_key,
-        'publisher.elasticsearch.{}'.format(ElasticsearchPublisher.ELASTICSEARCH_DOC_TYPE_CONFIG_KEY):
+        f'publisher.elasticsearch.{ElasticsearchPublisher.ELASTICSEARCH_DOC_TYPE_CONFIG_KEY}':
             elasticsearch_doc_type_key,
-        'publisher.elasticsearch.{}'.format(ElasticsearchPublisher.ELASTICSEARCH_ALIAS_CONFIG_KEY):
+        f'publisher.elasticsearch.{ElasticsearchPublisher.ELASTICSEARCH_ALIAS_CONFIG_KEY}':
             elasticsearch_index_alias,
     })
 
     # only optionally add these keys, so need to dynamically `put` them
     if cypher_query:
-        job_config.put('extractor.search_data.{}'.format(Neo4jSearchDataExtractor.CYPHER_QUERY_CONFIG_KEY),
-                       cypher_query)
+        job_config.put(f'extractor.search_data.{Neo4jSearchDataExtractor.CYPHER_QUERY_CONFIG_KEY}', cypher_query)
     if elasticsearch_mapping:
-        job_config.put('publisher.elasticsearch.{}'.format(ElasticsearchPublisher.ELASTICSEARCH_MAPPING_CONFIG_KEY),
+        job_config.put(f'publisher.elasticsearch.{ElasticsearchPublisher.ELASTICSEARCH_MAPPING_CONFIG_KEY}',
                        elasticsearch_mapping)
 
     job = DefaultJob(conf=job_config,

--- a/example/scripts/sample_deltalake_metadata.py
+++ b/example/scripts/sample_deltalake_metadata.py
@@ -5,6 +5,9 @@
 This is a example script for extracting Delta Lake Metadata Results
 """
 
+from pyhocon import ConfigFactory
+from pyspark.sql import SparkSession
+
 from databuilder.extractor.delta_lake_metadata_extractor import DeltaLakeMetadataExtractor
 from databuilder.job.job import DefaultJob
 from databuilder.loader.file_system_neo4j_csv_loader import FsNeo4jCSVLoader
@@ -12,8 +15,6 @@ from databuilder.models.table_metadata import DESCRIPTION_NODE_LABEL
 from databuilder.publisher import neo4j_csv_publisher
 from databuilder.publisher.neo4j_csv_publisher import Neo4jCsvPublisher
 from databuilder.task.task import DefaultTask
-from pyhocon import ConfigFactory
-from pyspark.sql import SparkSession
 
 # NEO4J cluster endpoints
 NEO4J_ENDPOINT = 'bolt://localhost:7687/'
@@ -32,33 +33,23 @@ exclude_list = ['bad_schema']
 
 def create_delta_lake_job_config():
     tmp_folder = '/var/tmp/amundsen/table_metadata'
-    node_files_folder = '{tmp_folder}/nodes/'.format(tmp_folder=tmp_folder)
-    relationship_files_folder = '{tmp_folder}/relationships/'.format(tmp_folder=tmp_folder)
+    node_files_folder = f'{tmp_folder}/nodes/'
+    relationship_files_folder = f'{tmp_folder}/relationships/'
 
     job_config = ConfigFactory.from_dict({
-        'extractor.delta_lake_table_metadata.{}'.format(DeltaLakeMetadataExtractor.CLUSTER_KEY): cluster_key,
-        'extractor.delta_lake_table_metadata.{}'.format(DeltaLakeMetadataExtractor.DATABASE_KEY): database,
-        'extractor.delta_lake_table_metadata.{}'.format(DeltaLakeMetadataExtractor.SCHEMA_LIST_KEY): schema_list,
-        'extractor.delta_lake_table_metadata.{}'.format(DeltaLakeMetadataExtractor.EXCLUDE_LIST_SCHEMAS_KEY):
-            exclude_list,
-        'loader.filesystem_csv_neo4j.{}'.format(FsNeo4jCSVLoader.NODE_DIR_PATH):
-            node_files_folder,
-        'loader.filesystem_csv_neo4j.{}'.format(FsNeo4jCSVLoader.RELATION_DIR_PATH):
-            relationship_files_folder,
-        'publisher.neo4j.{}'.format(neo4j_csv_publisher.NODE_FILES_DIR):
-            node_files_folder,
-        'publisher.neo4j.{}'.format(neo4j_csv_publisher.RELATION_FILES_DIR):
-            relationship_files_folder,
-        'publisher.neo4j.{}'.format(neo4j_csv_publisher.NEO4J_END_POINT_KEY):
-            neo4j_endpoint,
-        'publisher.neo4j.{}'.format(neo4j_csv_publisher.NEO4J_USER):
-            neo4j_user,
-        'publisher.neo4j.{}'.format(neo4j_csv_publisher.NEO4J_PASSWORD):
-            neo4j_password,
-        'publisher.neo4j.{}'.format(neo4j_csv_publisher.NEO4J_CREATE_ONLY_NODES):
-            [DESCRIPTION_NODE_LABEL],
-        'publisher.neo4j.job_publish_tag':
-            'some_unique_tag'  # TO-DO unique tag must be added
+        f'extractor.delta_lake_table_metadata.{DeltaLakeMetadataExtractor.CLUSTER_KEY}': cluster_key,
+        f'extractor.delta_lake_table_metadata.{DeltaLakeMetadataExtractor.DATABASE_KEY}': database,
+        f'extractor.delta_lake_table_metadata.{DeltaLakeMetadataExtractor.SCHEMA_LIST_KEY}': schema_list,
+        f'extractor.delta_lake_table_metadata.{DeltaLakeMetadataExtractor.EXCLUDE_LIST_SCHEMAS_KEY}': exclude_list,
+        f'loader.filesystem_csv_neo4j.{FsNeo4jCSVLoader.NODE_DIR_PATH}': node_files_folder,
+        f'loader.filesystem_csv_neo4j.{FsNeo4jCSVLoader.RELATION_DIR_PATH}': relationship_files_folder,
+        f'publisher.neo4j.{neo4j_csv_publisher.NODE_FILES_DIR}': node_files_folder,
+        f'publisher.neo4j.{neo4j_csv_publisher.RELATION_FILES_DIR}': relationship_files_folder,
+        f'publisher.neo4j.{neo4j_csv_publisher.NEO4J_END_POINT_KEY}': neo4j_endpoint,
+        f'publisher.neo4j.{neo4j_csv_publisher.NEO4J_USER}': neo4j_user,
+        f'publisher.neo4j.{neo4j_csv_publisher.NEO4J_PASSWORD}': neo4j_password,
+        f'publisher.neo4j.{neo4j_csv_publisher.NEO4J_CREATE_ONLY_NODES}': [DESCRIPTION_NODE_LABEL],
+        f'publisher.neo4j.job_publish_tag': 'some_unique_tag'  # TO-DO unique tag must be added
     })
     return job_config
 

--- a/example/scripts/sample_feast_loader.py
+++ b/example/scripts/sample_feast_loader.py
@@ -13,17 +13,19 @@ For example:
 
 import sys
 import uuid
+
+from elasticsearch.client import Elasticsearch
+from pyhocon import ConfigFactory
+
 from databuilder.extractor.feast_extractor import FeastExtractor
 from databuilder.extractor.neo4j_extractor import Neo4jExtractor
 from databuilder.extractor.neo4j_search_data_extractor import Neo4jSearchDataExtractor
 from databuilder.job.job import DefaultJob
-from databuilder.loader.file_system_neo4j_csv_loader import FsNeo4jCSVLoader
 from databuilder.loader.file_system_elasticsearch_json_loader import FSElasticsearchJSONLoader
+from databuilder.loader.file_system_neo4j_csv_loader import FsNeo4jCSVLoader
 from databuilder.publisher import neo4j_csv_publisher
 from databuilder.publisher.elasticsearch_publisher import ElasticsearchPublisher
 from databuilder.task.task import DefaultTask
-from pyhocon import ConfigFactory
-from elasticsearch.client import Elasticsearch
 
 feast_endpoint = sys.argv[1]
 neo4j_endpoint = sys.argv[2]
@@ -36,47 +38,31 @@ neo4j_password = "test"
 
 def create_feast_job_config():
     tmp_folder = "/var/tmp/amundsen/table_metadata"
-    node_files_folder = "{tmp_folder}/nodes/".format(tmp_folder=tmp_folder)
-    relationship_files_folder = "{tmp_folder}/relationships/".format(
-        tmp_folder=tmp_folder
-    )
+    node_files_folder = f"{tmp_folder}/nodes/"
+    relationship_files_folder = f"{tmp_folder}/relationships/"
 
     job_config = ConfigFactory.from_dict(
         {
-            "extractor.feast.{}".format(
-                FeastExtractor.FEAST_ENDPOINT_CONFIG_KEY
-            ): feast_endpoint,
-            "loader.filesystem_csv_neo4j.{}".format(
-                FsNeo4jCSVLoader.NODE_DIR_PATH
-            ): node_files_folder,
-            "loader.filesystem_csv_neo4j.{}".format(
-                FsNeo4jCSVLoader.RELATION_DIR_PATH
-            ): relationship_files_folder,
-            "publisher.neo4j.{}".format(
-                neo4j_csv_publisher.NODE_FILES_DIR
-            ): node_files_folder,
-            "publisher.neo4j.{}".format(
-                neo4j_csv_publisher.RELATION_FILES_DIR
-            ): relationship_files_folder,
-            "publisher.neo4j.{}".format(
-                neo4j_csv_publisher.NEO4J_END_POINT_KEY
-            ): neo4j_endpoint,
-            "publisher.neo4j.{}".format(neo4j_csv_publisher.NEO4J_USER): neo4j_user,
-            "publisher.neo4j.{}".format(
-                neo4j_csv_publisher.NEO4J_PASSWORD
-            ): neo4j_password,
-            "publisher.neo4j.job_publish_tag": "some_unique_tag",  # TO-DO unique tag must be added
+            f"extractor.feast.{FeastExtractor.FEAST_ENDPOINT_CONFIG_KEY}": feast_endpoint,
+            f"loader.filesystem_csv_neo4j.{FsNeo4jCSVLoader.NODE_DIR_PATH}": node_files_folder,
+            f"loader.filesystem_csv_neo4j.{FsNeo4jCSVLoader.RELATION_DIR_PATH}": relationship_files_folder,
+            f"publisher.neo4j.{neo4j_csv_publisher.NODE_FILES_DIR}": node_files_folder,
+            f"publisher.neo4j.{neo4j_csv_publisher.RELATION_FILES_DIR}": relationship_files_folder,
+            f"publisher.neo4j.{neo4j_csv_publisher.NEO4J_END_POINT_KEY}": neo4j_endpoint,
+            f"publisher.neo4j.{neo4j_csv_publisher.NEO4J_USER}": neo4j_user,
+            f"publisher.neo4j.{neo4j_csv_publisher.NEO4J_PASSWORD}": neo4j_password,
+            f"publisher.neo4j.job_publish_tag": "some_unique_tag",  # TO-DO unique tag must be added
         }
     )
     return job_config
 
 
 def create_es_publish_job_config(
-    elasticsearch_index_alias="table_search_index",
-    elasticsearch_doc_type_key="table",
-    model_name="databuilder.models.table_elasticsearch_document.TableESDocument",
-    cypher_query=None,
-    elasticsearch_mapping=None,
+        elasticsearch_index_alias="table_search_index",
+        elasticsearch_doc_type_key="table",
+        model_name="databuilder.models.table_elasticsearch_document.TableESDocument",
+        cypher_query=None,
+        elasticsearch_mapping=None,
 ):
     """
     :param elasticsearch_index_alias:  alias for Elasticsearch used in
@@ -99,58 +85,35 @@ def create_es_publish_job_config(
 
     job_config = ConfigFactory.from_dict(
         {
-            "extractor.search_data.extractor.neo4j.{}".format(
-                Neo4jExtractor.GRAPH_URL_CONFIG_KEY
-            ): neo4j_endpoint,
-            "extractor.search_data.extractor.neo4j.{}".format(
-                Neo4jExtractor.MODEL_CLASS_CONFIG_KEY
-            ): model_name,
-            "extractor.search_data.extractor.neo4j.{}".format(
-                Neo4jExtractor.NEO4J_AUTH_USER
-            ): neo4j_user,
-            "extractor.search_data.extractor.neo4j.{}".format(
-                Neo4jExtractor.NEO4J_AUTH_PW
-            ): neo4j_password,
-            "loader.filesystem.elasticsearch.{}".format(
-                FSElasticsearchJSONLoader.FILE_PATH_CONFIG_KEY
-            ): extracted_search_data_path,
-            "loader.filesystem.elasticsearch.{}".format(
-                FSElasticsearchJSONLoader.FILE_MODE_CONFIG_KEY
-            ): "w",
-            "publisher.elasticsearch.{}".format(
-                ElasticsearchPublisher.FILE_PATH_CONFIG_KEY
-            ): extracted_search_data_path,
-            "publisher.elasticsearch.{}".format(
-                ElasticsearchPublisher.FILE_MODE_CONFIG_KEY
-            ): "r",
-            "publisher.elasticsearch.{}".format(
-                ElasticsearchPublisher.ELASTICSEARCH_CLIENT_CONFIG_KEY
-            ): elasticsearch_client,
-            "publisher.elasticsearch.{}".format(
-                ElasticsearchPublisher.ELASTICSEARCH_NEW_INDEX_CONFIG_KEY
-            ): elasticsearch_new_index_key,
-            "publisher.elasticsearch.{}".format(
-                ElasticsearchPublisher.ELASTICSEARCH_DOC_TYPE_CONFIG_KEY
-            ): elasticsearch_doc_type_key,
-            "publisher.elasticsearch.{}".format(
-                ElasticsearchPublisher.ELASTICSEARCH_ALIAS_CONFIG_KEY
-            ): elasticsearch_index_alias,
+            f"extractor.search_data.extractor.neo4j.{Neo4jExtractor.GRAPH_URL_CONFIG_KEY}": neo4j_endpoint,
+            f"extractor.search_data.extractor.neo4j.{Neo4jExtractor.MODEL_CLASS_CONFIG_KEY}": model_name,
+            f"extractor.search_data.extractor.neo4j.{Neo4jExtractor.NEO4J_AUTH_USER}": neo4j_user,
+            f"extractor.search_data.extractor.neo4j.{Neo4jExtractor.NEO4J_AUTH_PW}": neo4j_password,
+            f"loader.filesystem.elasticsearch.{FSElasticsearchJSONLoader.FILE_PATH_CONFIG_KEY}":
+                extracted_search_data_path,
+            f"loader.filesystem.elasticsearch.{FSElasticsearchJSONLoader.FILE_MODE_CONFIG_KEY}": "w",
+            f"publisher.elasticsearch.{ElasticsearchPublisher.FILE_PATH_CONFIG_KEY}": extracted_search_data_path,
+            f"publisher.elasticsearch.{ElasticsearchPublisher.FILE_MODE_CONFIG_KEY}": "r",
+            f"publisher.elasticsearch.{ElasticsearchPublisher.ELASTICSEARCH_CLIENT_CONFIG_KEY}":
+                elasticsearch_client,
+            f"publisher.elasticsearch.{ElasticsearchPublisher.ELASTICSEARCH_NEW_INDEX_CONFIG_KEY}":
+                elasticsearch_new_index_key,
+            f"publisher.elasticsearch.{ElasticsearchPublisher.ELASTICSEARCH_DOC_TYPE_CONFIG_KEY}":
+                elasticsearch_doc_type_key,
+            f"publisher.elasticsearch.{ElasticsearchPublisher.ELASTICSEARCH_ALIAS_CONFIG_KEY}":
+                elasticsearch_index_alias,
         }
     )
 
     # only optionally add these keys, so need to dynamically `put` them
     if cypher_query:
         job_config.put(
-            "extractor.search_data.{}".format(
-                Neo4jSearchDataExtractor.CYPHER_QUERY_CONFIG_KEY
-            ),
+            f"extractor.search_data.{Neo4jSearchDataExtractor.CYPHER_QUERY_CONFIG_KEY}",
             cypher_query,
         )
     if elasticsearch_mapping:
         job_config.put(
-            "publisher.elasticsearch.{}".format(
-                ElasticsearchPublisher.ELASTICSEARCH_MAPPING_CONFIG_KEY
-            ),
+            f"publisher.elasticsearch.{ElasticsearchPublisher.ELASTICSEARCH_MAPPING_CONFIG_KEY}",
             elasticsearch_mapping,
         )
 

--- a/example/scripts/sample_glue_loader.py
+++ b/example/scripts/sample_glue_loader.py
@@ -1,9 +1,9 @@
 # Copyright Contributors to the Amundsen project.
 # SPDX-License-Identifier: Apache-2.0
 
+import uuid
 from datetime import datetime
 from pathlib import Path
-import uuid
 
 from elasticsearch import Elasticsearch
 from pyhocon import ConfigFactory
@@ -20,7 +20,6 @@ from databuilder.publisher.neo4j_csv_publisher import Neo4jCsvPublisher
 from databuilder.task.task import DefaultTask
 from databuilder.transformer.base_transformer import NoopTransformer
 
-
 # change the following values to your liking
 NEO4J_ENDPOINT = 'bolt://127.0.0.1:7687'
 NEO4j_USERNAME = 'neo4j'
@@ -31,32 +30,21 @@ es = Elasticsearch([{'host': '127.0.0.1'}, ])
 
 
 def create_glue_extractor_job():
-
     tmp_folder = '/var/tmp/amundsen/table_metadata'
     node_files_folder = Path(tmp_folder, 'nodes')
     relationship_files_folder = Path(tmp_folder, 'relationships')
 
     job_config = ConfigFactory.from_dict({
-        'extractor.glue.{}'.format(GlueExtractor.CLUSTER_KEY):
-            GLUE_CLUSTER_KEY,
-        'extractor.glue.{}'.format(GlueExtractor.FILTER_KEY):
-            [],
-        'loader.filesystem_csv_neo4j.{}'.format(FsNeo4jCSVLoader.NODE_DIR_PATH):
-            node_files_folder,
-        'loader.filesystem_csv_neo4j.{}'.format(FsNeo4jCSVLoader.RELATION_DIR_PATH):
-            relationship_files_folder,
-        'publisher.neo4j.{}'.format(neo4j_csv_publisher.NODE_FILES_DIR):
-            node_files_folder,
-        'publisher.neo4j.{}'.format(neo4j_csv_publisher.RELATION_FILES_DIR):
-            relationship_files_folder,
-        'publisher.neo4j.{}'.format(neo4j_csv_publisher.NEO4J_END_POINT_KEY):
-            NEO4J_ENDPOINT,
-        'publisher.neo4j.{}'.format(neo4j_csv_publisher.NEO4J_USER):
-            NEO4j_USERNAME,
-        'publisher.neo4j.{}'.format(neo4j_csv_publisher.NEO4J_PASSWORD):
-            NEO4j_PASSWORD,
-        'publisher.neo4j.{}'.format(neo4j_csv_publisher.JOB_PUBLISH_TAG):
-            str(int(datetime.utcnow().timestamp()))
+        f'extractor.glue.{GlueExtractor.CLUSTER_KEY}': GLUE_CLUSTER_KEY,
+        f'extractor.glue.{GlueExtractor.FILTER_KEY}': [],
+        f'loader.filesystem_csv_neo4j.{FsNeo4jCSVLoader.NODE_DIR_PATH}': node_files_folder,
+        f'loader.filesystem_csv_neo4j.{FsNeo4jCSVLoader.RELATION_DIR_PATH}': relationship_files_folder,
+        f'publisher.neo4j.{neo4j_csv_publisher.NODE_FILES_DIR}': node_files_folder,
+        f'publisher.neo4j.{neo4j_csv_publisher.RELATION_FILES_DIR}': relationship_files_folder,
+        f'publisher.neo4j.{neo4j_csv_publisher.NEO4J_END_POINT_KEY}': NEO4J_ENDPOINT,
+        f'publisher.neo4j.{neo4j_csv_publisher.NEO4J_USER}': NEO4j_USERNAME,
+        f'publisher.neo4j.{neo4j_csv_publisher.NEO4J_PASSWORD}': NEO4j_PASSWORD,
+        f'publisher.neo4j.{neo4j_csv_publisher.JOB_PUBLISH_TAG}': str(int(datetime.utcnow().timestamp()))
     })
 
     return DefaultJob(conf=job_config,
@@ -68,7 +56,6 @@ def create_glue_extractor_job():
 
 
 def create_es_publisher_job():
-
     # loader saves data to this location and publisher reads it from here
     extracted_search_data_path = '/var/tmp/amundsen/search_data.json'
 
@@ -85,29 +72,29 @@ def create_es_publisher_job():
     elasticsearch_index_alias = 'table_search_index'
 
     job_config = ConfigFactory.from_dict({
-        'extractor.search_data.extractor.neo4j.{}'.format(Neo4jExtractor.GRAPH_URL_CONFIG_KEY):
+        f'extractor.search_data.extractor.neo4j.{Neo4jExtractor.GRAPH_URL_CONFIG_KEY}':
             NEO4J_ENDPOINT,
-        'extractor.search_data.extractor.neo4j.{}'.format(Neo4jExtractor.MODEL_CLASS_CONFIG_KEY):
+        f'extractor.search_data.extractor.neo4j.{Neo4jExtractor.MODEL_CLASS_CONFIG_KEY}':
             'databuilder.models.table_elasticsearch_document.TableESDocument',
-        'extractor.search_data.extractor.neo4j.{}'.format(Neo4jExtractor.NEO4J_AUTH_USER):
+        f'extractor.search_data.extractor.neo4j.{Neo4jExtractor.NEO4J_AUTH_USER}':
             NEO4j_USERNAME,
-        'extractor.search_data.extractor.neo4j.{}'.format(Neo4jExtractor.NEO4J_AUTH_PW):
+        f'extractor.search_data.extractor.neo4j.{Neo4jExtractor.NEO4J_AUTH_PW}':
             NEO4j_PASSWORD,
-        'loader.filesystem.elasticsearch.{}'.format(FSElasticsearchJSONLoader.FILE_PATH_CONFIG_KEY):
+        f'loader.filesystem.elasticsearch.{FSElasticsearchJSONLoader.FILE_PATH_CONFIG_KEY}':
             extracted_search_data_path,
-        'loader.filesystem.elasticsearch.{}'.format(FSElasticsearchJSONLoader.FILE_MODE_CONFIG_KEY):
+        f'loader.filesystem.elasticsearch.{FSElasticsearchJSONLoader.FILE_MODE_CONFIG_KEY}':
             'w',
-        'publisher.elasticsearch.{}'.format(ElasticsearchPublisher.FILE_PATH_CONFIG_KEY):
+        f'publisher.elasticsearch.{ElasticsearchPublisher.FILE_PATH_CONFIG_KEY}':
             extracted_search_data_path,
-        'publisher.elasticsearch.{}'.format(ElasticsearchPublisher.FILE_MODE_CONFIG_KEY):
+        f'publisher.elasticsearch.{ElasticsearchPublisher.FILE_MODE_CONFIG_KEY}':
             'r',
-        'publisher.elasticsearch.{}'.format(ElasticsearchPublisher.ELASTICSEARCH_CLIENT_CONFIG_KEY):
+        f'publisher.elasticsearch.{ElasticsearchPublisher.ELASTICSEARCH_CLIENT_CONFIG_KEY}':
             elasticsearch_client,
-        'publisher.elasticsearch.{}'.format(ElasticsearchPublisher.ELASTICSEARCH_NEW_INDEX_CONFIG_KEY):
+        f'publisher.elasticsearch.{ElasticsearchPublisher.ELASTICSEARCH_NEW_INDEX_CONFIG_KEY}':
             elasticsearch_new_index_key,
-        'publisher.elasticsearch.{}'.format(ElasticsearchPublisher.ELASTICSEARCH_DOC_TYPE_CONFIG_KEY):
+        f'publisher.elasticsearch.{ElasticsearchPublisher.ELASTICSEARCH_DOC_TYPE_CONFIG_KEY}':
             elasticsearch_new_index_key_type,
-        'publisher.elasticsearch.{}'.format(ElasticsearchPublisher.ELASTICSEARCH_ALIAS_CONFIG_KEY):
+        f'publisher.elasticsearch.{ElasticsearchPublisher.ELASTICSEARCH_ALIAS_CONFIG_KEY}':
             elasticsearch_index_alias
     })
 
@@ -117,7 +104,6 @@ def create_es_publisher_job():
 
 
 if __name__ == "__main__":
-
     glue_job = create_glue_extractor_job()
     glue_job.launch()
 

--- a/example/scripts/sample_mssql_metadata.py
+++ b/example/scripts/sample_mssql_metadata.py
@@ -9,16 +9,16 @@ without using an Airflow DAG.
 """
 
 import sys
-import textwrap
 import uuid
+
 from elasticsearch import Elasticsearch
 from pyhocon import ConfigFactory
 from sqlalchemy.ext.declarative import declarative_base
 
 from databuilder.extractor.mssql_metadata_extractor import MSSQLMetadataExtractor
-from databuilder.extractor.sql_alchemy_extractor import SQLAlchemyExtractor
 from databuilder.extractor.neo4j_extractor import Neo4jExtractor
 from databuilder.extractor.neo4j_search_data_extractor import Neo4jSearchDataExtractor
+from databuilder.extractor.sql_alchemy_extractor import SQLAlchemyExtractor
 from databuilder.job.job import DefaultJob
 from databuilder.loader.file_system_elasticsearch_json_loader import FSElasticsearchJSONLoader
 from databuilder.loader.file_system_neo4j_csv_loader import FsNeo4jCSVLoader
@@ -36,13 +36,13 @@ if len(sys.argv) > 2:
     neo_host = sys.argv[2]
 
 es = Elasticsearch([
-    {'host': es_host if es_host else 'localhost'},
+    {'host': es_host or 'localhost'},
 ])
 
 DB_FILE = '/tmp/test.db'
 Base = declarative_base()
 
-NEO4J_ENDPOINT = 'bolt://{}:7687'.format(neo_host if neo_host else 'localhost')
+NEO4J_ENDPOINT = f'bolt://{neo_host or "localhost"}:7687'
 
 neo4j_endpoint = NEO4J_ENDPOINT
 
@@ -64,24 +64,18 @@ def connection_string(windows_auth=False):
     """
 
     if windows_auth:
-        base_string = (
-            "mssql+pyodbc://@{host}/{db}" +
-            "?driver=ODBC+Driver+17+for+SQL+Server" +
-            "?trusted_connection=yes" +
-            "&autocommit=true"  # comment to disable autocommit.
-        )
+        base_string = "mssql+pyodbc://@{host}/{db}" \
+                      "?driver=ODBC+Driver+17+for+SQL+Server" \
+                      "?trusted_connection=yes&autocommit=true"  # comment to disable autocommit.
         params = {
-
             "host": "localhost",
             "db": "master"
         }
 
     else:
-        base_string = (
-            "mssql+pyodbc://{user}:{pword}@{host}/{db}" +
-            "?driver=ODBC+Driver+17+for+SQL+Server" +
-            "&autocommit=true"  # comment to disable autocommit.
-        )
+        base_string = "mssql+pyodbc://{user}:{pword}@{host}/{db}" \
+                      "?driver=ODBC+Driver+17+for+SQL+Server" \
+                      "&autocommit=true"  # comment to disable autocommit.
         params = {
             "user": "username",
             "pword": "password",
@@ -93,40 +87,26 @@ def connection_string(windows_auth=False):
 
 
 def run_mssql_job():
-    where_clause_suffix = textwrap.dedent("""
-        ('dbo')
-    """)
+    where_clause_suffix = "('dbo')"
 
     tmp_folder = '/var/tmp/amundsen/table_metadata'
-    node_files_folder = '{tmp_folder}/nodes/'.format(tmp_folder=tmp_folder)
-    relationship_files_folder = '{tmp_folder}/relationships/'.format(
-        tmp_folder=tmp_folder)
+    node_files_folder = f'{tmp_folder}/nodes/'
+    relationship_files_folder = f'{tmp_folder}/relationships/'
 
     job_config = ConfigFactory.from_dict({
         # MSSQL Loader
-        'extractor.mssql_metadata.{}'.format(
-            MSSQLMetadataExtractor.WHERE_CLAUSE_SUFFIX_KEY): where_clause_suffix,
-        'extractor.mssql_metadata.{}'.format(
-            MSSQLMetadataExtractor.USE_CATALOG_AS_CLUSTER_NAME): True,
-        'extractor.mssql_metadata.extractor.sqlalchemy.{}'.format(
-            SQLAlchemyExtractor.CONN_STRING): connection_string(),
+        f'extractor.mssql_metadata.{MSSQLMetadataExtractor.WHERE_CLAUSE_SUFFIX_KEY}': where_clause_suffix,
+        f'extractor.mssql_metadata.{MSSQLMetadataExtractor.USE_CATALOG_AS_CLUSTER_NAME}': True,
+        f'extractor.mssql_metadata.extractor.sqlalchemy.{SQLAlchemyExtractor.CONN_STRING}': connection_string(),
         # NEO4J Loader
-        'loader.filesystem_csv_neo4j.{}'.format(FsNeo4jCSVLoader.NODE_DIR_PATH):
-            node_files_folder,
-        'loader.filesystem_csv_neo4j.{}'.format(FsNeo4jCSVLoader.RELATION_DIR_PATH):
-            relationship_files_folder,
-        'publisher.neo4j.{}'.format(neo4j_csv_publisher.NODE_FILES_DIR):
-            node_files_folder,
-        'publisher.neo4j.{}'.format(neo4j_csv_publisher.RELATION_FILES_DIR):
-            relationship_files_folder,
-        'publisher.neo4j.{}'.format(neo4j_csv_publisher.NEO4J_END_POINT_KEY):
-            neo4j_endpoint,
-        'publisher.neo4j.{}'.format(neo4j_csv_publisher.NEO4J_USER):
-            neo4j_user,
-        'publisher.neo4j.{}'.format(neo4j_csv_publisher.NEO4J_PASSWORD):
-            neo4j_password,
-        'publisher.neo4j.{}'.format(neo4j_csv_publisher.JOB_PUBLISH_TAG):
-            'unique_tag',  # should use unique tag here like {ds}
+        f'loader.filesystem_csv_neo4j.{FsNeo4jCSVLoader.NODE_DIR_PATH}': node_files_folder,
+        f'loader.filesystem_csv_neo4j.{FsNeo4jCSVLoader.RELATION_DIR_PATH}': relationship_files_folder,
+        f'publisher.neo4j.{neo4j_csv_publisher.NODE_FILES_DIR}': node_files_folder,
+        f'publisher.neo4j.{neo4j_csv_publisher.RELATION_FILES_DIR}': relationship_files_folder,
+        f'publisher.neo4j.{neo4j_csv_publisher.NEO4J_END_POINT_KEY}': neo4j_endpoint,
+        f'publisher.neo4j.{neo4j_csv_publisher.NEO4J_USER}': neo4j_user,
+        f'publisher.neo4j.{neo4j_csv_publisher.NEO4J_PASSWORD}': neo4j_password,
+        f'publisher.neo4j.{neo4j_csv_publisher.JOB_PUBLISH_TAG}': 'unique_tag',  # should use unique tag here like {ds}
     })
 
     job = DefaultJob(
@@ -167,32 +147,30 @@ def create_es_publisher_sample_job(elasticsearch_index_alias='table_search_index
     elasticsearch_new_index_key = 'tables' + str(uuid.uuid4())
 
     job_config = ConfigFactory.from_dict({
-        'extractor.search_data.extractor.neo4j.{}'.format(Neo4jExtractor.GRAPH_URL_CONFIG_KEY): neo4j_endpoint,
-        'extractor.search_data.extractor.neo4j.{}'.format(Neo4jExtractor.MODEL_CLASS_CONFIG_KEY): model_name,
-        'extractor.search_data.extractor.neo4j.{}'.format(Neo4jExtractor.NEO4J_AUTH_USER): neo4j_user,
-        'extractor.search_data.extractor.neo4j.{}'.format(Neo4jExtractor.NEO4J_AUTH_PW): neo4j_password,
-        'loader.filesystem.elasticsearch.{}'.format(FSElasticsearchJSONLoader.FILE_PATH_CONFIG_KEY):
-            extracted_search_data_path,
-        'loader.filesystem.elasticsearch.{}'.format(FSElasticsearchJSONLoader.FILE_MODE_CONFIG_KEY): 'w',
-        'publisher.elasticsearch.{}'.format(ElasticsearchPublisher.FILE_PATH_CONFIG_KEY):
-            extracted_search_data_path,
-        'publisher.elasticsearch.{}'.format(ElasticsearchPublisher.FILE_MODE_CONFIG_KEY): 'r',
-        'publisher.elasticsearch.{}'.format(ElasticsearchPublisher.ELASTICSEARCH_CLIENT_CONFIG_KEY):
+        f'extractor.search_data.extractor.neo4j.{Neo4jExtractor.GRAPH_URL_CONFIG_KEY}': neo4j_endpoint,
+        f'extractor.search_data.extractor.neo4j.{Neo4jExtractor.MODEL_CLASS_CONFIG_KEY}': model_name,
+        f'extractor.search_data.extractor.neo4j.{Neo4jExtractor.NEO4J_AUTH_USER}': neo4j_user,
+        f'extractor.search_data.extractor.neo4j.{Neo4jExtractor.NEO4J_AUTH_PW}': neo4j_password,
+        f'loader.filesystem.elasticsearch.{FSElasticsearchJSONLoader.FILE_PATH_CONFIG_KEY}': extracted_search_data_path,
+        f'loader.filesystem.elasticsearch.{FSElasticsearchJSONLoader.FILE_MODE_CONFIG_KEY}': 'w',
+        f'publisher.elasticsearch.{ElasticsearchPublisher.FILE_PATH_CONFIG_KEY}': extracted_search_data_path,
+        f'publisher.elasticsearch.{ElasticsearchPublisher.FILE_MODE_CONFIG_KEY}': 'r',
+        f'publisher.elasticsearch.{ElasticsearchPublisher.ELASTICSEARCH_CLIENT_CONFIG_KEY}':
             elasticsearch_client,
-        'publisher.elasticsearch.{}'.format(ElasticsearchPublisher.ELASTICSEARCH_NEW_INDEX_CONFIG_KEY):
+        f'publisher.elasticsearch.{ElasticsearchPublisher.ELASTICSEARCH_NEW_INDEX_CONFIG_KEY}':
             elasticsearch_new_index_key,
-        'publisher.elasticsearch.{}'.format(ElasticsearchPublisher.ELASTICSEARCH_DOC_TYPE_CONFIG_KEY):
+        f'publisher.elasticsearch.{ElasticsearchPublisher.ELASTICSEARCH_DOC_TYPE_CONFIG_KEY}':
             elasticsearch_doc_type_key,
-        'publisher.elasticsearch.{}'.format(ElasticsearchPublisher.ELASTICSEARCH_ALIAS_CONFIG_KEY):
+        f'publisher.elasticsearch.{ElasticsearchPublisher.ELASTICSEARCH_ALIAS_CONFIG_KEY}':
             elasticsearch_index_alias,
     })
 
     # only optionally add these keys, so need to dynamically `put` them
     if cypher_query:
-        job_config.put('extractor.search_data.{}'.format(Neo4jSearchDataExtractor.CYPHER_QUERY_CONFIG_KEY),
+        job_config.put(f'extractor.search_data.{Neo4jSearchDataExtractor.CYPHER_QUERY_CONFIG_KEY}',
                        cypher_query)
     if elasticsearch_mapping:
-        job_config.put('publisher.elasticsearch.{}'.format(ElasticsearchPublisher.ELASTICSEARCH_MAPPING_CONFIG_KEY),
+        job_config.put(f'publisher.elasticsearch.{ElasticsearchPublisher.ELASTICSEARCH_MAPPING_CONFIG_KEY}',
                        elasticsearch_mapping)
 
     job = DefaultJob(conf=job_config,

--- a/example/scripts/sample_mysql_loader.py
+++ b/example/scripts/sample_mysql_loader.py
@@ -10,14 +10,15 @@ into Neo4j and Elasticsearch without using an Airflow DAG.
 import sys
 import textwrap
 import uuid
+
 from elasticsearch import Elasticsearch
 from pyhocon import ConfigFactory
 from sqlalchemy.ext.declarative import declarative_base
 
 from databuilder.extractor.mysql_metadata_extractor import MysqlMetadataExtractor
-from databuilder.extractor.sql_alchemy_extractor import SQLAlchemyExtractor
 from databuilder.extractor.neo4j_extractor import Neo4jExtractor
 from databuilder.extractor.neo4j_search_data_extractor import Neo4jSearchDataExtractor
+from databuilder.extractor.sql_alchemy_extractor import SQLAlchemyExtractor
 from databuilder.job.job import DefaultJob
 from databuilder.loader.file_system_elasticsearch_json_loader import FSElasticsearchJSONLoader
 from databuilder.loader.file_system_neo4j_csv_loader import FsNeo4jCSVLoader
@@ -35,14 +36,14 @@ if len(sys.argv) > 2:
     neo_host = sys.argv[2]
 
 es = Elasticsearch([
-    {'host': es_host if es_host else 'localhost'},
+    {'host': es_host or 'localhost'},
 ])
 
 DB_FILE = '/tmp/test.db'
 SQLITE_CONN_STRING = 'sqlite:////tmp/test.db'
 Base = declarative_base()
 
-NEO4J_ENDPOINT = 'bolt://{}:7687'.format(neo_host if neo_host else 'localhost')
+NEO4J_ENDPOINT = f'bolt://{neo_host or "localhost"}:7687'
 
 neo4j_endpoint = NEO4J_ENDPOINT
 
@@ -65,32 +66,21 @@ def run_mysql_job():
     """)
 
     tmp_folder = '/var/tmp/amundsen/table_metadata'
-    node_files_folder = '{tmp_folder}/nodes/'.format(tmp_folder=tmp_folder)
-    relationship_files_folder = '{tmp_folder}/relationships/'.format(tmp_folder=tmp_folder)
+    node_files_folder = f'{tmp_folder}/nodes/'
+    relationship_files_folder = f'{tmp_folder}/relationships/'
 
     job_config = ConfigFactory.from_dict({
-        'extractor.mysql_metadata.{}'.format(MysqlMetadataExtractor.WHERE_CLAUSE_SUFFIX_KEY):
-            where_clause_suffix,
-        'extractor.mysql_metadata.{}'.format(MysqlMetadataExtractor.USE_CATALOG_AS_CLUSTER_NAME):
-            True,
-        'extractor.mysql_metadata.extractor.sqlalchemy.{}'.format(SQLAlchemyExtractor.CONN_STRING):
-            connection_string(),
-        'loader.filesystem_csv_neo4j.{}'.format(FsNeo4jCSVLoader.NODE_DIR_PATH):
-            node_files_folder,
-        'loader.filesystem_csv_neo4j.{}'.format(FsNeo4jCSVLoader.RELATION_DIR_PATH):
-            relationship_files_folder,
-        'publisher.neo4j.{}'.format(neo4j_csv_publisher.NODE_FILES_DIR):
-            node_files_folder,
-        'publisher.neo4j.{}'.format(neo4j_csv_publisher.RELATION_FILES_DIR):
-            relationship_files_folder,
-        'publisher.neo4j.{}'.format(neo4j_csv_publisher.NEO4J_END_POINT_KEY):
-            neo4j_endpoint,
-        'publisher.neo4j.{}'.format(neo4j_csv_publisher.NEO4J_USER):
-            neo4j_user,
-        'publisher.neo4j.{}'.format(neo4j_csv_publisher.NEO4J_PASSWORD):
-            neo4j_password,
-        'publisher.neo4j.{}'.format(neo4j_csv_publisher.JOB_PUBLISH_TAG):
-            'unique_tag',  # should use unique tag here like {ds}
+        f'extractor.mysql_metadata.{MysqlMetadataExtractor.WHERE_CLAUSE_SUFFIX_KEY}': where_clause_suffix,
+        f'extractor.mysql_metadata.{MysqlMetadataExtractor.USE_CATALOG_AS_CLUSTER_NAME}': True,
+        f'extractor.mysql_metadata.extractor.sqlalchemy.{SQLAlchemyExtractor.CONN_STRING}': connection_string(),
+        f'loader.filesystem_csv_neo4j.{FsNeo4jCSVLoader.NODE_DIR_PATH}': node_files_folder,
+        f'loader.filesystem_csv_neo4j.{FsNeo4jCSVLoader.RELATION_DIR_PATH}': relationship_files_folder,
+        f'publisher.neo4j.{neo4j_csv_publisher.NODE_FILES_DIR}': node_files_folder,
+        f'publisher.neo4j.{neo4j_csv_publisher.RELATION_FILES_DIR}': relationship_files_folder,
+        f'publisher.neo4j.{neo4j_csv_publisher.NEO4J_END_POINT_KEY}': neo4j_endpoint,
+        f'publisher.neo4j.{neo4j_csv_publisher.NEO4J_USER}': neo4j_user,
+        f'publisher.neo4j.{neo4j_csv_publisher.NEO4J_PASSWORD}': neo4j_password,
+        f'publisher.neo4j.{neo4j_csv_publisher.JOB_PUBLISH_TAG}': 'unique_tag',  # should use unique tag here like {ds}
     })
     job = DefaultJob(conf=job_config,
                      task=DefaultTask(extractor=MysqlMetadataExtractor(), loader=FsNeo4jCSVLoader()),
@@ -127,32 +117,30 @@ def create_es_publisher_sample_job(elasticsearch_index_alias='table_search_index
     elasticsearch_new_index_key = 'tables' + str(uuid.uuid4())
 
     job_config = ConfigFactory.from_dict({
-        'extractor.search_data.extractor.neo4j.{}'.format(Neo4jExtractor.GRAPH_URL_CONFIG_KEY): neo4j_endpoint,
-        'extractor.search_data.extractor.neo4j.{}'.format(Neo4jExtractor.MODEL_CLASS_CONFIG_KEY): model_name,
-        'extractor.search_data.extractor.neo4j.{}'.format(Neo4jExtractor.NEO4J_AUTH_USER): neo4j_user,
-        'extractor.search_data.extractor.neo4j.{}'.format(Neo4jExtractor.NEO4J_AUTH_PW): neo4j_password,
-        'loader.filesystem.elasticsearch.{}'.format(FSElasticsearchJSONLoader.FILE_PATH_CONFIG_KEY):
-            extracted_search_data_path,
-        'loader.filesystem.elasticsearch.{}'.format(FSElasticsearchJSONLoader.FILE_MODE_CONFIG_KEY): 'w',
-        'publisher.elasticsearch.{}'.format(ElasticsearchPublisher.FILE_PATH_CONFIG_KEY):
-            extracted_search_data_path,
-        'publisher.elasticsearch.{}'.format(ElasticsearchPublisher.FILE_MODE_CONFIG_KEY): 'r',
-        'publisher.elasticsearch.{}'.format(ElasticsearchPublisher.ELASTICSEARCH_CLIENT_CONFIG_KEY):
+        f'extractor.search_data.extractor.neo4j.{Neo4jExtractor.GRAPH_URL_CONFIG_KEY}': neo4j_endpoint,
+        f'extractor.search_data.extractor.neo4j.{Neo4jExtractor.MODEL_CLASS_CONFIG_KEY}': model_name,
+        f'extractor.search_data.extractor.neo4j.{Neo4jExtractor.NEO4J_AUTH_USER}': neo4j_user,
+        f'extractor.search_data.extractor.neo4j.{Neo4jExtractor.NEO4J_AUTH_PW}': neo4j_password,
+        f'loader.filesystem.elasticsearch.{FSElasticsearchJSONLoader.FILE_PATH_CONFIG_KEY}': extracted_search_data_path,
+        f'loader.filesystem.elasticsearch.{FSElasticsearchJSONLoader.FILE_MODE_CONFIG_KEY}': 'w',
+        f'publisher.elasticsearch.{ElasticsearchPublisher.FILE_PATH_CONFIG_KEY}': extracted_search_data_path,
+        f'publisher.elasticsearch.{ElasticsearchPublisher.FILE_MODE_CONFIG_KEY}': 'r',
+        f'publisher.elasticsearch.{ElasticsearchPublisher.ELASTICSEARCH_CLIENT_CONFIG_KEY}':
             elasticsearch_client,
-        'publisher.elasticsearch.{}'.format(ElasticsearchPublisher.ELASTICSEARCH_NEW_INDEX_CONFIG_KEY):
+        f'publisher.elasticsearch.{ElasticsearchPublisher.ELASTICSEARCH_NEW_INDEX_CONFIG_KEY}':
             elasticsearch_new_index_key,
-        'publisher.elasticsearch.{}'.format(ElasticsearchPublisher.ELASTICSEARCH_DOC_TYPE_CONFIG_KEY):
+        f'publisher.elasticsearch.{ElasticsearchPublisher.ELASTICSEARCH_DOC_TYPE_CONFIG_KEY}':
             elasticsearch_doc_type_key,
-        'publisher.elasticsearch.{}'.format(ElasticsearchPublisher.ELASTICSEARCH_ALIAS_CONFIG_KEY):
+        f'publisher.elasticsearch.{ElasticsearchPublisher.ELASTICSEARCH_ALIAS_CONFIG_KEY}':
             elasticsearch_index_alias,
     })
 
     # only optionally add these keys, so need to dynamically `put` them
     if cypher_query:
-        job_config.put('extractor.search_data.{}'.format(Neo4jSearchDataExtractor.CYPHER_QUERY_CONFIG_KEY),
+        job_config.put(f'extractor.search_data.{Neo4jSearchDataExtractor.CYPHER_QUERY_CONFIG_KEY}',
                        cypher_query)
     if elasticsearch_mapping:
-        job_config.put('publisher.elasticsearch.{}'.format(ElasticsearchPublisher.ELASTICSEARCH_MAPPING_CONFIG_KEY),
+        job_config.put(f'publisher.elasticsearch.{ElasticsearchPublisher.ELASTICSEARCH_MAPPING_CONFIG_KEY}',
                        elasticsearch_mapping)
 
     job = DefaultJob(conf=job_config,

--- a/example/scripts/sample_snowflake_data_loader.py
+++ b/example/scripts/sample_snowflake_data_loader.py
@@ -7,22 +7,23 @@ This is a example script which demo how to load data into neo4j without using Ai
 
 import logging
 import os
-from pyhocon import ConfigFactory
-import uuid
 import sys
+import uuid
 
-from databuilder.extractor.sql_alchemy_extractor import SQLAlchemyExtractor
+from elasticsearch.client import Elasticsearch
+from pyhocon import ConfigFactory
+
+from databuilder.extractor.neo4j_extractor import Neo4jExtractor
+from databuilder.extractor.neo4j_search_data_extractor import Neo4jSearchDataExtractor
 from databuilder.extractor.snowflake_metadata_extractor import SnowflakeMetadataExtractor
+from databuilder.extractor.sql_alchemy_extractor import SQLAlchemyExtractor
 from databuilder.job.job import DefaultJob
+from databuilder.loader.file_system_elasticsearch_json_loader import FSElasticsearchJSONLoader
 from databuilder.loader.file_system_neo4j_csv_loader import FsNeo4jCSVLoader
 from databuilder.publisher import neo4j_csv_publisher
+from databuilder.publisher.elasticsearch_publisher import ElasticsearchPublisher
 from databuilder.publisher.neo4j_csv_publisher import Neo4jCsvPublisher
 from databuilder.task.task import DefaultTask
-from databuilder.extractor.neo4j_search_data_extractor import Neo4jSearchDataExtractor
-from databuilder.extractor.neo4j_extractor import Neo4jExtractor
-from databuilder.loader.file_system_elasticsearch_json_loader import FSElasticsearchJSONLoader
-from databuilder.publisher.elasticsearch_publisher import ElasticsearchPublisher
-from elasticsearch.client import Elasticsearch
 from databuilder.transformer.base_transformer import NoopTransformer
 
 LOGGER = logging.getLogger(__name__)
@@ -33,7 +34,7 @@ logging.getLogger("snowflake.connector.network").disabled = True
 SNOWFLAKE_DATABASE_KEY = 'YourSnowflakeDbName'
 
 # set env NEO4J_HOST to override localhost
-NEO4J_ENDPOINT = 'bolt://{}:7687'.format(os.getenv('NEO4J_HOST', 'localhost'))
+NEO4J_ENDPOINT = f'bolt://{os.getenv("NEO4J_HOST", "localhost")}:7687'
 neo4j_endpoint = NEO4J_ENDPOINT
 
 neo4j_user = 'neo4j'
@@ -62,26 +63,19 @@ def connection_string():
     account = 'YourSnowflakeAccountHere'
     # specify a warehouse to connect to.
     warehouse = 'yourwarehouse'
-    return 'snowflake://{user}:{password}@{account}/{database}?warehouse={warehouse}'.format(
-        user=user,
-        password=password,
-        account=account,
-        database=SNOWFLAKE_DATABASE_KEY,
-        warehouse=warehouse,
-    )
+    return f'snowflake://{user}:{password}@{account}/{SNOWFLAKE_DATABASE_KEY}?warehouse={warehouse}'
 
 
 def create_sample_snowflake_job():
-
-    where_clause = "WHERE c.TABLE_SCHEMA not in ({0}) \
+    where_clause = f"WHERE c.TABLE_SCHEMA not in ({','.join(IGNORED_SCHEMAS)}) \
             AND c.TABLE_SCHEMA not like 'STAGE_%' \
             AND c.TABLE_SCHEMA not like 'HIST_%' \
             AND c.TABLE_SCHEMA not like 'SNAP_%' \
-            AND lower(c.COLUMN_NAME) not like 'dw_%';".format(','.join(IGNORED_SCHEMAS))
+            AND lower(c.COLUMN_NAME) not like 'dw_%';"
 
-    tmp_folder = '/var/tmp/amundsen/{}'.format('tables')
-    node_files_folder = '{tmp_folder}/nodes'.format(tmp_folder=tmp_folder)
-    relationship_files_folder = '{tmp_folder}/relationships'.format(tmp_folder=tmp_folder)
+    tmp_folder = '/var/tmp/amundsen/tables'
+    node_files_folder = f'{tmp_folder}/nodes'
+    relationship_files_folder = f'{tmp_folder}/relationships'
 
     sql_extractor = SnowflakeMetadataExtractor()
     csv_loader = FsNeo4jCSVLoader()
@@ -90,19 +84,19 @@ def create_sample_snowflake_job():
                        loader=csv_loader)
 
     job_config = ConfigFactory.from_dict({
-        'extractor.snowflake.extractor.sqlalchemy.{}'.format(SQLAlchemyExtractor.CONN_STRING): connection_string(),
-        'extractor.snowflake.{}'.format(SnowflakeMetadataExtractor.SNOWFLAKE_DATABASE_KEY): SNOWFLAKE_DATABASE_KEY,
-        'extractor.snowflake.{}'.format(SnowflakeMetadataExtractor.WHERE_CLAUSE_SUFFIX_KEY): where_clause,
-        'loader.filesystem_csv_neo4j.{}'.format(FsNeo4jCSVLoader.NODE_DIR_PATH): node_files_folder,
-        'loader.filesystem_csv_neo4j.{}'.format(FsNeo4jCSVLoader.RELATION_DIR_PATH): relationship_files_folder,
-        'loader.filesystem_csv_neo4j.{}'.format(FsNeo4jCSVLoader.SHOULD_DELETE_CREATED_DIR): True,
-        'loader.filesystem_csv_neo4j.{}'.format(FsNeo4jCSVLoader.FORCE_CREATE_DIR): True,
-        'publisher.neo4j.{}'.format(neo4j_csv_publisher.NODE_FILES_DIR): node_files_folder,
-        'publisher.neo4j.{}'.format(neo4j_csv_publisher.RELATION_FILES_DIR): relationship_files_folder,
-        'publisher.neo4j.{}'.format(neo4j_csv_publisher.NEO4J_END_POINT_KEY): neo4j_endpoint,
-        'publisher.neo4j.{}'.format(neo4j_csv_publisher.NEO4J_USER): neo4j_user,
-        'publisher.neo4j.{}'.format(neo4j_csv_publisher.NEO4J_PASSWORD): neo4j_password,
-        'publisher.neo4j.{}'.format(neo4j_csv_publisher.JOB_PUBLISH_TAG): 'unique_tag'
+        f'extractor.snowflake.extractor.sqlalchemy.{SQLAlchemyExtractor.CONN_STRING}': connection_string(),
+        f'extractor.snowflake.{SnowflakeMetadataExtractor.SNOWFLAKE_DATABASE_KEY}': SNOWFLAKE_DATABASE_KEY,
+        f'extractor.snowflake.{SnowflakeMetadataExtractor.WHERE_CLAUSE_SUFFIX_KEY}': where_clause,
+        f'loader.filesystem_csv_neo4j.{FsNeo4jCSVLoader.NODE_DIR_PATH}': node_files_folder,
+        f'loader.filesystem_csv_neo4j.{FsNeo4jCSVLoader.RELATION_DIR_PATH}': relationship_files_folder,
+        f'loader.filesystem_csv_neo4j.{FsNeo4jCSVLoader.SHOULD_DELETE_CREATED_DIR}': True,
+        f'loader.filesystem_csv_neo4j.{FsNeo4jCSVLoader.FORCE_CREATE_DIR}': True,
+        f'publisher.neo4j.{neo4j_csv_publisher.NODE_FILES_DIR}': node_files_folder,
+        f'publisher.neo4j.{neo4j_csv_publisher.RELATION_FILES_DIR}': relationship_files_folder,
+        f'publisher.neo4j.{neo4j_csv_publisher.NEO4J_END_POINT_KEY}': neo4j_endpoint,
+        f'publisher.neo4j.{neo4j_csv_publisher.NEO4J_USER}': neo4j_user,
+        f'publisher.neo4j.{neo4j_csv_publisher.NEO4J_PASSWORD}': neo4j_password,
+        f'publisher.neo4j.{neo4j_csv_publisher.JOB_PUBLISH_TAG}': 'unique_tag'
     })
     job = DefaultJob(conf=job_config,
                      task=task,
@@ -139,32 +133,30 @@ def create_es_publisher_sample_job(elasticsearch_index_alias='table_search_index
     elasticsearch_new_index_key = 'tables' + str(uuid.uuid4())
 
     job_config = ConfigFactory.from_dict({
-        'extractor.search_data.extractor.neo4j.{}'.format(Neo4jExtractor.GRAPH_URL_CONFIG_KEY): neo4j_endpoint,
-        'extractor.search_data.extractor.neo4j.{}'.format(Neo4jExtractor.MODEL_CLASS_CONFIG_KEY): model_name,
-        'extractor.search_data.extractor.neo4j.{}'.format(Neo4jExtractor.NEO4J_AUTH_USER): neo4j_user,
-        'extractor.search_data.extractor.neo4j.{}'.format(Neo4jExtractor.NEO4J_AUTH_PW): neo4j_password,
-        'loader.filesystem.elasticsearch.{}'.format(FSElasticsearchJSONLoader.FILE_PATH_CONFIG_KEY):
-            extracted_search_data_path,
-        'loader.filesystem.elasticsearch.{}'.format(FSElasticsearchJSONLoader.FILE_MODE_CONFIG_KEY): 'w',
-        'publisher.elasticsearch.{}'.format(ElasticsearchPublisher.FILE_PATH_CONFIG_KEY):
-            extracted_search_data_path,
-        'publisher.elasticsearch.{}'.format(ElasticsearchPublisher.FILE_MODE_CONFIG_KEY): 'r',
-        'publisher.elasticsearch.{}'.format(ElasticsearchPublisher.ELASTICSEARCH_CLIENT_CONFIG_KEY):
+        f'extractor.search_data.extractor.neo4j.{Neo4jExtractor.GRAPH_URL_CONFIG_KEY}': neo4j_endpoint,
+        f'extractor.search_data.extractor.neo4j.{Neo4jExtractor.MODEL_CLASS_CONFIG_KEY}': model_name,
+        f'extractor.search_data.extractor.neo4j.{Neo4jExtractor.NEO4J_AUTH_USER}': neo4j_user,
+        f'extractor.search_data.extractor.neo4j.{Neo4jExtractor.NEO4J_AUTH_PW}': neo4j_password,
+        f'loader.filesystem.elasticsearch.{FSElasticsearchJSONLoader.FILE_PATH_CONFIG_KEY}': extracted_search_data_path,
+        f'loader.filesystem.elasticsearch.{FSElasticsearchJSONLoader.FILE_MODE_CONFIG_KEY}': 'w',
+        f'publisher.elasticsearch.{ElasticsearchPublisher.FILE_PATH_CONFIG_KEY}': extracted_search_data_path,
+        f'publisher.elasticsearch.{ElasticsearchPublisher.FILE_MODE_CONFIG_KEY}': 'r',
+        f'publisher.elasticsearch.{ElasticsearchPublisher.ELASTICSEARCH_CLIENT_CONFIG_KEY}':
             elasticsearch_client,
-        'publisher.elasticsearch.{}'.format(ElasticsearchPublisher.ELASTICSEARCH_NEW_INDEX_CONFIG_KEY):
+        f'publisher.elasticsearch.{ElasticsearchPublisher.ELASTICSEARCH_NEW_INDEX_CONFIG_KEY}':
             elasticsearch_new_index_key,
-        'publisher.elasticsearch.{}'.format(ElasticsearchPublisher.ELASTICSEARCH_DOC_TYPE_CONFIG_KEY):
+        f'publisher.elasticsearch.{ElasticsearchPublisher.ELASTICSEARCH_DOC_TYPE_CONFIG_KEY}':
             elasticsearch_doc_type_key,
-        'publisher.elasticsearch.{}'.format(ElasticsearchPublisher.ELASTICSEARCH_ALIAS_CONFIG_KEY):
+        f'publisher.elasticsearch.{ElasticsearchPublisher.ELASTICSEARCH_ALIAS_CONFIG_KEY}':
             elasticsearch_index_alias,
     })
 
     # only optionally add these keys, so need to dynamically `put` them
     if cypher_query:
-        job_config.put('extractor.search_data.{}'.format(Neo4jSearchDataExtractor.CYPHER_QUERY_CONFIG_KEY),
+        job_config.put(f'extractor.search_data.{Neo4jSearchDataExtractor.CYPHER_QUERY_CONFIG_KEY}',
                        cypher_query)
     if elasticsearch_mapping:
-        job_config.put('publisher.elasticsearch.{}'.format(ElasticsearchPublisher.ELASTICSEARCH_MAPPING_CONFIG_KEY),
+        job_config.put(f'publisher.elasticsearch.{ElasticsearchPublisher.ELASTICSEARCH_MAPPING_CONFIG_KEY}',
                        elasticsearch_mapping)
 
     job = DefaultJob(conf=job_config,

--- a/example/scripts/sample_tableau_data_loader.py
+++ b/example/scripts/sample_tableau_data_loader.py
@@ -25,12 +25,14 @@ from pyhocon import ConfigFactory
 from sqlalchemy.ext.declarative import declarative_base
 
 from databuilder.extractor.dashboard.tableau.tableau_dashboard_extractor import TableauDashboardExtractor
-from databuilder.extractor.dashboard.tableau.tableau_dashboard_last_modified_extractor import \
-    TableauDashboardLastModifiedExtractor
+from databuilder.extractor.dashboard.tableau.tableau_dashboard_last_modified_extractor import (
+    TableauDashboardLastModifiedExtractor,
+)
 from databuilder.extractor.dashboard.tableau.tableau_dashboard_query_extractor import TableauDashboardQueryExtractor
 from databuilder.extractor.dashboard.tableau.tableau_dashboard_table_extractor import TableauDashboardTableExtractor
-from databuilder.extractor.dashboard.tableau.tableau_external_table_extractor import \
-    TableauDashboardExternalTableExtractor
+from databuilder.extractor.dashboard.tableau.tableau_external_table_extractor import (
+    TableauDashboardExternalTableExtractor,
+)
 from databuilder.extractor.neo4j_search_data_extractor import Neo4jSearchDataExtractor
 from databuilder.job.job import DefaultJob
 from databuilder.loader.file_system_elasticsearch_json_loader import FSElasticsearchJSONLoader

--- a/example/scripts/sample_tableau_data_loader.py
+++ b/example/scripts/sample_tableau_data_loader.py
@@ -24,6 +24,13 @@ from elasticsearch import Elasticsearch
 from pyhocon import ConfigFactory
 from sqlalchemy.ext.declarative import declarative_base
 
+from databuilder.extractor.dashboard.tableau.tableau_dashboard_extractor import TableauDashboardExtractor
+from databuilder.extractor.dashboard.tableau.tableau_dashboard_last_modified_extractor import \
+    TableauDashboardLastModifiedExtractor
+from databuilder.extractor.dashboard.tableau.tableau_dashboard_query_extractor import TableauDashboardQueryExtractor
+from databuilder.extractor.dashboard.tableau.tableau_dashboard_table_extractor import TableauDashboardTableExtractor
+from databuilder.extractor.dashboard.tableau.tableau_external_table_extractor import \
+    TableauDashboardExternalTableExtractor
 from databuilder.extractor.neo4j_search_data_extractor import Neo4jSearchDataExtractor
 from databuilder.job.job import DefaultJob
 from databuilder.loader.file_system_elasticsearch_json_loader import FSElasticsearchJSONLoader
@@ -33,15 +40,6 @@ from databuilder.publisher.elasticsearch_publisher import ElasticsearchPublisher
 from databuilder.publisher.neo4j_csv_publisher import Neo4jCsvPublisher
 from databuilder.task.task import DefaultTask
 from databuilder.transformer.base_transformer import NoopTransformer
-
-from databuilder.extractor.dashboard.tableau.tableau_dashboard_extractor import TableauDashboardExtractor
-from databuilder.extractor.dashboard.tableau.tableau_dashboard_last_modified_extractor import \
-    TableauDashboardLastModifiedExtractor
-from databuilder.extractor.dashboard.tableau.tableau_dashboard_query_extractor import TableauDashboardQueryExtractor
-from databuilder.extractor.dashboard.tableau.tableau_dashboard_table_extractor import TableauDashboardTableExtractor
-from databuilder.extractor.dashboard.tableau.tableau_external_table_extractor import \
-    TableauDashboardExternalTableExtractor
-
 
 es_host = os.getenv('CREDENTIALS_ELASTICSEARCH_PROXY_HOST', 'localhost')
 neo_host = os.getenv('CREDENTIALS_NEO4J_PROXY_HOST', 'localhost')
@@ -59,7 +57,7 @@ es = Elasticsearch([
 
 Base = declarative_base()
 
-NEO4J_ENDPOINT = 'bolt://{}:{}'.format(neo_host, neo_port)
+NEO4J_ENDPOINT = f'bolt://{neo_host}:{neo_port}'
 
 neo4j_endpoint = NEO4J_ENDPOINT
 
@@ -117,7 +115,7 @@ def create_es_publisher_sample_job(elasticsearch_index_alias='table_search_index
     # elastic search client instance
     elasticsearch_client = es
     # unique name of new index in Elasticsearch
-    elasticsearch_new_index_key = '{}_'.format(elasticsearch_doc_type_key) + str(uuid.uuid4())
+    elasticsearch_new_index_key = f'{elasticsearch_doc_type_key}_{uuid.uuid4()}'
 
     job_config = ConfigFactory.from_dict({
         'extractor.search_data.entity_type': entity_type,
@@ -138,7 +136,7 @@ def create_es_publisher_sample_job(elasticsearch_index_alias='table_search_index
 
     # only optionally add these keys, so need to dynamically `put` them
     if elasticsearch_mapping:
-        job_config.put('publisher.elasticsearch.{}'.format(ElasticsearchPublisher.ELASTICSEARCH_MAPPING_CONFIG_KEY),
+        job_config.put(f'publisher.elasticsearch.{ElasticsearchPublisher.ELASTICSEARCH_MAPPING_CONFIG_KEY}',
                        elasticsearch_mapping)
 
     job = DefaultJob(conf=job_config,
@@ -152,8 +150,8 @@ def run_tableau_metadata_job():
 
     tmp_folder = '/var/tmp/amundsen/tableau_dashboard_metadata'
 
-    node_files_folder = '{tmp_folder}/nodes'.format(tmp_folder=tmp_folder)
-    relationship_files_folder = '{tmp_folder}/relationships'.format(tmp_folder=tmp_folder)
+    node_files_folder = f'{tmp_folder}/nodes'
+    relationship_files_folder = f'{tmp_folder}/relationships'
 
     dict_config = common_tableau_config
     dict_config.update({
@@ -192,8 +190,8 @@ def run_tableau_last_modified_job():
 
     tmp_folder = '/var/tmp/amundsen/tableau_dashboard_user'
 
-    node_files_folder = '{tmp_folder}/nodes'.format(tmp_folder=tmp_folder)
-    relationship_files_folder = '{tmp_folder}/relationships'.format(tmp_folder=tmp_folder)
+    node_files_folder = f'{tmp_folder}/nodes'
+    relationship_files_folder = f'{tmp_folder}/relationships'
 
     dict_config = common_tableau_config
     dict_config.update({
@@ -231,23 +229,20 @@ def run_tableau_query_job():
 
     tmp_folder = '/var/tmp/amundsen/tableau_dashboard_query'
 
-    node_files_folder = '{tmp_folder}/nodes'.format(tmp_folder=tmp_folder)
-    relationship_files_folder = '{tmp_folder}/relationships'.format(tmp_folder=tmp_folder)
+    node_files_folder = f'{tmp_folder}/nodes'
+    relationship_files_folder = f'{tmp_folder}/relationships'
 
     dict_config = common_tableau_config
     dict_config.update({
         'extractor.tableau_dashboard_query.api_base_url': tableau_api_base_url,
         'extractor.tableau_dashboard_query.api_version': tableau_api_version,
         'extractor.tableau_dashboard_query.site_name': tableau_site_name,
-        'extractor.tableau_dashboard_query.tableau_personal_access_token_name':
-            tableau_personal_access_token_name,
-        'extractor.tableau_dashboard_query.tableau_personal_access_token_secret':
-            tableau_personal_access_token_secret,
+        'extractor.tableau_dashboard_query.tableau_personal_access_token_name': tableau_personal_access_token_name,
+        'extractor.tableau_dashboard_query.tableau_personal_access_token_secret': tableau_personal_access_token_secret,
         'extractor.tableau_dashboard_query.excluded_projects': tableau_excluded_projects,
         'extractor.tableau_dashboard_query.cluster': tableau_dashboard_cluster,
         'extractor.tableau_dashboard_query.database': tableau_dashboard_database,
-        'extractor.tableau_dashboard_query.transformer.timestamp_str_to_epoch.timestamp_format':
-            "%Y-%m-%dT%H:%M:%SZ",
+        'extractor.tableau_dashboard_query.transformer.timestamp_str_to_epoch.timestamp_format': "%Y-%m-%dT%H:%M:%SZ",
         'extractor.tableau_dashboard_query.verify_request': tableau_verify_request,
         'loader.filesystem_csv_neo4j.node_dir_path': node_files_folder,
         'loader.filesystem_csv_neo4j.relationship_dir_path': relationship_files_folder,
@@ -270,18 +265,16 @@ def run_tableau_table_job():
 
     tmp_folder = '/var/tmp/amundsen/tableau_dashboard_table'
 
-    node_files_folder = '{tmp_folder}/nodes'.format(tmp_folder=tmp_folder)
-    relationship_files_folder = '{tmp_folder}/relationships'.format(tmp_folder=tmp_folder)
+    node_files_folder = f'{tmp_folder}/nodes'
+    relationship_files_folder = f'{tmp_folder}/relationships'
 
     dict_config = common_tableau_config
     dict_config.update({
         'extractor.tableau_dashboard_table.api_base_url': tableau_api_base_url,
         'extractor.tableau_dashboard_table.api_version': tableau_api_version,
         'extractor.tableau_dashboard_table.site_name': tableau_site_name,
-        'extractor.tableau_dashboard_table.tableau_personal_access_token_name':
-            tableau_personal_access_token_name,
-        'extractor.tableau_dashboard_table.tableau_personal_access_token_secret':
-            tableau_personal_access_token_secret,
+        'extractor.tableau_dashboard_table.tableau_personal_access_token_name': tableau_personal_access_token_name,
+        'extractor.tableau_dashboard_table.tableau_personal_access_token_secret': tableau_personal_access_token_secret,
         'extractor.tableau_dashboard_table.excluded_projects': tableau_excluded_projects,
         'extractor.tableau_dashboard_table.cluster': tableau_dashboard_cluster,
         'extractor.tableau_dashboard_table.database': tableau_dashboard_database,
@@ -310,18 +303,16 @@ def run_tableau_external_table_job():
 
     tmp_folder = '/var/tmp/amundsen/tableau_dashboard_external_table'
 
-    node_files_folder = '{tmp_folder}/nodes'.format(tmp_folder=tmp_folder)
-    relationship_files_folder = '{tmp_folder}/relationships'.format(tmp_folder=tmp_folder)
+    node_files_folder = f'{tmp_folder}/nodes'
+    relationship_files_folder = f'{tmp_folder}/relationships'
 
     dict_config = common_tableau_config
     dict_config.update({
         'extractor.tableau_external_table.api_base_url': tableau_api_base_url,
         'extractor.tableau_external_table.api_version': tableau_api_version,
         'extractor.tableau_external_table.site_name': tableau_site_name,
-        'extractor.tableau_external_table.tableau_personal_access_token_name':
-            tableau_personal_access_token_name,
-        'extractor.tableau_external_table.tableau_personal_access_token_secret':
-            tableau_personal_access_token_secret,
+        'extractor.tableau_external_table.tableau_personal_access_token_name': tableau_personal_access_token_name,
+        'extractor.tableau_external_table.tableau_personal_access_token_secret': tableau_personal_access_token_secret,
         'extractor.tableau_external_table.excluded_projects': tableau_excluded_projects,
         'extractor.tableau_external_table.cluster': tableau_dashboard_cluster,
         'extractor.tableau_external_table.database': tableau_dashboard_database,

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,6 +8,11 @@ flake8==3.5.0
 # Upstream url: https://pypi.python.org/pypi/flake8-tidy-imports
 flake8-tidy-imports>=1.1.0,<2.0
 
+# A Python utility / library to sort imports.
+# License: MIT
+# Upstream url: https://github.com/PyCQA/isort
+isort[colors]~=5.4
+
 # A mature full-featured Python testing tool.
 # License: MIT
 # Upstream url: http://pytest.org/

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,15 @@
 [flake8]
 format = pylint
-exclude = .svc,CVS,.bzr,.hg,.git,__pycache__,venv,build,databuilder/sql_parser/usage/presto/antlr_generated
+exclude =
+  CVS,
+  .svc,
+  .bzr,
+  .hg,
+  .git,
+  __pycache__,
+  venv,
+  build,
+  databuilder/sql_parser/usage/presto/antlr_generated
 max-complexity = 10
 max-line-length = 120
 ignore = NONE
@@ -9,7 +18,14 @@ ignore = NONE
 max-line-length = 120
 
 [tool:pytest]
-addopts = -rs --cov=databuilder --cov-fail-under=70 --cov-report=term-missing:skip-covered --cov-report=xml --cov-report=html -vvv
+addopts =
+  -rs
+  --cov=databuilder
+  --cov-fail-under=70
+  --cov-report=term-missing:skip-covered
+  --cov-report=xml
+  --cov-report=html
+  -vvv
 
 [coverage:run]
 branch = True

--- a/setup.cfg
+++ b/setup.cfg
@@ -25,3 +25,13 @@ directory = build/coverage_html
 python_version = 3.6
 disallow_untyped_defs = True
 ignore_missing_imports = True
+
+[isort]
+profile = django
+line_length = 120
+force_grid_wrap = 3
+combine_star = true
+combine_as_imports = true
+remove_redundant_aliases = true
+color_output = true
+skip_glob = []

--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,7 @@
 # Copyright Contributors to the Amundsen project.
 # SPDX-License-Identifier: Apache-2.0
 
-from setuptools import setup, find_packages
-
+from setuptools import find_packages, setup
 
 __version__ = '4.0.3'
 

--- a/tests/unit/callback/test_call_back.py
+++ b/tests/unit/callback/test_call_back.py
@@ -2,9 +2,9 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import unittest
+from typing import List
 
 from mock import MagicMock
-from typing import List
 
 from databuilder.callback.call_back import Callback, notify_callbacks
 

--- a/tests/unit/extractor/dashboard/mode_analytics/batch/test_mode_dashboard_charts_batch_extractor.py
+++ b/tests/unit/extractor/dashboard/mode_analytics/batch/test_mode_dashboard_charts_batch_extractor.py
@@ -2,12 +2,14 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import unittest
+
 from mock import patch
 from pyhocon import ConfigFactory
 
 from databuilder import Scoped
-from databuilder.extractor.dashboard.mode_analytics.batch.\
-    mode_dashboard_charts_batch_extractor import ModeDashboardChartsBatchExtractor
+from databuilder.extractor.dashboard.mode_analytics.batch.mode_dashboard_charts_batch_extractor import (
+    ModeDashboardChartsBatchExtractor,
+)
 
 
 class TestModeDashboardChartsBatchExtractor(unittest.TestCase):

--- a/tests/unit/extractor/dashboard/redash/test_redash_dashboard_extractor.py
+++ b/tests/unit/extractor/dashboard/redash/test_redash_dashboard_extractor.py
@@ -3,20 +3,22 @@
 
 import logging
 import unittest
+from typing import (
+    Any, Dict, List,
+)
 
 from mock import patch
 from pyhocon import ConfigFactory
-from typing import Any, Dict, List
 
 from databuilder import Scoped
-from databuilder.extractor.dashboard.redash.redash_dashboard_extractor import \
-    RedashDashboardExtractor, TableRelationData
+from databuilder.extractor.dashboard.redash.redash_dashboard_extractor import (
+    RedashDashboardExtractor, TableRelationData,
+)
+from databuilder.models.dashboard.dashboard_chart import DashboardChart
 from databuilder.models.dashboard.dashboard_last_modified import DashboardLastModifiedTimestamp
 from databuilder.models.dashboard.dashboard_owner import DashboardOwner
 from databuilder.models.dashboard.dashboard_query import DashboardQuery
 from databuilder.models.dashboard.dashboard_table import DashboardTable
-from databuilder.models.dashboard.dashboard_chart import DashboardChart
-
 
 logging.basicConfig(level=logging.INFO)
 

--- a/tests/unit/extractor/dashboard/redash/test_redash_dashboard_extractor.py
+++ b/tests/unit/extractor/dashboard/redash/test_redash_dashboard_extractor.py
@@ -134,7 +134,7 @@ class TestRedashDashboardExtractor(unittest.TestCase):
             expected_query = DashboardQuery(
                 query_id='1234',
                 query_name='Test Query',
-                url=u'{base}/queries/1234'.format(base=redash_base_url),
+                url=f'{redash_base_url}/queries/1234',
                 query_text='SELECT id FROM users',
                 **identity
             )

--- a/tests/unit/extractor/dashboard/redash/test_redash_dashboard_utils.py
+++ b/tests/unit/extractor/dashboard/redash/test_redash_dashboard_utils.py
@@ -4,14 +4,17 @@
 import logging
 import random
 import unittest
+from typing import (
+    Any, Dict, List,
+)
 
 from mock import patch
-from typing import Any, Dict, List
 
+from databuilder.extractor.dashboard.redash.redash_dashboard_utils import (
+    RedashPaginatedRestApiQuery, generate_dashboard_description, get_auth_headers, get_text_widgets,
+    get_visualization_widgets, sort_widgets,
+)
 from databuilder.rest_api.base_rest_api_query import EmptyRestApiQuerySeed
-from databuilder.extractor.dashboard.redash.redash_dashboard_utils import \
-    get_text_widgets, get_visualization_widgets, sort_widgets, \
-    generate_dashboard_description, get_auth_headers, RedashPaginatedRestApiQuery
 
 logging.basicConfig(level=logging.INFO)
 

--- a/tests/unit/extractor/dashboard/tableau/test_tableau_dashboard_extractor.py
+++ b/tests/unit/extractor/dashboard/tableau/test_tableau_dashboard_extractor.py
@@ -10,9 +10,9 @@ from pyhocon import ConfigFactory
 
 from databuilder import Scoped
 from databuilder.extractor.dashboard.tableau.tableau_dashboard_extractor import TableauDashboardExtractor
-from databuilder.extractor.dashboard.tableau.tableau_dashboard_utils \
-    import TableauDashboardAuth, TableauGraphQLApiExtractor
-
+from databuilder.extractor.dashboard.tableau.tableau_dashboard_utils import (
+    TableauDashboardAuth, TableauGraphQLApiExtractor,
+)
 
 logging.basicConfig(level=logging.INFO)
 

--- a/tests/unit/extractor/dashboard/tableau/test_tableau_dashboard_last_modified_extractor.py
+++ b/tests/unit/extractor/dashboard/tableau/test_tableau_dashboard_last_modified_extractor.py
@@ -9,11 +9,12 @@ from mock import patch
 from pyhocon import ConfigFactory
 
 from databuilder import Scoped
-from databuilder.extractor.dashboard.tableau.tableau_dashboard_last_modified_extractor \
-    import TableauDashboardLastModifiedExtractor
-from databuilder.extractor.dashboard.tableau.tableau_dashboard_utils \
-    import TableauDashboardAuth, TableauGraphQLApiExtractor
-
+from databuilder.extractor.dashboard.tableau.tableau_dashboard_last_modified_extractor import (
+    TableauDashboardLastModifiedExtractor,
+)
+from databuilder.extractor.dashboard.tableau.tableau_dashboard_utils import (
+    TableauDashboardAuth, TableauGraphQLApiExtractor,
+)
 
 logging.basicConfig(level=logging.INFO)
 

--- a/tests/unit/extractor/dashboard/tableau/test_tableau_dashboard_query_extractor.py
+++ b/tests/unit/extractor/dashboard/tableau/test_tableau_dashboard_query_extractor.py
@@ -10,9 +10,9 @@ from pyhocon import ConfigFactory
 
 from databuilder import Scoped
 from databuilder.extractor.dashboard.tableau.tableau_dashboard_query_extractor import TableauDashboardQueryExtractor
-from databuilder.extractor.dashboard.tableau.tableau_dashboard_utils \
-    import TableauDashboardAuth, TableauGraphQLApiExtractor
-
+from databuilder.extractor.dashboard.tableau.tableau_dashboard_utils import (
+    TableauDashboardAuth, TableauGraphQLApiExtractor,
+)
 
 logging.basicConfig(level=logging.INFO)
 

--- a/tests/unit/extractor/dashboard/tableau/test_tableau_dashboard_table_extractor.py
+++ b/tests/unit/extractor/dashboard/tableau/test_tableau_dashboard_table_extractor.py
@@ -10,9 +10,9 @@ from pyhocon import ConfigFactory
 
 from databuilder import Scoped
 from databuilder.extractor.dashboard.tableau.tableau_dashboard_table_extractor import TableauDashboardTableExtractor
-from databuilder.extractor.dashboard.tableau.tableau_dashboard_utils \
-    import TableauDashboardAuth, TableauGraphQLApiExtractor
-
+from databuilder.extractor.dashboard.tableau.tableau_dashboard_utils import (
+    TableauDashboardAuth, TableauGraphQLApiExtractor,
+)
 
 logging.basicConfig(level=logging.INFO)
 

--- a/tests/unit/extractor/restapi/test_rest_api_extractor.py
+++ b/tests/unit/extractor/restapi/test_rest_api_extractor.py
@@ -5,8 +5,9 @@ import unittest
 
 from pyhocon import ConfigFactory
 
-from databuilder.extractor.restapi.rest_api_extractor import RestAPIExtractor, REST_API_QUERY, MODEL_CLASS, \
-    STATIC_RECORD_DICT
+from databuilder.extractor.restapi.rest_api_extractor import (
+    MODEL_CLASS, REST_API_QUERY, STATIC_RECORD_DICT, RestAPIExtractor,
+)
 from databuilder.models.dashboard.dashboard_metadata import DashboardMetadata
 from databuilder.rest_api.base_rest_api_query import RestApiQuerySeed
 

--- a/tests/unit/extractor/test_athena_metadata_extractor.py
+++ b/tests/unit/extractor/test_athena_metadata_extractor.py
@@ -3,10 +3,10 @@
 
 import logging
 import unittest
+from typing import Any, Dict
 
 from mock import patch, MagicMock
 from pyhocon import ConfigFactory
-from typing import Any, Dict
 
 from databuilder.extractor.athena_metadata_extractor import AthenaMetadataExtractor
 from databuilder.extractor.sql_alchemy_extractor import SQLAlchemyExtractor
@@ -18,11 +18,8 @@ class TestAthenaMetadataExtractor(unittest.TestCase):
         logging.basicConfig(level=logging.INFO)
 
         config_dict = {
-            'extractor.sqlalchemy.{}'.format(SQLAlchemyExtractor.CONN_STRING):
-            'TEST_CONNECTION',
-            'extractor.athena_metadata.{}'.format(AthenaMetadataExtractor.CATALOG_KEY):
-            'MY_CATALOG'
-
+            f'extractor.sqlalchemy.{SQLAlchemyExtractor.CONN_STRING}': 'TEST_CONNECTION',
+            f'extractor.athena_metadata.{AthenaMetadataExtractor.CATALOG_KEY}': 'MY_CATALOG'
         }
         self.conf = ConfigFactory.from_dict(config_dict)
 
@@ -43,56 +40,64 @@ class TestAthenaMetadataExtractor(unittest.TestCase):
             mock_connection.return_value = connection
             sql_execute = MagicMock()
             connection.execute = sql_execute
-            table = {'schema': 'test_schema',
-                     'name': 'test_table',
-                     'description': '',
-                     'cluster': self.conf['extractor.athena_metadata.{}'.format(AthenaMetadataExtractor.CATALOG_KEY)],
-                     }
+            table = {
+                'schema': 'test_schema',
+                'name': 'test_table',
+                'description': '',
+                'cluster': self.conf[f'extractor.athena_metadata.{AthenaMetadataExtractor.CATALOG_KEY}'],
+            }
 
             sql_execute.return_value = [
-                self._union(
-                    {'col_name': 'col_id1',
-                     'col_type': 'bigint',
-                     'col_description': 'description of id1',
-                     'col_sort_order': 0,
-                     'extras': None}, table),
-                self._union(
-                    {'col_name': 'col_id2',
-                     'col_type': 'bigint',
-                     'col_description': 'description of id2',
-                     'col_sort_order': 1,
-                     'extras': None}, table),
-                self._union(
-                    {'col_name': 'is_active',
-                     'col_type': 'boolean',
-                     'col_description': None,
-                     'col_sort_order': 2,
-                     'extras': None}, table),
-                self._union(
-                    {'col_name': 'source',
-                     'col_type': 'varchar',
-                     'col_description': 'description of source',
-                     'col_sort_order': 3,
-                     'extras': None}, table),
-                self._union(
-                    {'col_name': 'etl_created_at',
-                     'col_type': 'timestamp',
-                     'col_description': None,
-                     'col_sort_order': 4,
-                     'extras': 'partition key'}, table),
-                self._union(
-                    {'col_name': 'ds',
-                     'col_type': 'varchar',
-                     'col_description': None,
-                     'col_sort_order': 5,
-                     'extras': None}, table)
+                self._union({
+                    'col_name': 'col_id1',
+                    'col_type': 'bigint',
+                    'col_description': 'description of id1',
+                    'col_sort_order': 0,
+                    'extras': None
+                }, table),
+                self._union({
+                    'col_name': 'col_id2',
+                    'col_type': 'bigint',
+                    'col_description': 'description of id2',
+                    'col_sort_order': 1,
+                    'extras': None
+                }, table),
+                self._union({
+                    'col_name': 'is_active',
+                    'col_type': 'boolean',
+                    'col_description': None,
+                    'col_sort_order': 2,
+                    'extras': None
+                }, table),
+                self._union({
+                    'col_name': 'source',
+                    'col_type': 'varchar',
+                    'col_description': 'description of source',
+                    'col_sort_order': 3,
+                    'extras': None
+                }, table),
+                self._union({
+                    'col_name': 'etl_created_at',
+                    'col_type': 'timestamp',
+                    'col_description': None,
+                    'col_sort_order': 4,
+                    'extras': 'partition key'
+                }, table),
+                self._union({
+                    'col_name': 'ds',
+                    'col_type': 'varchar',
+                    'col_description': None,
+                    'col_sort_order': 5,
+                    'extras': None
+                }, table)
             ]
 
             extractor = AthenaMetadataExtractor()
             extractor.init(self.conf)
             actual = extractor.extract()
-            expected = TableMetadata('athena', self.conf['extractor.athena_metadata.{}'.
-                                                         format(AthenaMetadataExtractor.CATALOG_KEY)], 'test_schema',
+            expected = TableMetadata('athena',
+                                     self.conf[f'extractor.athena_metadata.{AthenaMetadataExtractor.CATALOG_KEY}'],
+                                     'test_schema',
                                      'test_table', '',
                                      [ColumnMetadata('col_id1', 'description of id1', 'bigint', 0),
                                       ColumnMetadata('col_id2', 'description of id2', 'bigint', 1),
@@ -112,19 +117,19 @@ class TestAthenaMetadataExtractor(unittest.TestCase):
             table = {'schema': 'test_schema1',
                      'name': 'test_table1',
                      'description': '',
-                     'cluster': self.conf['extractor.athena_metadata.{}'.format(AthenaMetadataExtractor.CATALOG_KEY)],
+                     'cluster': self.conf[f'extractor.athena_metadata.{AthenaMetadataExtractor.CATALOG_KEY}'],
                      }
 
             table1 = {'schema': 'test_schema1',
                       'name': 'test_table2',
                       'description': '',
-                      'cluster': self.conf['extractor.athena_metadata.{}'.format(AthenaMetadataExtractor.CATALOG_KEY)],
+                      'cluster': self.conf[f'extractor.athena_metadata.{AthenaMetadataExtractor.CATALOG_KEY}'],
                       }
 
             table2 = {'schema': 'test_schema2',
                       'name': 'test_table3',
                       'description': '',
-                      'cluster': self.conf['extractor.athena_metadata.{}'.format(AthenaMetadataExtractor.CATALOG_KEY)],
+                      'cluster': self.conf[f'extractor.athena_metadata.{AthenaMetadataExtractor.CATALOG_KEY}'],
                       }
 
             sql_execute.return_value = [
@@ -194,8 +199,7 @@ class TestAthenaMetadataExtractor(unittest.TestCase):
             extractor.init(self.conf)
 
             expected = TableMetadata('athena',
-                                     self.conf['extractor.athena_metadata.{}'.format(
-                                         AthenaMetadataExtractor.CATALOG_KEY)],
+                                     self.conf[f'extractor.athena_metadata.{AthenaMetadataExtractor.CATALOG_KEY}'],
                                      'test_schema1', 'test_table1', '',
                                      [ColumnMetadata('col_id1', 'description of col_id1', 'bigint', 0),
                                       ColumnMetadata('col_id2', 'description of col_id2', 'bigint', 1),
@@ -206,16 +210,14 @@ class TestAthenaMetadataExtractor(unittest.TestCase):
             self.assertEqual(expected.__repr__(), extractor.extract().__repr__())
 
             expected = TableMetadata('athena',
-                                     self.conf['extractor.athena_metadata.{}'.format(
-                                         AthenaMetadataExtractor.CATALOG_KEY)],
+                                     self.conf[f'extractor.athena_metadata.{AthenaMetadataExtractor.CATALOG_KEY}'],
                                      'test_schema1', 'test_table2', '',
                                      [ColumnMetadata('col_name', 'description of col_name', 'varchar', 0),
                                       ColumnMetadata('col_name2', 'description of col_name2', 'varchar', 1)])
             self.assertEqual(expected.__repr__(), extractor.extract().__repr__())
 
             expected = TableMetadata('athena',
-                                     self.conf['extractor.athena_metadata.{}'.format(
-                                         AthenaMetadataExtractor.CATALOG_KEY)],
+                                     self.conf[f'extractor.athena_metadata.{AthenaMetadataExtractor.CATALOG_KEY}'],
                                      'test_schema2', 'test_table3', '',
                                      [ColumnMetadata('col_id3', 'description of col_id3', 'varchar', 0),
                                       ColumnMetadata('col_name3', 'description of col_name3',
@@ -240,8 +242,7 @@ class TestAthenaMetadataExtractorWithWhereClause(unittest.TestCase):
         """
         config_dict = {
             AthenaMetadataExtractor.WHERE_CLAUSE_SUFFIX_KEY: self.where_clause_suffix,
-            'extractor.sqlalchemy.{}'.format(SQLAlchemyExtractor.CONN_STRING):
-                'TEST_CONNECTION'
+            f'extractor.sqlalchemy.{SQLAlchemyExtractor.CONN_STRING}': 'TEST_CONNECTION'
         }
         self.conf = ConfigFactory.from_dict(config_dict)
 

--- a/tests/unit/extractor/test_athena_metadata_extractor.py
+++ b/tests/unit/extractor/test_athena_metadata_extractor.py
@@ -5,12 +5,12 @@ import logging
 import unittest
 from typing import Any, Dict
 
-from mock import patch, MagicMock
+from mock import MagicMock, patch
 from pyhocon import ConfigFactory
 
 from databuilder.extractor.athena_metadata_extractor import AthenaMetadataExtractor
 from databuilder.extractor.sql_alchemy_extractor import SQLAlchemyExtractor
-from databuilder.models.table_metadata import TableMetadata, ColumnMetadata
+from databuilder.models.table_metadata import ColumnMetadata, TableMetadata
 
 
 class TestAthenaMetadataExtractor(unittest.TestCase):

--- a/tests/unit/extractor/test_bigquery_metadata_extractor.py
+++ b/tests/unit/extractor/test_bigquery_metadata_extractor.py
@@ -3,10 +3,10 @@
 
 import logging
 import unittest
+from typing import Any
 
 from mock import patch, Mock
 from pyhocon import ConfigFactory
-from typing import Any
 
 from databuilder import Scoped
 from databuilder.extractor.bigquery_metadata_extractor import BigQueryMetadataExtractor
@@ -14,52 +14,95 @@ from databuilder.models.table_metadata import TableMetadata
 
 logging.basicConfig(level=logging.INFO)
 
-
 NO_DATASETS = {'kind': 'bigquery#datasetList', 'etag': '1B2M2Y8AsgTpgAmY7PhCfg=='}
-ONE_DATASET = {'kind': 'bigquery#datasetList', 'etag': 'yScH5WIHeNUBF9b/VKybXA==',
-    'datasets': [{'kind': 'bigquery#dataset', 'id': 'your-project-here:empty', 'datasetReference':
-        {'datasetId': 'empty', 'projectId': 'your-project-here'}, 'location': 'US'}]}  # noqa
+ONE_DATASET = {
+    'kind': 'bigquery#datasetList', 'etag': 'yScH5WIHeNUBF9b/VKybXA==',
+    'datasets': [{
+        'kind': 'bigquery#dataset',
+        'id': 'your-project-here:empty',
+        'datasetReference': {
+            'datasetId': 'empty',
+            'projectId': 'your-project-here'
+        },
+        'location': 'US'
+    }]
+}  # noqa
 NO_TABLES = {'kind': 'bigquery#tableList', 'etag': '1B2M2Y8AsgTpgAmY7PhCfg==', 'totalItems': 0}
-ONE_TABLE = {'kind': 'bigquery#tableList', 'etag': 'Iaqrz2TCDIANAOD/Xerkjw==',
-    'tables': [{'kind': 'bigquery#table', 'id': 'your-project-here:fdgdfgh.nested_recs', 'tableReference':
-        {'projectId': 'your-project-here', 'datasetId': 'fdgdfgh', 'tableId': 'nested_recs'},
-        'type': 'TABLE', 'creationTime': '1557578974009'}],
-    'totalItems': 1}  # noqa
-ONE_VIEW = {'kind': 'bigquery#tableList', 'etag': 'Iaqrz2TCDIANAOD/Xerkjw==',
-    'tables': [{'kind': 'bigquery#table', 'id': 'your-project-here:fdgdfgh.abab', 'tableReference':
-        {'projectId': 'your-project-here', 'datasetId': 'fdgdfgh', 'tableId': 'abab'},
-        'type': 'VIEW', 'view': {'useLegacySql': False}, 'creationTime': '1557577874991'}],
-        'totalItems': 1}  # noqa
-TIME_PARTITIONED = {'kind': 'bigquery#tableList', 'etag': 'Iaqrz2TCDIANAOD/Xerkjw==',
-    'tables': [{'kind': 'bigquery#table', 'id': 'your-project-here:fdgdfgh.other', 'tableReference':
-            {'projectId': 'your-project-here', 'datasetId': 'fdgdfgh', 'tableId': 'other'},
-            'type': 'TABLE', 'timePartitioning': {'type': 'DAY', 'requirePartitionFilter': False},
-            'creationTime': '1557577779306'}], 'totalItems': 1}  # noqa
-TABLE_DATE_RANGE = {'kind': 'bigquery#tableList', 'etag': 'Iaqrz2TCDIANAOD/Xerkjw==',
-    'tables': [{'kind': 'bigquery#table', 'id': 'your-project-here:fdgdfgh.other_20190101', 'tableReference':
-            {'projectId': 'your-project-here', 'datasetId': 'fdgdfgh', 'tableId': 'date_range_20190101'},
-            'type': 'TABLE', 'creationTime': '1557577779306'},
-            {'kind': 'bigquery#table', 'id': 'your-project-here:fdgdfgh.other_20190102', 'tableReference':
-            {'projectId': 'your-project-here', 'datasetId': 'fdgdfgh', 'tableId': 'date_range_20190102'},
-            'type': 'TABLE', 'creationTime': '1557577779306'}], 'totalItems': 2}  # noqa
-TABLE_DATA = {'kind': 'bigquery#table', 'etag': 'Hzc/56Rp9VR4Y6jhZApD/g==', 'id': 'your-project-here:fdgdfgh.test',
+ONE_TABLE = {
+    'kind': 'bigquery#tableList', 'etag': 'Iaqrz2TCDIANAOD/Xerkjw==',
+    'tables': [{
+        'kind': 'bigquery#table',
+        'id': 'your-project-here:fdgdfgh.nested_recs',
+        'tableReference': {
+            'projectId': 'your-project-here',
+            'datasetId': 'fdgdfgh',
+            'tableId': 'nested_recs'
+        },
+        'type': 'TABLE',
+        'creationTime': '1557578974009'
+    }],
+    'totalItems': 1
+}  # noqa
+ONE_VIEW = {
+    'kind': 'bigquery#tableList', 'etag': 'Iaqrz2TCDIANAOD/Xerkjw==',
+    'tables': [{
+        'kind': 'bigquery#table',
+        'id': 'your-project-here:fdgdfgh.abab',
+        'tableReference': {'projectId': 'your-project-here', 'datasetId': 'fdgdfgh', 'tableId': 'abab'},
+        'type': 'VIEW',
+        'view': {'useLegacySql': False},
+        'creationTime': '1557577874991'
+    }],
+    'totalItems': 1
+}  # noqa
+TIME_PARTITIONED = {
+    'kind': 'bigquery#tableList', 'etag': 'Iaqrz2TCDIANAOD/Xerkjw==',
+    'tables': [{
+        'kind': 'bigquery#table',
+        'id': 'your-project-here:fdgdfgh.other',
+        'tableReference': {'projectId': 'your-project-here', 'datasetId': 'fdgdfgh', 'tableId': 'other'},
+        'type': 'TABLE',
+        'timePartitioning': {'type': 'DAY', 'requirePartitionFilter': False},
+        'creationTime': '1557577779306'
+    }],
+    'totalItems': 1
+}  # noqa
+TABLE_DATE_RANGE = {
+    'kind': 'bigquery#tableList', 'etag': 'Iaqrz2TCDIANAOD/Xerkjw==',
+    'tables': [{
+        'kind': 'bigquery#table', 'id': 'your-project-here:fdgdfgh.other_20190101',
+        'tableReference': {'projectId': 'your-project-here', 'datasetId': 'fdgdfgh', 'tableId': 'date_range_20190101'},
+        'type': 'TABLE',
+        'creationTime': '1557577779306'
+    }, {
+        'kind': 'bigquery#table', 'id': 'your-project-here:fdgdfgh.other_20190102',
+        'tableReference': {'projectId': 'your-project-here', 'datasetId': 'fdgdfgh', 'tableId': 'date_range_20190102'},
+        'type': 'TABLE',
+        'creationTime': '1557577779306'
+    }],
+    'totalItems': 2
+}  # noqa
+TABLE_DATA = {
+    'kind': 'bigquery#table', 'etag': 'Hzc/56Rp9VR4Y6jhZApD/g==', 'id': 'your-project-here:fdgdfgh.test',
     'selfLink': 'https://www.googleapis.com/bigquery/v2/projects/your-project-here/datasets/fdgdfgh/tables/test',
     'tableReference': {'projectId': 'your-project-here', 'datasetId': 'fdgdfgh', 'tableId': 'test'},
     'schema': {
-        'fields': [
-            {'name': 'test', 'type': 'STRING', 'description': 'some_description'},
-            {'name': 'test2', 'type': 'INTEGER'},
-            {'name': 'test3', 'type': 'FLOAT', 'description': 'another description'},
-            {'name': 'test4', 'type': 'BOOLEAN'},
-            {'name': 'test5', 'type': 'DATETIME'}]},
+        'fields': [{'name': 'test', 'type': 'STRING', 'description': 'some_description'},
+                   {'name': 'test2', 'type': 'INTEGER'},
+                   {'name': 'test3', 'type': 'FLOAT', 'description': 'another description'},
+                   {'name': 'test4', 'type': 'BOOLEAN'},
+                   {'name': 'test5', 'type': 'DATETIME'}]
+    },
     'numBytes': '0',
     'numLongTermBytes': '0',
     'numRows': '0',
     'creationTime': '1557577756303',
     'lastModifiedTime': '1557577756370',
     'type': 'TABLE',
-    'location': 'EU'}  # noqa
-NO_SCHEMA = {'kind': 'bigquery#table', 'etag': 'Hzc/56Rp9VR4Y6jhZApD/g==', 'id': 'your-project-here:fdgdfgh.no_schema',
+    'location': 'EU'
+}  # noqa
+NO_SCHEMA = {
+    'kind': 'bigquery#table', 'etag': 'Hzc/56Rp9VR4Y6jhZApD/g==', 'id': 'your-project-here:fdgdfgh.no_schema',
     'selfLink': 'https://www.googleapis.com/bigquery/v2/projects/your-project-here/datasets/fdgdfgh/tables/no_schema',
     'tableReference': {'projectId': 'your-project-here', 'datasetId': 'fdgdfgh', 'tableId': 'no_schema'},
     'numBytes': '0',
@@ -68,8 +111,10 @@ NO_SCHEMA = {'kind': 'bigquery#table', 'etag': 'Hzc/56Rp9VR4Y6jhZApD/g==', 'id':
     'creationTime': '1557577756303',
     'lastModifiedTime': '1557577756370',
     'type': 'TABLE',
-    'location': 'EU'}  # noqa
-NO_COLS = {'kind': 'bigquery#table', 'etag': 'Hzc/56Rp9VR4Y6jhZApD/g==', 'id': 'your-project-here:fdgdfgh.no_columns',
+    'location': 'EU'
+}  # noqa
+NO_COLS = {
+    'kind': 'bigquery#table', 'etag': 'Hzc/56Rp9VR4Y6jhZApD/g==', 'id': 'your-project-here:fdgdfgh.no_columns',
     'selfLink': 'https://www.googleapis.com/bigquery/v2/projects/your-project-here/datasets/fdgdfgh/tables/no_columns',
     'tableReference': {'projectId': 'your-project-here', 'datasetId': 'fdgdfgh', 'tableId': 'no_columns'},
     'schema': {},
@@ -79,16 +124,20 @@ NO_COLS = {'kind': 'bigquery#table', 'etag': 'Hzc/56Rp9VR4Y6jhZApD/g==', 'id': '
     'creationTime': '1557577756303',
     'lastModifiedTime': '1557577756370',
     'type': 'TABLE',
-    'location': 'EU'}  # noqa
-VIEW_DATA = {'kind': 'bigquery#table', 'etag': 'E6+jjbQ/HsegSNpTEgELUA==', 'id': 'gerard-cloud-2:fdgdfgh.abab',
+    'location': 'EU'
+}  # noqa
+VIEW_DATA = {
+    'kind': 'bigquery#table', 'etag': 'E6+jjbQ/HsegSNpTEgELUA==', 'id': 'gerard-cloud-2:fdgdfgh.abab',
     'selfLink': 'https://www.googleapis.com/bigquery/v2/projects/gerard-cloud-2/datasets/fdgdfgh/tables/abab',
     'tableReference': {'projectId': 'gerard-cloud-2', 'datasetId': 'fdgdfgh', 'tableId': 'abab'},
-    'schema': {'fields': [
-        {'name': 'test', 'type': 'STRING'},
-        {'name': 'test2', 'type': 'INTEGER'},
-        {'name': 'test3', 'type': 'FLOAT'},
-        {'name': 'test4', 'type': 'BOOLEAN'},
-        {'name': 'test5', 'type': 'DATETIME'}]},
+    'schema': {
+        'fields': [
+            {'name': 'test', 'type': 'STRING'},
+            {'name': 'test2', 'type': 'INTEGER'},
+            {'name': 'test3', 'type': 'FLOAT'},
+            {'name': 'test4', 'type': 'BOOLEAN'},
+            {'name': 'test5', 'type': 'DATETIME'}]
+    },
     'numBytes': '0',
     'numLongTermBytes': '0',
     'numRows': '0',
@@ -96,20 +145,24 @@ VIEW_DATA = {'kind': 'bigquery#table', 'etag': 'E6+jjbQ/HsegSNpTEgELUA==', 'id':
     'lastModifiedTime': '1557577874991',
     'type': 'VIEW',
     'view': {'query': 'SELECT * from `gerard-cloud-2.fdgdfgh.test`', 'useLegacySql': False},
-    'location': 'EU'}  # noqa
-NESTED_DATA = {'kind': 'bigquery#table', 'etag': 'Hzc/56Rp9VR4Y6jhZApD/g==', 'id': 'your-project-here:fdgdfgh.test',
+    'location': 'EU'
+}  # noqa
+NESTED_DATA = {
+    'kind': 'bigquery#table', 'etag': 'Hzc/56Rp9VR4Y6jhZApD/g==', 'id': 'your-project-here:fdgdfgh.test',
     'selfLink': 'https://www.googleapis.com/bigquery/v2/projects/your-project-here/datasets/fdgdfgh/tables/test',
     'tableReference': {'projectId': 'your-project-here', 'datasetId': 'fdgdfgh', 'tableId': 'test'},
     'schema': {
-        'fields': [
-            {'name': 'nested', 'type': 'RECORD',
-            'fields': [
-                {'name': 'nested2', 'type': 'RECORD',
-                'fields': [
-                    {'name': 'ahah', 'type': 'STRING'}]}]}]},
+        'fields': [{
+            'name': 'nested', 'type': 'RECORD',
+            'fields': [{
+                'name': 'nested2', 'type': 'RECORD',
+                'fields': [{'name': 'ahah', 'type': 'STRING'}]
+            }]
+        }]
+    },
     'type': 'TABLE',
-    'location': 'EU'}  # noqa
-
+    'location': 'EU'
+}  # noqa
 
 try:
     FileNotFoundError
@@ -147,8 +200,8 @@ class MockBigQueryClient():
 class TestBigQueryMetadataExtractor(unittest.TestCase):
     def setUp(self) -> None:
         config_dict = {
-            'extractor.bigquery_table_metadata.{}'.format(BigQueryMetadataExtractor.PROJECT_ID_KEY):
-                'your-project-here'}
+            f'extractor.bigquery_table_metadata.{BigQueryMetadataExtractor.PROJECT_ID_KEY}': 'your-project-here'
+        }
         self.conf = ConfigFactory.from_dict(config_dict)
 
     @patch('databuilder.extractor.base_bigquery_extractor.build')
@@ -172,10 +225,8 @@ class TestBigQueryMetadataExtractor(unittest.TestCase):
     @patch('databuilder.extractor.base_bigquery_extractor.build')
     def test_accepts_dataset_filter_by_label(self, mock_build: Any) -> None:
         config_dict = {
-            'extractor.bigquery_table_metadata.{}'.format(BigQueryMetadataExtractor.PROJECT_ID_KEY):
-                'your-project-here',
-            'extractor.bigquery_table_metadata.{}'.format(BigQueryMetadataExtractor.FILTER_KEY):
-                'label.key:value'
+            f'extractor.bigquery_table_metadata.{BigQueryMetadataExtractor.PROJECT_ID_KEY}': 'your-project-here',
+            f'extractor.bigquery_table_metadata.{BigQueryMetadataExtractor.FILTER_KEY}': 'label.key:value'
         }
         conf = ConfigFactory.from_dict(config_dict)
 
@@ -269,12 +320,9 @@ class TestBigQueryMetadataExtractor(unittest.TestCase):
     @patch('databuilder.extractor.base_bigquery_extractor.build')
     def test_keypath_and_pagesize_can_be_set(self, mock_build: Any) -> None:
         config_dict = {
-            'extractor.bigquery_table_metadata.{}'.format(BigQueryMetadataExtractor.PROJECT_ID_KEY):
-                'your-project-here',
-            'extractor.bigquery_table_metadata.{}'.format(BigQueryMetadataExtractor.PAGE_SIZE_KEY):
-                200,
-            'extractor.bigquery_table_metadata.{}'.format(BigQueryMetadataExtractor.KEY_PATH_KEY):
-                '/tmp/doesnotexist',
+            f'extractor.bigquery_table_metadata.{BigQueryMetadataExtractor.PROJECT_ID_KEY}': 'your-project-here',
+            f'extractor.bigquery_table_metadata.{BigQueryMetadataExtractor.PAGE_SIZE_KEY}': 200,
+            f'extractor.bigquery_table_metadata.{BigQueryMetadataExtractor.KEY_PATH_KEY}': '/tmp/doesnotexist',
         }
         conf = ConfigFactory.from_dict(config_dict)
 

--- a/tests/unit/extractor/test_bigquery_metadata_extractor.py
+++ b/tests/unit/extractor/test_bigquery_metadata_extractor.py
@@ -5,7 +5,7 @@ import logging
 import unittest
 from typing import Any
 
-from mock import patch, Mock
+from mock import Mock, patch
 from pyhocon import ConfigFactory
 
 from databuilder import Scoped

--- a/tests/unit/extractor/test_bigquery_usage_extractor.py
+++ b/tests/unit/extractor/test_bigquery_usage_extractor.py
@@ -6,12 +6,11 @@ import tempfile
 import unittest
 from typing import Any
 
-from mock import patch, Mock
+from mock import Mock, patch
 from pyhocon import ConfigFactory
 
 from databuilder import Scoped
-from databuilder.extractor.bigquery_usage_extractor import BigQueryTableUsageExtractor
-from databuilder.extractor.bigquery_usage_extractor import TableColumnUsageTuple
+from databuilder.extractor.bigquery_usage_extractor import BigQueryTableUsageExtractor, TableColumnUsageTuple
 
 CORRECT_DATA = {
     "entries": [{

--- a/tests/unit/extractor/test_bigquery_usage_extractor.py
+++ b/tests/unit/extractor/test_bigquery_usage_extractor.py
@@ -1,137 +1,137 @@
 # Copyright Contributors to the Amundsen project.
 # SPDX-License-Identifier: Apache-2.0
 
-from mock import patch, Mock
 import base64
 import tempfile
 import unittest
-
-from pyhocon import ConfigFactory
 from typing import Any
+
+from mock import patch, Mock
+from pyhocon import ConfigFactory
 
 from databuilder import Scoped
 from databuilder.extractor.bigquery_usage_extractor import BigQueryTableUsageExtractor
 from databuilder.extractor.bigquery_usage_extractor import TableColumnUsageTuple
 
-
-CORRECT_DATA = {"entries": [
-{
-"protoPayload": {
-"@type": "type.googleapis.com/google.cloud.audit.AuditLog",
-"status": {},
-"authenticationInfo": {
-    "principalEmail": "your-user-here@test.com"
-},
-"serviceName": "bigquery.googleapis.com",
-"methodName": "jobservice.jobcompleted",
-"resourceName": "projects/your-project-here/jobs/bquxjob_758c08d1_16a96889839",
-"serviceData": {
-    "@type": "type.googleapis.com/google.cloud.bigquery.logging.v1.AuditData",
-    "jobCompletedEvent": {
-        "eventName": "query_job_completed",
-        "job": {
-            "jobName": {
-                "projectId": "your-project-here",
-                "jobId": "bquxjob_758c08d1_16a96889839",
-                "location": "US"
+CORRECT_DATA = {
+    "entries": [{
+        "protoPayload": {
+            "@type": "type.googleapis.com/google.cloud.audit.AuditLog",
+            "status": {},
+            "authenticationInfo": {
+                "principalEmail": "your-user-here@test.com"
             },
-            "jobConfiguration": {
-                "query": {
-                    "query": "select descript from "
-                    "`bigquery-public-data.austin_incidents.incidents_2008`\n",
-                    "destinationTable": {
-                        "projectId": "your-project-here",
-                        "datasetId": "_07147a061ddfd6dcaf246cfc5e858a0ccefa7080",
-                        "tableId": "anon1dd83635c62357091e55a5f76fb62d7deebcfa4c"
-                    },
-                    "createDisposition": "CREATE_IF_NEEDED",
-                    "writeDisposition": "WRITE_TRUNCATE",
-                    "defaultDataset": {},
-                    "queryPriority": "QUERY_INTERACTIVE",
-                    "statementType": "SELECT"
-                }
-            },
-            "jobStatus": {
-                "state": "DONE",
-                "error": {}
-            },
-            "jobStatistics": {
-                "createTime": "2019-05-08T08:22:56.349Z",
-                "startTime": "2019-05-08T08:22:56.660Z",
-                "endTime": "2019-05-08T08:23:00.049Z",
-                "totalProcessedBytes": "3637807",
-                "totalBilledBytes": "10485760",
-                "billingTier": 1,
-                "totalSlotMs": "452",
-                "referencedTables": [
-                    {
-                        "projectId": "bigquery-public-data",
-                        "datasetId": "austin_incidents",
-                        "tableId": "incidents_2008"
+            "serviceName": "bigquery.googleapis.com",
+            "methodName": "jobservice.jobcompleted",
+            "resourceName": "projects/your-project-here/jobs/bquxjob_758c08d1_16a96889839",
+            "serviceData": {
+                "@type": "type.googleapis.com/google.cloud.bigquery.logging.v1.AuditData",
+                "jobCompletedEvent": {
+                    "eventName": "query_job_completed",
+                    "job": {
+                        "jobName": {
+                            "projectId": "your-project-here",
+                            "jobId": "bquxjob_758c08d1_16a96889839",
+                            "location": "US"
+                        },
+                        "jobConfiguration": {
+                            "query": {
+                                "query": "select descript from "
+                                         "`bigquery-public-data.austin_incidents.incidents_2008`\n",
+                                "destinationTable": {
+                                    "projectId": "your-project-here",
+                                    "datasetId": "_07147a061ddfd6dcaf246cfc5e858a0ccefa7080",
+                                    "tableId": "anon1dd83635c62357091e55a5f76fb62d7deebcfa4c"
+                                },
+                                "createDisposition": "CREATE_IF_NEEDED",
+                                "writeDisposition": "WRITE_TRUNCATE",
+                                "defaultDataset": {},
+                                "queryPriority": "QUERY_INTERACTIVE",
+                                "statementType": "SELECT"
+                            }
+                        },
+                        "jobStatus": {
+                            "state": "DONE",
+                            "error": {}
+                        },
+                        "jobStatistics": {
+                            "createTime": "2019-05-08T08:22:56.349Z",
+                            "startTime": "2019-05-08T08:22:56.660Z",
+                            "endTime": "2019-05-08T08:23:00.049Z",
+                            "totalProcessedBytes": "3637807",
+                            "totalBilledBytes": "10485760",
+                            "billingTier": 1,
+                            "totalSlotMs": "452",
+                            "referencedTables": [
+                                {
+                                    "projectId": "bigquery-public-data",
+                                    "datasetId": "austin_incidents",
+                                    "tableId": "incidents_2008"
+                                }
+                            ],
+                            "totalTablesProcessed": 1,
+                            "queryOutputRowCount": "179524"
+                        }
                     }
-                ],
-                "totalTablesProcessed": 1,
-                "queryOutputRowCount": "179524"
+                }
             }
-        }
-    }
-}
-},
-"insertId": "-jyqvjse6lwjz",
-"resource": {
-"type": "bigquery_resource",
-"labels": {
-    "project_id": "your-project-here"
-}
-},
-"timestamp": "2019-05-08T08:23:00.061Z",
-"severity": "INFO",
-"logName": "projects/your-project-here/logs/cloudaudit.googleapis.com%2Fdata_access",
-"receiveTimestamp": "2019-05-08T08:23:00.310709609Z"
-}
-]}   # noqa
+        },
+        "insertId": "-jyqvjse6lwjz",
+        "resource": {
+            "type": "bigquery_resource",
+            "labels": {
+                "project_id": "your-project-here"
+            }
+        },
+        "timestamp": "2019-05-08T08:23:00.061Z",
+        "severity": "INFO",
+        "logName": "projects/your-project-here/logs/cloudaudit.googleapis.com%2Fdata_access",
+        "receiveTimestamp": "2019-05-08T08:23:00.310709609Z"
+    }]
+}  # noqa
 
-FAILURE = {"entries": [
-{
-    "protoPayload": {
-        "authenticationInfo": {
-            "principalEmail": "your-user-here@test.com"
-        },
-        "methodName": "jobservice.jobcompleted",
-        "serviceData": {
-            "jobCompletedEvent": {
-                "job": {
-                    "jobStatus": {
-                        "state": "DONE",
-                        "error": {
-                            "code": 11,
-                            "message": "Some descriptive error message"
+FAILURE = {
+    "entries": [{
+        "protoPayload": {
+            "authenticationInfo": {
+                "principalEmail": "your-user-here@test.com"
+            },
+            "methodName": "jobservice.jobcompleted",
+            "serviceData": {
+                "jobCompletedEvent": {
+                    "job": {
+                        "jobStatus": {
+                            "state": "DONE",
+                            "error": {
+                                "code": 11,
+                                "message": "Some descriptive error message"
+                            }
+                        },
+                        "jobStatistics": {
+                            "createTime": "2019-05-08T08:22:56.349Z",
+                            "startTime": "2019-05-08T08:22:56.660Z",
+                            "endTime": "2019-05-08T08:23:00.049Z",
+                            "totalProcessedBytes": "3637807",
+                            "totalBilledBytes": "10485760",
+                            "referencedTables": [
+                                {
+                                    "projectId": "bigquery-public-data",
+                                    "datasetId": "austin_incidents",
+                                    "tableId": "incidents_2008"
+                                }
+                            ]
                         }
-                    },
-                "jobStatistics": {
-                    "createTime": "2019-05-08T08:22:56.349Z",
-                    "startTime": "2019-05-08T08:22:56.660Z",
-                    "endTime": "2019-05-08T08:23:00.049Z",
-                    "totalProcessedBytes": "3637807",
-                    "totalBilledBytes": "10485760",
-                    "referencedTables": [
-                        {
-                            "projectId": "bigquery-public-data",
-                            "datasetId": "austin_incidents",
-                            "tableId": "incidents_2008"
-                        }
-                    ]
+                    }
                 }
-                }
-            }
+            },
         },
-    },
-}]}   # noqa
+    }]
+}  # noqa
 
 # An empty dict will be ignored, but putting in nextPageToken causes the test
 # to loop infinitely, so we need a bogus key/value to ensure that we will try
 # to read entries
-NO_ENTRIES = {'key': 'value'}   # noqa
+NO_ENTRIES = {'key': 'value'}  # noqa
 
 KEYFILE_DATA = """
 ewogICJ0eXBlIjogInNlcnZpY2VfYWNjb3VudCIsCiAgInByb2plY3RfaWQiOiAieW91ci1wcm9q
@@ -200,8 +200,7 @@ class TestBigqueryUsageExtractor(unittest.TestCase):
         Test Extraction using mock class
         """
         config_dict = {
-            'extractor.bigquery_table_usage.{}'.format(BigQueryTableUsageExtractor.PROJECT_ID_KEY):
-                'your-project-here',
+            f'extractor.bigquery_table_usage.{BigQueryTableUsageExtractor.PROJECT_ID_KEY}': 'your-project-here',
         }
         conf = ConfigFactory.from_dict(config_dict)
 
@@ -227,8 +226,7 @@ class TestBigqueryUsageExtractor(unittest.TestCase):
     @patch('databuilder.extractor.base_bigquery_extractor.build')
     def test_no_entries(self, mock_build: Any) -> None:
         config_dict = {
-            'extractor.bigquery_table_usage.{}'.format(BigQueryTableUsageExtractor.PROJECT_ID_KEY):
-                'your-project-here',
+            f'extractor.bigquery_table_usage.{BigQueryTableUsageExtractor.PROJECT_ID_KEY}': 'your-project-here',
         }
         conf = ConfigFactory.from_dict(config_dict)
 
@@ -252,10 +250,8 @@ class TestBigqueryUsageExtractor(unittest.TestCase):
             keyfile.write(base64.b64decode(KEYFILE_DATA))
             keyfile.flush()
             config_dict = {
-                'extractor.bigquery_table_usage.{}'.format(BigQueryTableUsageExtractor.PROJECT_ID_KEY):
-                    'your-project-here',
-                'extractor.bigquery_table_usage.{}'.format(BigQueryTableUsageExtractor.KEY_PATH_KEY):
-                    keyfile.name,
+                f'extractor.bigquery_table_usage.{BigQueryTableUsageExtractor.PROJECT_ID_KEY}': 'your-project-here',
+                f'extractor.bigquery_table_usage.{BigQueryTableUsageExtractor.KEY_PATH_KEY}': keyfile.name,
             }
             conf = ConfigFactory.from_dict(config_dict)
 
@@ -278,12 +274,9 @@ class TestBigqueryUsageExtractor(unittest.TestCase):
         PAGESIZE = 215
 
         config_dict = {
-            'extractor.bigquery_table_usage.{}'.format(BigQueryTableUsageExtractor.PROJECT_ID_KEY):
-                'your-project-here',
-            'extractor.bigquery_table_usage.{}'.format(BigQueryTableUsageExtractor.TIMESTAMP_KEY):
-                TIMESTAMP,
-            'extractor.bigquery_table_usage.{}'.format(BigQueryTableUsageExtractor.PAGE_SIZE_KEY):
-                PAGESIZE,
+            f'extractor.bigquery_table_usage.{BigQueryTableUsageExtractor.PROJECT_ID_KEY}': 'your-project-here',
+            f'extractor.bigquery_table_usage.{BigQueryTableUsageExtractor.TIMESTAMP_KEY}': TIMESTAMP,
+            f'extractor.bigquery_table_usage.{BigQueryTableUsageExtractor.PAGE_SIZE_KEY}': PAGESIZE,
         }
         conf = ConfigFactory.from_dict(config_dict)
 
@@ -301,10 +294,8 @@ class TestBigqueryUsageExtractor(unittest.TestCase):
 
     @patch('databuilder.extractor.base_bigquery_extractor.build')
     def test_failed_jobs_should_not_be_counted(self, mock_build: Any) -> None:
-
         config_dict = {
-            'extractor.bigquery_table_usage.{}'.format(BigQueryTableUsageExtractor.PROJECT_ID_KEY):
-                'your-project-here',
+            f'extractor.bigquery_table_usage.{BigQueryTableUsageExtractor.PROJECT_ID_KEY}': 'your-project-here',
         }
         conf = ConfigFactory.from_dict(config_dict)
 
@@ -320,10 +311,8 @@ class TestBigqueryUsageExtractor(unittest.TestCase):
     @patch('databuilder.extractor.base_bigquery_extractor.build')
     def test_email_filter_not_counted(self, mock_build: Any) -> None:
         config_dict = {
-            'extractor.bigquery_table_usage.{}'.format(BigQueryTableUsageExtractor.PROJECT_ID_KEY):
-                'your-project-here',
-            'extractor.bigquery_table_usage.{}'.format(BigQueryTableUsageExtractor.EMAIL_PATTERN):
-                'emailFilter',
+            f'extractor.bigquery_table_usage.{BigQueryTableUsageExtractor.PROJECT_ID_KEY}': 'your-project-here',
+            f'extractor.bigquery_table_usage.{BigQueryTableUsageExtractor.EMAIL_PATTERN}': 'emailFilter',
         }
         conf = ConfigFactory.from_dict(config_dict)
 
@@ -337,10 +326,8 @@ class TestBigqueryUsageExtractor(unittest.TestCase):
     @patch('databuilder.extractor.base_bigquery_extractor.build')
     def test_email_filter_counted(self, mock_build: Any) -> None:
         config_dict = {
-            'extractor.bigquery_table_usage.{}'.format(BigQueryTableUsageExtractor.PROJECT_ID_KEY):
-                'your-project-here',
-            'extractor.bigquery_table_usage.{}'.format(BigQueryTableUsageExtractor.EMAIL_PATTERN):
-                '.*@test.com.*',
+            f'extractor.bigquery_table_usage.{BigQueryTableUsageExtractor.PROJECT_ID_KEY}': 'your-project-here',
+            f'extractor.bigquery_table_usage.{BigQueryTableUsageExtractor.EMAIL_PATTERN}': '.*@test.com.*',
         }
         conf = ConfigFactory.from_dict(config_dict)
 

--- a/tests/unit/extractor/test_bigquery_watermark_extractor.py
+++ b/tests/unit/extractor/test_bigquery_watermark_extractor.py
@@ -4,54 +4,101 @@
 import logging
 import unittest
 from datetime import datetime
+from typing import Any
 
 from mock import patch, Mock
 from pyhocon import ConfigFactory
-from typing import Any
 
 from databuilder import Scoped
 from databuilder.extractor.bigquery_watermark_extractor import BigQueryWatermarkExtractor
 
 logging.basicConfig(level=logging.INFO)
 
-
 NO_DATASETS = {'kind': 'bigquery#datasetList', 'etag': '1B2M2Y8AsgTpgAmY7PhCfg=='}
-ONE_DATASET = {'kind': 'bigquery#datasetList', 'etag': 'yScH5WIHeNUBF9b/VKybXA==',
-    'datasets': [{'kind': 'bigquery#dataset', 'id': 'your-project-here:empty', 'datasetReference':
-        {'datasetId': 'empty', 'projectId': 'your-project-here'}, 'location': 'US'}]}  # noqa
+ONE_DATASET = {
+    'kind': 'bigquery#datasetList', 'etag': 'yScH5WIHeNUBF9b/VKybXA==',
+    'datasets': [{
+        'kind': 'bigquery#dataset',
+        'id': 'your-project-here:empty',
+        'datasetReference': {'datasetId': 'empty', 'projectId': 'your-project-here'},
+        'location': 'US'
+    }]
+}  # noqa
 NO_TABLES = {'kind': 'bigquery#tableList', 'etag': '1B2M2Y8AsgTpgAmY7PhCfg==', 'totalItems': 0}
-ONE_TABLE = {'kind': 'bigquery#tableList', 'etag': 'Iaqrz2TCDIANAOD/Xerkjw==',
-    'tables': [{'kind': 'bigquery#table', 'id': 'your-project-here:fdgdfgh.nested_recs', 'tableReference':
-        {'projectId': 'your-project-here', 'datasetId': 'fdgdfgh', 'tableId': 'nested_recs'},
-        'type': 'TABLE', 'creationTime': '1557578974009'}],
-    'totalItems': 1}  # noqa
-TIME_PARTITIONED = {'kind': 'bigquery#tableList', 'etag': 'Iaqrz2TCDIANAOD/Xerkjw==',
-    'tables': [{'kind': 'bigquery#table', 'id': 'your-project-here:fdgdfgh.other', 'tableReference':
-            {'projectId': 'your-project-here', 'datasetId': 'fdgdfgh', 'tableId': 'other'},
-            'type': 'TABLE', 'timePartitioning': {'type': 'DAY', 'requirePartitionFilter': False},
-            'creationTime': '1557577779306'}], 'totalItems': 1}  # noqa
-TIME_PARTITIONED_WITH_FIELD = {'kind': 'bigquery#tableList', 'etag': 'Iaqrz2TCDIANAOD/Xerkjw==',
-    'tables': [{'kind': 'bigquery#table', 'id': 'your-project-here:fdgdfgh.other', 'tableReference':
-            {'projectId': 'your-project-here', 'datasetId': 'fdgdfgh', 'tableId': 'other'},
-            'type': 'TABLE', 'timePartitioning': {'type': 'DAY', 'field': 'processed_date',
-            'requirePartitionFilter': False}, 'creationTime': '1557577779306'}], 'totalItems': 1}  # noqa
-TABLE_DATE_RANGE = {'kind': 'bigquery#tableList', 'etag': 'Iaqrz2TCDIANAOD/Xerkjw==',
-    'tables': [{'kind': 'bigquery#table', 'id': 'your-project-here:fdgdfgh.other_20190101', 'tableReference':
-            {'projectId': 'your-project-here', 'datasetId': 'fdgdfgh', 'tableId': 'date_range_20190101'},
-            'type': 'TABLE', 'creationTime': '1557577779306'},
-            {'kind': 'bigquery#table', 'id': 'your-project-here:fdgdfgh.other_20190102', 'tableReference':
-            {'projectId': 'your-project-here', 'datasetId': 'fdgdfgh', 'tableId': 'date_range_20190102'},
-            'type': 'TABLE', 'creationTime': '1557577779306'}], 'totalItems': 2}  # noqa
-PARTITION_DATA = {'kind': 'bigquery#queryResponse',
-     'schema': {'fields': [{'name': 'partition_id', 'type': 'STRING', 'mode': 'NULLABLE'},
-                           {'name': 'creation_time', 'type': 'TIMESTAMP', 'mode': 'NULLABLE'}]},
-     'jobReference': {'projectId': 'your-project-here', 'jobId': 'job_bfTRGj3Lv0tRjcrotXbZSgMCpNhY', 'location': 'EU'},
-     'totalRows': '3',
-     'rows': [{'f': [{'v': '20180802'}, {'v': '1.547512241348E9'}]},
-              {'f': [{'v': '20180803'}, {'v': '1.547512241348E9'}]},
-              {'f': [{'v': '20180804'}, {'v': '1.547512241348E9'}]}],
-     'totalBytesProcessed': '0', 'jobComplete': True, 'cacheHit': False}  # noqa
-
+ONE_TABLE = {
+    'kind': 'bigquery#tableList', 'etag': 'Iaqrz2TCDIANAOD/Xerkjw==',
+    'tables': [{
+        'kind': 'bigquery#table',
+        'id': 'your-project-here:fdgdfgh.nested_recs',
+        'tableReference': {'projectId': 'your-project-here', 'datasetId': 'fdgdfgh', 'tableId': 'nested_recs'},
+        'type': 'TABLE',
+        'creationTime': '1557578974009'
+    }],
+    'totalItems': 1
+}  # noqa
+TIME_PARTITIONED = {
+    'kind': 'bigquery#tableList', 'etag': 'Iaqrz2TCDIANAOD/Xerkjw==',
+    'tables': [{
+        'kind': 'bigquery#table',
+        'id': 'your-project-here:fdgdfgh.other',
+        'tableReference': {'projectId': 'your-project-here', 'datasetId': 'fdgdfgh', 'tableId': 'other'},
+        'type': 'TABLE',
+        'timePartitioning': {'type': 'DAY', 'requirePartitionFilter': False},
+        'creationTime': '1557577779306'
+    }],
+    'totalItems': 1
+}  # noqa
+TIME_PARTITIONED_WITH_FIELD = {
+    'kind': 'bigquery#tableList', 'etag': 'Iaqrz2TCDIANAOD/Xerkjw==',
+    'tables': [{
+        'kind': 'bigquery#table',
+        'id': 'your-project-here:fdgdfgh.other',
+        'tableReference': {'projectId': 'your-project-here', 'datasetId': 'fdgdfgh', 'tableId': 'other'},
+        'type': 'TABLE',
+        'timePartitioning': {'type': 'DAY', 'field': 'processed_date', 'requirePartitionFilter': False},
+        'creationTime': '1557577779306'
+    }],
+    'totalItems': 1
+}  # noqa
+TABLE_DATE_RANGE = {
+    'kind': 'bigquery#tableList', 'etag': 'Iaqrz2TCDIANAOD/Xerkjw==',
+    'tables': [{
+        'kind': 'bigquery#table',
+        'id': 'your-project-here:fdgdfgh.other_20190101',
+        'tableReference': {'projectId': 'your-project-here', 'datasetId': 'fdgdfgh', 'tableId': 'date_range_20190101'},
+        'type': 'TABLE',
+        'creationTime': '1557577779306'
+    }, {
+        'kind': 'bigquery#table',
+        'id': 'your-project-here:fdgdfgh.other_20190102',
+        'tableReference': {'projectId': 'your-project-here', 'datasetId': 'fdgdfgh', 'tableId': 'date_range_20190102'},
+        'type': 'TABLE',
+        'creationTime': '1557577779306'
+    }],
+    'totalItems': 2
+}  # noqa
+PARTITION_DATA = {
+    'kind': 'bigquery#queryResponse',
+    'schema': {
+        'fields': [{
+            'name': 'partition_id',
+            'type': 'STRING',
+            'mode': 'NULLABLE'
+        }, {
+            'name': 'creation_time',
+            'type': 'TIMESTAMP',
+            'mode': 'NULLABLE'
+        }]
+    },
+    'jobReference': {'projectId': 'your-project-here', 'jobId': 'job_bfTRGj3Lv0tRjcrotXbZSgMCpNhY', 'location': 'EU'},
+    'totalRows': '3',
+    'rows': [{'f': [{'v': '20180802'}, {'v': '1.547512241348E9'}]},
+             {'f': [{'v': '20180803'}, {'v': '1.547512241348E9'}]},
+             {'f': [{'v': '20180804'}, {'v': '1.547512241348E9'}]}],
+    'totalBytesProcessed': '0',
+    'jobComplete': True,
+    'cacheHit': False
+}  # noqa
 
 try:
     FileNotFoundError
@@ -93,7 +140,7 @@ class MockBigQueryClient():
 class TestBigQueryWatermarkExtractor(unittest.TestCase):
     def setUp(self) -> None:
         config_dict = {
-            'extractor.bigquery_watermarks.{}'.format(BigQueryWatermarkExtractor.PROJECT_ID_KEY):
+            f'extractor.bigquery_watermarks.{BigQueryWatermarkExtractor.PROJECT_ID_KEY}':
                 'your-project-here'}
         self.conf = ConfigFactory.from_dict(config_dict)
 
@@ -177,10 +224,8 @@ class TestBigQueryWatermarkExtractor(unittest.TestCase):
     @patch('databuilder.extractor.base_bigquery_extractor.build')
     def test_keypath_can_be_set(self, mock_build: Any) -> None:
         config_dict = {
-            'extractor.bigquery_watermarks.{}'.format(BigQueryWatermarkExtractor.PROJECT_ID_KEY):
-                'your-project-here',
-            'extractor.bigquery_watermarks.{}'.format(BigQueryWatermarkExtractor.KEY_PATH_KEY):
-                '/tmp/doesnotexist',
+            f'extractor.bigquery_watermarks.{BigQueryWatermarkExtractor.PROJECT_ID_KEY}': 'your-project-here',
+            f'extractor.bigquery_watermarks.{BigQueryWatermarkExtractor.KEY_PATH_KEY}': '/tmp/doesnotexist',
         }
         conf = ConfigFactory.from_dict(config_dict)
 

--- a/tests/unit/extractor/test_bigquery_watermark_extractor.py
+++ b/tests/unit/extractor/test_bigquery_watermark_extractor.py
@@ -6,7 +6,7 @@ import unittest
 from datetime import datetime
 from typing import Any
 
-from mock import patch, Mock
+from mock import Mock, patch
 from pyhocon import ConfigFactory
 
 from databuilder import Scoped

--- a/tests/unit/extractor/test_cassandra_extractor.py
+++ b/tests/unit/extractor/test_cassandra_extractor.py
@@ -4,14 +4,14 @@
 import logging
 import unittest
 from collections import OrderedDict
-
-from mock import patch
-from pyhocon import ConfigFactory
 from typing import Any
 
 from cassandra.metadata import ColumnMetadata as CassandraColumnMetadata
+from mock import patch
+from pyhocon import ConfigFactory
+
 from databuilder.extractor.cassandra_extractor import CassandraExtractor
-from databuilder.models.table_metadata import TableMetadata, ColumnMetadata
+from databuilder.models.table_metadata import ColumnMetadata, TableMetadata
 
 
 # patch whole class to avoid actually calling for boto3.client during tests

--- a/tests/unit/extractor/test_csv_extractor.py
+++ b/tests/unit/extractor/test_csv_extractor.py
@@ -13,8 +13,8 @@ class TestCsvExtractor(unittest.TestCase):
 
     def setUp(self) -> None:
         config_dict = {
-            'extractor.csv.{}'.format(CsvExtractor.FILE_LOCATION): 'example/sample_data/sample_table.csv',
-            'extractor.csv.model_class': 'databuilder.models.table_metadata.TableMetadata',
+            f'extractor.csv.{CsvExtractor.FILE_LOCATION}': 'example/sample_data/sample_table.csv',
+            f'extractor.csv.model_class': 'databuilder.models.table_metadata.TableMetadata',
         }
         self.conf = ConfigFactory.from_dict(config_dict)
 

--- a/tests/unit/extractor/test_deltalake_extractor.py
+++ b/tests/unit/extractor/test_deltalake_extractor.py
@@ -4,36 +4,37 @@
 import logging
 import tempfile
 import unittest
+from typing import Dict
+
+from pyhocon import ConfigFactory
+# patch whole class to avoid actually calling for boto3.client during tests
+from pyspark.sql import SparkSession
+from pyspark.sql.catalog import Table
 
 from databuilder import Scoped
 from databuilder.extractor.delta_lake_metadata_extractor import DeltaLakeMetadataExtractor, \
     ScrapedTableMetadata, ScrapedColumnMetadata
 from databuilder.models.table_metadata import TableMetadata, ColumnMetadata
-from pyhocon import ConfigFactory
-# patch whole class to avoid actually calling for boto3.client during tests
-from pyspark.sql import SparkSession
-from pyspark.sql.catalog import Table
-from typing import Dict
 
 
 class TestDeltaLakeExtractor(unittest.TestCase):
 
     def setUp(self) -> None:
         logging.basicConfig(level=logging.INFO)
-        self.spark = SparkSession.builder\
-            .appName("Amundsen Delta Lake Metadata Extraction")\
-            .master("local")\
+        self.spark = SparkSession.builder \
+            .appName("Amundsen Delta Lake Metadata Extraction") \
+            .master("local") \
             .config("spark.jars.packages", "io.delta:delta-core_2.12:0.7.0") \
             .config("spark.sql.warehouse.dir", tempfile.TemporaryDirectory()) \
             .config("spark.sql.extensions", "io.delta.sql.DeltaSparkSessionExtension") \
             .config("spark.sql.catalog.spark_catalog", "org.apache.spark.sql.delta.catalog.DeltaCatalog") \
             .getOrCreate()
         self.config_dict = {
-            'extractor.delta_lake_table_metadata.{}'.format(DeltaLakeMetadataExtractor.CLUSTER_KEY): 'test_cluster',
-            'extractor.delta_lake_table_metadata.{}'.format(DeltaLakeMetadataExtractor.SCHEMA_LIST_KEY): [],
-            'extractor.delta_lake_table_metadata.{}'.format(DeltaLakeMetadataExtractor.EXCLUDE_LIST_SCHEMAS_KEY): [],
-            'extractor.delta_lake_table_metadata.{}'.format(DeltaLakeMetadataExtractor.DATABASE_KEY): 'test_database',
-            'extractor.delta_lake_table_metadata.{}'.format(DeltaLakeMetadataExtractor.DELTA_TABLES_ONLY): False
+            f'extractor.delta_lake_table_metadata.{DeltaLakeMetadataExtractor.CLUSTER_KEY}': 'test_cluster',
+            f'extractor.delta_lake_table_metadata.{DeltaLakeMetadataExtractor.SCHEMA_LIST_KEY}': [],
+            f'extractor.delta_lake_table_metadata.{DeltaLakeMetadataExtractor.EXCLUDE_LIST_SCHEMAS_KEY}': [],
+            f'extractor.delta_lake_table_metadata.{DeltaLakeMetadataExtractor.DATABASE_KEY}': 'test_database',
+            f'extractor.delta_lake_table_metadata.{DeltaLakeMetadataExtractor.DELTA_TABLES_ONLY}': False
         }
         conf = ConfigFactory.from_dict(self.config_dict)
         self.dExtractor = DeltaLakeMetadataExtractor()
@@ -172,11 +173,10 @@ class TestDeltaLakeExtractor(unittest.TestCase):
 
     def test_extract_with_only_specific_schemas(self) -> None:
         self.config_dict = {
-            'extractor.delta_lake_table_metadata.{}'.format(DeltaLakeMetadataExtractor.CLUSTER_KEY): 'test_cluster',
-            'extractor.delta_lake_table_metadata.{}'
-            .format(DeltaLakeMetadataExtractor.SCHEMA_LIST_KEY): ['test_schema2'],
-            'extractor.delta_lake_table_metadata.{}'.format(DeltaLakeMetadataExtractor.EXCLUDE_LIST_SCHEMAS_KEY): [],
-            'extractor.delta_lake_table_metadata.{}'.format(DeltaLakeMetadataExtractor.DATABASE_KEY): 'test_database'
+            f'extractor.delta_lake_table_metadata.{DeltaLakeMetadataExtractor.CLUSTER_KEY}': 'test_cluster',
+            f'extractor.delta_lake_table_metadata.{DeltaLakeMetadataExtractor.SCHEMA_LIST_KEY}': ['test_schema2'],
+            f'extractor.delta_lake_table_metadata.{DeltaLakeMetadataExtractor.EXCLUDE_LIST_SCHEMAS_KEY}': [],
+            f'extractor.delta_lake_table_metadata.{DeltaLakeMetadataExtractor.DATABASE_KEY}': 'test_database'
         }
         conf = ConfigFactory.from_dict(self.config_dict)
         self.dExtractor.init(Scoped.get_scoped_conf(conf=conf,
@@ -190,12 +190,11 @@ class TestDeltaLakeExtractor(unittest.TestCase):
 
     def test_extract_when_excluding(self) -> None:
         self.config_dict = {
-            'extractor.delta_lake_table_metadata.{}'.format(DeltaLakeMetadataExtractor.CLUSTER_KEY): 'test_cluster',
-            'extractor.delta_lake_table_metadata.{}'.format(DeltaLakeMetadataExtractor.SCHEMA_LIST_KEY): [],
-            'extractor.delta_lake_table_metadata.{}'
-            .format(DeltaLakeMetadataExtractor.EXCLUDE_LIST_SCHEMAS_KEY): ['test_schema2'],
-            'extractor.delta_lake_table_metadata.{}'.format(DeltaLakeMetadataExtractor.DATABASE_KEY): 'test_database'
-
+            f'extractor.delta_lake_table_metadata.{DeltaLakeMetadataExtractor.CLUSTER_KEY}': 'test_cluster',
+            f'extractor.delta_lake_table_metadata.{DeltaLakeMetadataExtractor.SCHEMA_LIST_KEY}': [],
+            f'extractor.delta_lake_table_metadata.{DeltaLakeMetadataExtractor.EXCLUDE_LIST_SCHEMAS_KEY}':
+                ['test_schema2'],
+            f'extractor.delta_lake_table_metadata.{DeltaLakeMetadataExtractor.DATABASE_KEY}': 'test_database'
         }
         conf = ConfigFactory.from_dict(self.config_dict)
         self.dExtractor.init(Scoped.get_scoped_conf(conf=conf,

--- a/tests/unit/extractor/test_deltalake_extractor.py
+++ b/tests/unit/extractor/test_deltalake_extractor.py
@@ -12,9 +12,10 @@ from pyspark.sql import SparkSession
 from pyspark.sql.catalog import Table
 
 from databuilder import Scoped
-from databuilder.extractor.delta_lake_metadata_extractor import DeltaLakeMetadataExtractor, \
-    ScrapedTableMetadata, ScrapedColumnMetadata
-from databuilder.models.table_metadata import TableMetadata, ColumnMetadata
+from databuilder.extractor.delta_lake_metadata_extractor import (
+    DeltaLakeMetadataExtractor, ScrapedColumnMetadata, ScrapedTableMetadata,
+)
+from databuilder.models.table_metadata import ColumnMetadata, TableMetadata
 
 
 class TestDeltaLakeExtractor(unittest.TestCase):

--- a/tests/unit/extractor/test_dremio_metadata_extractor.py
+++ b/tests/unit/extractor/test_dremio_metadata_extractor.py
@@ -2,14 +2,16 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import logging
-from typing import Dict, List, Any
 import unittest
+from typing import (
+    Any, Dict, List,
+)
 from unittest.mock import MagicMock, patch
 
 from pyhocon import ConfigFactory
 
 from databuilder.extractor.dremio_metadata_extractor import DremioMetadataExtractor
-from databuilder.models.table_metadata import TableMetadata, ColumnMetadata
+from databuilder.models.table_metadata import ColumnMetadata, TableMetadata
 
 
 class TestDremioMetadataExtractor(unittest.TestCase):

--- a/tests/unit/extractor/test_feast_extractor.py
+++ b/tests/unit/extractor/test_feast_extractor.py
@@ -5,10 +5,10 @@ import json
 import re
 import unittest
 
+from feast.entity import Entity
+from feast.feature_table import FeatureTable
 from mock import call, MagicMock
 from pyhocon import ConfigFactory
-from feast.feature_table import FeatureTable
-from feast.entity import Entity
 
 from databuilder import Scoped
 from databuilder.extractor.feast_extractor import FeastExtractor
@@ -167,15 +167,9 @@ class TestFeastExtractor(unittest.TestCase):
 
     def _init_extractor(self, programmatic_description_enabled: bool = True) -> None:
         conf = {
-            "extractor.feast.{}".format(
-                FeastExtractor.FEAST_ENDPOINT_CONFIG_KEY
-            ): "feast-core.example.com:6565",
-            "extractor.feast.{}".format(
-                FeastExtractor.FEAST_SERVICE_CONFIG_KEY
-            ): "unittest-feast-instance",
-            "extractor.feast.{}".format(
-                FeastExtractor.DESCRIBE_FEATURE_TABLES
-            ): programmatic_description_enabled,
+            f'extractor.feast.{FeastExtractor.FEAST_ENDPOINT_CONFIG_KEY}': 'feast-core.example.com:6565',
+            f'extractor.feast.{FeastExtractor.FEAST_SERVICE_CONFIG_KEY}': 'unittest-feast-instance',
+            f'extractor.feast.{FeastExtractor.DESCRIBE_FEATURE_TABLES}': programmatic_description_enabled,
         }
         self.extractor = FeastExtractor()
         self.extractor.init(
@@ -190,7 +184,7 @@ class TestFeastExtractor(unittest.TestCase):
         return re.sub("\n[ \t]*\\|", "\n", text)
 
     def _mock_feature_table(
-        self, labels: dict = {}, add_stream_source: bool = False
+            self, labels: dict = {}, add_stream_source: bool = False
     ) -> None:
         table_spec = {
             "name": "driver_trips",

--- a/tests/unit/extractor/test_feast_extractor.py
+++ b/tests/unit/extractor/test_feast_extractor.py
@@ -7,15 +7,13 @@ import unittest
 
 from feast.entity import Entity
 from feast.feature_table import FeatureTable
-from mock import call, MagicMock
+from mock import MagicMock, call
 from pyhocon import ConfigFactory
 
 from databuilder import Scoped
 from databuilder.extractor.feast_extractor import FeastExtractor
 from databuilder.models.table_metadata import (
-    TableMetadata,
-    ColumnMetadata,
-    DescriptionMetadata,
+    ColumnMetadata, DescriptionMetadata, TableMetadata,
 )
 
 

--- a/tests/unit/extractor/test_generic_extractor.py
+++ b/tests/unit/extractor/test_generic_extractor.py
@@ -17,8 +17,7 @@ class TestGenericExtractor(unittest.TestCase):
         """
         config_dict = {
             'extractor.generic.extraction_items': [{'timestamp': 10000000}],
-            'extractor.generic.model_class':
-                'databuilder.models.neo4j_es_last_updated.Neo4jESLastUpdated',
+            'extractor.generic.model_class': 'databuilder.models.neo4j_es_last_updated.Neo4jESLastUpdated',
         }
         conf = ConfigFactory.from_dict(config_dict)
 

--- a/tests/unit/extractor/test_glue_extractor.py
+++ b/tests/unit/extractor/test_glue_extractor.py
@@ -8,7 +8,7 @@ from mock import patch
 from pyhocon import ConfigFactory
 
 from databuilder.extractor.glue_extractor import GlueExtractor
-from databuilder.models.table_metadata import TableMetadata, ColumnMetadata
+from databuilder.models.table_metadata import ColumnMetadata, TableMetadata
 
 
 # patch whole class to avoid actually calling for boto3.client during tests

--- a/tests/unit/extractor/test_hive_table_last_updated_extractor.py
+++ b/tests/unit/extractor/test_hive_table_last_updated_extractor.py
@@ -5,9 +5,11 @@ import itertools
 import logging
 import unittest
 from datetime import datetime
-from typing import Iterable, Iterator, Optional, TypeVar
+from typing import (
+    Iterable, Iterator, Optional, TypeVar,
+)
 
-from mock import patch, MagicMock
+from mock import MagicMock, patch
 from pyhocon import ConfigFactory
 from pytz import UTC
 

--- a/tests/unit/extractor/test_hive_table_last_updated_extractor.py
+++ b/tests/unit/extractor/test_hive_table_last_updated_extractor.py
@@ -5,18 +5,17 @@ import itertools
 import logging
 import unittest
 from datetime import datetime
-from pytz import UTC
+from typing import Iterable, Iterator, Optional, TypeVar
 
 from mock import patch, MagicMock
 from pyhocon import ConfigFactory
-from typing import Iterable, Iterator, Optional, TypeVar
+from pytz import UTC
 
 from databuilder.extractor.hive_table_last_updated_extractor import HiveTableLastUpdatedExtractor
 from databuilder.extractor.sql_alchemy_extractor import SQLAlchemyExtractor
-from databuilder.models.table_last_updated import TableLastUpdated
 from databuilder.filesystem.filesystem import FileSystem
 from databuilder.filesystem.metadata import FileMetadata
-
+from databuilder.models.table_last_updated import TableLastUpdated
 
 T = TypeVar('T')
 
@@ -36,11 +35,9 @@ class TestHiveTableLastUpdatedExtractor(unittest.TestCase):
         logging.basicConfig(level=logging.INFO)
 
     def test_extraction_with_empty_query_result(self) -> None:
-
         config_dict = {
-            'extractor.sqlalchemy.{}'.format(SQLAlchemyExtractor.CONN_STRING):
-                'TEST_CONNECTION',
-            'filesystem.{}'.format(FileSystem.DASK_FILE_SYSTEM): MagicMock()
+            f'extractor.sqlalchemy.{SQLAlchemyExtractor.CONN_STRING}': 'TEST_CONNECTION',
+            f'filesystem.{FileSystem.DASK_FILE_SYSTEM}': MagicMock()
         }
         conf = ConfigFactory.from_dict(config_dict)
         with patch.object(SQLAlchemyExtractor, '_get_connection'):
@@ -52,24 +49,25 @@ class TestHiveTableLastUpdatedExtractor(unittest.TestCase):
 
     def test_extraction_with_partition_table_result(self) -> None:
         config_dict = {
-            'filesystem.{}'.format(FileSystem.DASK_FILE_SYSTEM): MagicMock()
+            f'filesystem.{FileSystem.DASK_FILE_SYSTEM}': MagicMock()
         }
         conf = ConfigFactory.from_dict(config_dict)
 
         pt_alchemy_extractor_instance = MagicMock()
         non_pt_alchemy_extractor_instance = MagicMock()
         with patch.object(HiveTableLastUpdatedExtractor, '_get_partitioned_table_sql_alchemy_extractor',
-                          return_value=pt_alchemy_extractor_instance),\
+                          return_value=pt_alchemy_extractor_instance), \
             patch.object(HiveTableLastUpdatedExtractor, '_get_non_partitioned_table_sql_alchemy_extractor',
                          return_value=non_pt_alchemy_extractor_instance):
-            pt_alchemy_extractor_instance.extract = MagicMock(side_effect=null_iterator([
-                {'schema': 'foo_schema',
-                 'table_name': 'table_1',
-                 'last_updated_time': 1},
-                {'schema': 'foo_schema',
-                 'table_name': 'table_2',
-                 'last_updated_time': 2}
-            ]))
+            pt_alchemy_extractor_instance.extract = MagicMock(side_effect=null_iterator([{
+                'schema': 'foo_schema',
+                'table_name': 'table_1',
+                'last_updated_time': 1
+            }, {
+                'schema': 'foo_schema',
+                'table_name': 'table_2',
+                'last_updated_time': 2
+            }]))
 
             non_pt_alchemy_extractor_instance.extract = MagicMock(return_value=None)
 
@@ -102,20 +100,19 @@ class TestHiveTableLastUpdatedExtractor(unittest.TestCase):
         pt_alchemy_extractor_instance = MagicMock()
         non_pt_alchemy_extractor_instance = MagicMock()
 
-        with patch.object(HiveTableLastUpdatedExtractor,
-                          '_get_partitioned_table_sql_alchemy_extractor', return_value=pt_alchemy_extractor_instance), \
-            patch.object(HiveTableLastUpdatedExtractor,
-                         '_get_non_partitioned_table_sql_alchemy_extractor',
+        with patch.object(HiveTableLastUpdatedExtractor, '_get_partitioned_table_sql_alchemy_extractor',
+                          return_value=pt_alchemy_extractor_instance), \
+            patch.object(HiveTableLastUpdatedExtractor, '_get_non_partitioned_table_sql_alchemy_extractor',
                          return_value=non_pt_alchemy_extractor_instance), \
-            patch.object(HiveTableLastUpdatedExtractor,
-                         '_get_filesystem', return_value=fs):
+            patch.object(HiveTableLastUpdatedExtractor, '_get_filesystem',
+                         return_value=fs):
             pt_alchemy_extractor_instance.extract = MagicMock(return_value=None)
 
-            non_pt_alchemy_extractor_instance.extract = MagicMock(side_effect=null_iterator([
-                {'schema': 'foo_schema',
-                 'table_name': 'table_1',
-                 'location': '/foo/bar'},
-            ]))
+            non_pt_alchemy_extractor_instance.extract = MagicMock(side_effect=null_iterator([{
+                'schema': 'foo_schema',
+                'table_name': 'table_1',
+                'location': '/foo/bar'
+            }]))
 
             extractor = HiveTableLastUpdatedExtractor()
             extractor.init(ConfigFactory.from_dict({}))

--- a/tests/unit/extractor/test_hive_table_metadata_extractor.py
+++ b/tests/unit/extractor/test_hive_table_metadata_extractor.py
@@ -5,12 +5,12 @@ import logging
 import unittest
 from typing import Any, Dict
 
-from mock import patch, MagicMock
+from mock import MagicMock, patch
 from pyhocon import ConfigFactory
 
 from databuilder.extractor.hive_table_metadata_extractor import HiveTableMetadataExtractor
 from databuilder.extractor.sql_alchemy_extractor import SQLAlchemyExtractor
-from databuilder.models.table_metadata import TableMetadata, ColumnMetadata
+from databuilder.models.table_metadata import ColumnMetadata, TableMetadata
 
 
 class TestHiveTableMetadataExtractor(unittest.TestCase):

--- a/tests/unit/extractor/test_hive_table_metadata_extractor.py
+++ b/tests/unit/extractor/test_hive_table_metadata_extractor.py
@@ -3,10 +3,10 @@
 
 import logging
 import unittest
+from typing import Any, Dict
 
 from mock import patch, MagicMock
 from pyhocon import ConfigFactory
-from typing import Any, Dict
 
 from databuilder.extractor.hive_table_metadata_extractor import HiveTableMetadataExtractor
 from databuilder.extractor.sql_alchemy_extractor import SQLAlchemyExtractor
@@ -18,8 +18,7 @@ class TestHiveTableMetadataExtractor(unittest.TestCase):
         logging.basicConfig(level=logging.INFO)
 
         config_dict = {
-            'extractor.sqlalchemy.{}'.format(SQLAlchemyExtractor.CONN_STRING):
-            'TEST_CONNECTION'
+            f'extractor.sqlalchemy.{SQLAlchemyExtractor.CONN_STRING}': 'TEST_CONNECTION'
         }
         self.conf = ConfigFactory.from_dict(config_dict)
 
@@ -38,8 +37,8 @@ class TestHiveTableMetadataExtractor(unittest.TestCase):
 
     def test_extraction_with_single_result(self) -> None:
         with patch.object(SQLAlchemyExtractor, '_get_connection') as mock_connection, \
-            patch.object(HiveTableMetadataExtractor, '_choose_default_sql_stm',
-                         return_value=HiveTableMetadataExtractor.DEFAULT_SQL_STATEMENT):
+                patch.object(HiveTableMetadataExtractor, '_choose_default_sql_stm',
+                             return_value=HiveTableMetadataExtractor.DEFAULT_SQL_STATEMENT):
             connection = MagicMock()
             mock_connection.return_value = connection
             sql_execute = MagicMock()
@@ -106,8 +105,8 @@ class TestHiveTableMetadataExtractor(unittest.TestCase):
 
     def test_extraction_with_multiple_result(self) -> None:
         with patch.object(SQLAlchemyExtractor, '_get_connection') as mock_connection, \
-            patch.object(HiveTableMetadataExtractor, '_choose_default_sql_stm',
-                         return_value=HiveTableMetadataExtractor.DEFAULT_SQL_STATEMENT):
+                patch.object(HiveTableMetadataExtractor, '_choose_default_sql_stm',
+                             return_value=HiveTableMetadataExtractor.DEFAULT_SQL_STATEMENT):
             connection = MagicMock()
             mock_connection.return_value = connection
             sql_execute = MagicMock()
@@ -237,8 +236,7 @@ class TestHiveTableMetadataExtractorWithWhereClause(unittest.TestCase):
 
         config_dict = {
             HiveTableMetadataExtractor.WHERE_CLAUSE_SUFFIX_KEY: self.where_clause_suffix,
-            'extractor.sqlalchemy.{}'.format(SQLAlchemyExtractor.CONN_STRING):
-                'TEST_CONNECTION'
+            f'extractor.sqlalchemy.{SQLAlchemyExtractor.CONN_STRING}': 'TEST_CONNECTION'
         }
         self.conf = ConfigFactory.from_dict(config_dict)
 
@@ -263,8 +261,7 @@ class TestHiveTableMetadataExtractorWithWhereClause(unittest.TestCase):
                          return_value=HiveTableMetadataExtractor.DEFAULT_SQL_STATEMENT):
             config_dict = {
                 HiveTableMetadataExtractor.WHERE_CLAUSE_SUFFIX_KEY: self.where_clause_suffix,
-                'extractor.sqlalchemy.{}'.format(SQLAlchemyExtractor.CONN_STRING):
-                    'TEST_CONNECTION',
+                f'extractor.sqlalchemy.{SQLAlchemyExtractor.CONN_STRING}': 'TEST_CONNECTION',
                 HiveTableMetadataExtractor.EXTRACT_SQL:
                     'select sth for test {where_clause_suffix}'
             }

--- a/tests/unit/extractor/test_kafka_source_extractor.py
+++ b/tests/unit/extractor/test_kafka_source_extractor.py
@@ -4,7 +4,7 @@
 import logging
 import unittest
 
-from mock import patch, MagicMock
+from mock import MagicMock, patch
 from pyhocon import ConfigFactory
 
 from databuilder import Scoped

--- a/tests/unit/extractor/test_kafka_source_extractor.py
+++ b/tests/unit/extractor/test_kafka_source_extractor.py
@@ -2,9 +2,9 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import logging
-from mock import patch, MagicMock
 import unittest
 
+from mock import patch, MagicMock
 from pyhocon import ConfigFactory
 
 from databuilder import Scoped
@@ -15,13 +15,11 @@ class TestKafkaSourceExtractor(unittest.TestCase):
     def setUp(self) -> None:
         logging.basicConfig(level=logging.INFO)
         config_dict = {
-            'extractor.kafka_source.consumer_config': {'"group.id"': 'consumer-group',
-                                                       '"enable.auto.commit"': False},
-            'extractor.kafka_source.{}'.format(KafkaSourceExtractor.RAW_VALUE_TRANSFORMER):
+            f'extractor.kafka_source.consumer_config': {'"group.id"': 'consumer-group', '"enable.auto.commit"': False},
+            f'extractor.kafka_source.{KafkaSourceExtractor.RAW_VALUE_TRANSFORMER}':
                 'databuilder.transformer.base_transformer.NoopTransformer',
-            'extractor.kafka_source.{}'.format(KafkaSourceExtractor.TOPIC_NAME_LIST): ['test-topic'],
-            'extractor.kafka_source.{}'.format(KafkaSourceExtractor.CONSUMER_TOTAL_TIMEOUT_SEC): 1,
-
+            f'extractor.kafka_source.{KafkaSourceExtractor.TOPIC_NAME_LIST}': ['test-topic'],
+            f'extractor.kafka_source.{KafkaSourceExtractor.CONSUMER_TOTAL_TIMEOUT_SEC}': 1,
         }
         self.conf = ConfigFactory.from_dict(config_dict)
 
@@ -31,7 +29,6 @@ class TestKafkaSourceExtractor(unittest.TestCase):
                                                     scope=kafka_extractor.get_scope()))
 
         with patch.object(kafka_extractor, 'consumer') as mock_consumer:
-
             mock_poll = MagicMock()
             mock_poll.error.return_value = False
             # only return once

--- a/tests/unit/extractor/test_mssql_metadata_extractor.py
+++ b/tests/unit/extractor/test_mssql_metadata_extractor.py
@@ -3,10 +3,10 @@
 
 import logging
 import unittest
+from typing import Any, Dict
 
 from mock import patch, MagicMock
 from pyhocon import ConfigFactory
-from typing import Any, Dict
 
 from databuilder.extractor.mssql_metadata_extractor import MSSQLMetadataExtractor
 from databuilder.extractor.sql_alchemy_extractor import SQLAlchemyExtractor
@@ -18,15 +18,11 @@ class TestMSSQLMetadataExtractor(unittest.TestCase):
         logging.basicConfig(level=logging.INFO)
 
         config_dict = {
-            'extractor.sqlalchemy.{}'.format(SQLAlchemyExtractor.CONN_STRING):
-                'TEST_CONNECTION',
-            'extractor.mssql_metadata.{}'.format(MSSQLMetadataExtractor.CLUSTER_KEY):
-                'MY_CLUSTER',
-            'extractor.mssql_metadata.{}'.format(MSSQLMetadataExtractor.USE_CATALOG_AS_CLUSTER_NAME):
-                False,
-            'extractor.mssql_metadata.{}'.format(MSSQLMetadataExtractor.DATABASE_KEY):
-                'mssql',
-            'extractor.mssql_metadata.{}'.format(MSSQLMetadataExtractor.WHERE_CLAUSE_SUFFIX_KEY): ''
+            f'extractor.sqlalchemy.{SQLAlchemyExtractor.CONN_STRING}': 'TEST_CONNECTION',
+            f'extractor.mssql_metadata.{MSSQLMetadataExtractor.CLUSTER_KEY}': 'MY_CLUSTER',
+            f'extractor.mssql_metadata.{MSSQLMetadataExtractor.USE_CATALOG_AS_CLUSTER_NAME}': False,
+            f'extractor.mssql_metadata.{MSSQLMetadataExtractor.DATABASE_KEY}': 'mssql',
+            f'extractor.mssql_metadata.{MSSQLMetadataExtractor.WHERE_CLAUSE_SUFFIX_KEY}': ''
         }
         self.conf = ConfigFactory.from_dict(config_dict)
 
@@ -51,7 +47,7 @@ class TestMSSQLMetadataExtractor(unittest.TestCase):
                      'name': 'test_table',
                      'description': 'a table for testing',
                      'cluster':
-                         self.conf['extractor.mssql_metadata.{}'.format(MSSQLMetadataExtractor.CLUSTER_KEY)]
+                         self.conf[f'extractor.mssql_metadata.{MSSQLMetadataExtractor.CLUSTER_KEY}']
                      }
 
             sql_execute.return_value = [
@@ -111,21 +107,21 @@ class TestMSSQLMetadataExtractor(unittest.TestCase):
                      'name': 'test_table1',
                      'description': 'test table 1',
                      'cluster':
-                         self.conf['extractor.mssql_metadata.{}'.format(MSSQLMetadataExtractor.CLUSTER_KEY)]
+                         self.conf[f'extractor.mssql_metadata.{MSSQLMetadataExtractor.CLUSTER_KEY}']
                      }
 
             table1 = {'schema_name': 'test_schema1',
                       'name': 'test_table2',
                       'description': 'test table 2',
                       'cluster':
-                          self.conf['extractor.mssql_metadata.{}'.format(MSSQLMetadataExtractor.CLUSTER_KEY)]
+                          self.conf[f'extractor.mssql_metadata.{MSSQLMetadataExtractor.CLUSTER_KEY}']
                       }
 
             table2 = {'schema_name': 'test_schema2',
                       'name': 'test_table3',
                       'description': 'test table 3',
                       'cluster':
-                          self.conf['extractor.mssql_metadata.{}'.format(MSSQLMetadataExtractor.CLUSTER_KEY)]
+                          self.conf[f'extractor.mssql_metadata.{MSSQLMetadataExtractor.CLUSTER_KEY}']
                       }
 
             sql_execute.return_value = [
@@ -185,8 +181,7 @@ class TestMSSQLMetadataExtractor(unittest.TestCase):
             extractor.init(self.conf)
 
             expected = TableMetadata('mssql',
-                                     self.conf['extractor.mssql_metadata.{}'.format(
-                                         MSSQLMetadataExtractor.CLUSTER_KEY)],
+                                     self.conf[f'extractor.mssql_metadata.{MSSQLMetadataExtractor.CLUSTER_KEY}'],
                                      'test_schema1', 'test_table1', 'test table 1',
                                      [ColumnMetadata('col_id1', 'description of col_id1', 'bigint', 0),
                                       ColumnMetadata('col_id2', 'description of col_id2', 'bigint', 1),
@@ -197,8 +192,7 @@ class TestMSSQLMetadataExtractor(unittest.TestCase):
             self.assertEqual(expected.__repr__(), extractor.extract().__repr__())
 
             expected = TableMetadata('mssql',
-                                     self.conf['extractor.mssql_metadata.{}'.format(
-                                         MSSQLMetadataExtractor.CLUSTER_KEY)],
+                                     self.conf[f'extractor.mssql_metadata.{MSSQLMetadataExtractor.CLUSTER_KEY}'],
                                      'test_schema1', 'test_table2', 'test table 2',
                                      [ColumnMetadata('col_name', 'description of col_name', 'varchar', 0),
                                       ColumnMetadata('col_name2', 'description of col_name2', 'varchar', 1)],
@@ -206,8 +200,7 @@ class TestMSSQLMetadataExtractor(unittest.TestCase):
             self.assertEqual(expected.__repr__(), extractor.extract().__repr__())
 
             expected = TableMetadata('mssql',
-                                     self.conf['extractor.mssql_metadata.{}'.format(
-                                         MSSQLMetadataExtractor.CLUSTER_KEY)],
+                                     self.conf[f'extractor.mssql_metadata.{MSSQLMetadataExtractor.CLUSTER_KEY}'],
                                      'test_schema2', 'test_table3', 'test table 3',
                                      [ColumnMetadata('col_id3', 'description of col_id3', 'varchar', 0),
                                       ColumnMetadata('col_name3', 'description of col_name3',
@@ -233,8 +226,7 @@ class TestMSSQLMetadataExtractorWithWhereClause(unittest.TestCase):
 
         config_dict = {
             MSSQLMetadataExtractor.WHERE_CLAUSE_SUFFIX_KEY: self.where_clause_suffix,
-            'extractor.sqlalchemy.{}'.format(SQLAlchemyExtractor.CONN_STRING):
-                'TEST_CONNECTION'
+            f'extractor.sqlalchemy.{SQLAlchemyExtractor.CONN_STRING}': 'TEST_CONNECTION'
         }
         self.conf = ConfigFactory.from_dict(config_dict)
 
@@ -256,8 +248,7 @@ class TestMSSQLMetadataExtractorClusterKeyNoTableCatalog(unittest.TestCase):
 
         config_dict = {
             MSSQLMetadataExtractor.CLUSTER_KEY: self.cluster_key,
-            'extractor.sqlalchemy.{}'.format(SQLAlchemyExtractor.CONN_STRING):
-                'TEST_CONNECTION',
+            f'extractor.sqlalchemy.{SQLAlchemyExtractor.CONN_STRING}': 'TEST_CONNECTION',
             MSSQLMetadataExtractor.USE_CATALOG_AS_CLUSTER_NAME: False
         }
         self.conf = ConfigFactory.from_dict(config_dict)
@@ -278,8 +269,7 @@ class TestMSSQLMetadataExtractorNoClusterKeyNoTableCatalog(unittest.TestCase):
         logging.basicConfig(level=logging.INFO)
 
         config_dict = {
-            'extractor.sqlalchemy.{}'.format(SQLAlchemyExtractor.CONN_STRING):
-                'TEST_CONNECTION',
+            f'extractor.sqlalchemy.{SQLAlchemyExtractor.CONN_STRING}': 'TEST_CONNECTION',
             MSSQLMetadataExtractor.USE_CATALOG_AS_CLUSTER_NAME: False
         }
         self.conf = ConfigFactory.from_dict(config_dict)
@@ -302,8 +292,7 @@ class TestMSSQLMetadataExtractorTableCatalogEnabled(unittest.TestCase):
 
         config_dict = {
             MSSQLMetadataExtractor.CLUSTER_KEY: self.cluster_key,
-            'extractor.sqlalchemy.{}'.format(SQLAlchemyExtractor.CONN_STRING):
-                'TEST_CONNECTION',
+            f'extractor.sqlalchemy.{SQLAlchemyExtractor.CONN_STRING}': 'TEST_CONNECTION',
             MSSQLMetadataExtractor.USE_CATALOG_AS_CLUSTER_NAME: True
         }
         self.conf = ConfigFactory.from_dict(config_dict)

--- a/tests/unit/extractor/test_mssql_metadata_extractor.py
+++ b/tests/unit/extractor/test_mssql_metadata_extractor.py
@@ -5,12 +5,12 @@ import logging
 import unittest
 from typing import Any, Dict
 
-from mock import patch, MagicMock
+from mock import MagicMock, patch
 from pyhocon import ConfigFactory
 
 from databuilder.extractor.mssql_metadata_extractor import MSSQLMetadataExtractor
 from databuilder.extractor.sql_alchemy_extractor import SQLAlchemyExtractor
-from databuilder.models.table_metadata import TableMetadata, ColumnMetadata
+from databuilder.models.table_metadata import ColumnMetadata, TableMetadata
 
 
 class TestMSSQLMetadataExtractor(unittest.TestCase):

--- a/tests/unit/extractor/test_neo4j_es_last_updated_extractor.py
+++ b/tests/unit/extractor/test_neo4j_es_last_updated_extractor.py
@@ -1,10 +1,10 @@
 # Copyright Contributors to the Amundsen project.
 # SPDX-License-Identifier: Apache-2.0
 
-from mock import patch
-from typing import Any
 import unittest
+from typing import Any
 
+from mock import patch
 from pyhocon import ConfigFactory
 
 from databuilder import Scoped

--- a/tests/unit/extractor/test_neo4j_extractor.py
+++ b/tests/unit/extractor/test_neo4j_extractor.py
@@ -2,10 +2,10 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import unittest
+from typing import Any
 
 from mock import patch
 from pyhocon import ConfigFactory
-from typing import Any
 
 from databuilder import Scoped
 from databuilder.extractor.neo4j_extractor import Neo4jExtractor
@@ -16,10 +16,10 @@ class TestNeo4jExtractor(unittest.TestCase):
 
     def setUp(self) -> None:
         config_dict = {
-            'extractor.neo4j.{}'.format(Neo4jExtractor.GRAPH_URL_CONFIG_KEY): 'TEST_GRAPH_URL',
-            'extractor.neo4j.{}'.format(Neo4jExtractor.CYPHER_QUERY_CONFIG_KEY): 'TEST_QUERY',
-            'extractor.neo4j.{}'.format(Neo4jExtractor.NEO4J_AUTH_USER): 'TEST_USER',
-            'extractor.neo4j.{}'.format(Neo4jExtractor.NEO4J_AUTH_PW): 'TEST_PW'
+            f'extractor.neo4j.{Neo4jExtractor.GRAPH_URL_CONFIG_KEY}': 'TEST_GRAPH_URL',
+            f'extractor.neo4j.{Neo4jExtractor.CYPHER_QUERY_CONFIG_KEY}': 'TEST_QUERY',
+            f'extractor.neo4j.{Neo4jExtractor.NEO4J_AUTH_USER}': 'TEST_USER',
+            f'extractor.neo4j.{Neo4jExtractor.NEO4J_AUTH_PW}': 'TEST_PW'
         }
 
         self.conf = ConfigFactory.from_dict(config_dict)
@@ -83,11 +83,11 @@ class TestNeo4jExtractor(unittest.TestCase):
         Test Extraction using model class
         """
         config_dict = {
-            'extractor.neo4j.{}'.format(Neo4jExtractor.GRAPH_URL_CONFIG_KEY): 'TEST_GRAPH_URL',
-            'extractor.neo4j.{}'.format(Neo4jExtractor.CYPHER_QUERY_CONFIG_KEY): 'TEST_QUERY',
-            'extractor.neo4j.{}'.format(Neo4jExtractor.NEO4J_AUTH_USER): 'TEST_USER',
-            'extractor.neo4j.{}'.format(Neo4jExtractor.NEO4J_AUTH_PW): 'TEST_PW',
-            'extractor.neo4j.{}'.format(Neo4jExtractor.MODEL_CLASS_CONFIG_KEY):
+            f'extractor.neo4j.{Neo4jExtractor.GRAPH_URL_CONFIG_KEY}': 'TEST_GRAPH_URL',
+            f'extractor.neo4j.{Neo4jExtractor.CYPHER_QUERY_CONFIG_KEY}': 'TEST_QUERY',
+            f'extractor.neo4j.{Neo4jExtractor.NEO4J_AUTH_USER}': 'TEST_USER',
+            f'extractor.neo4j.{Neo4jExtractor.NEO4J_AUTH_PW}': 'TEST_PW',
+            f'extractor.neo4j.{Neo4jExtractor.MODEL_CLASS_CONFIG_KEY}':
                 'databuilder.models.table_elasticsearch_document.TableESDocument'
         }
 

--- a/tests/unit/extractor/test_neo4j_search_data_extractor.py
+++ b/tests/unit/extractor/test_neo4j_search_data_extractor.py
@@ -2,10 +2,11 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import unittest
-from mock import patch
 from typing import Any
 
+from mock import patch
 from pyhocon import ConfigFactory
+
 from databuilder import Scoped
 from databuilder.extractor.neo4j_extractor import Neo4jExtractor
 from databuilder.extractor.neo4j_search_data_extractor import Neo4jSearchDataExtractor
@@ -30,14 +31,10 @@ class TestNeo4jExtractor(unittest.TestCase):
         with patch.object(Neo4jExtractor, '_get_driver'):
             extractor = Neo4jSearchDataExtractor()
             conf = ConfigFactory.from_dict({
-                'extractor.search_data.extractor.neo4j.{}'.format(Neo4jExtractor.GRAPH_URL_CONFIG_KEY):
-                    'test-endpoint',
-                'extractor.search_data.extractor.neo4j.{}'.format(Neo4jExtractor.NEO4J_AUTH_USER):
-                    'test-user',
-                'extractor.search_data.extractor.neo4j.{}'.format(Neo4jExtractor.NEO4J_AUTH_PW):
-                    'test-passwd',
-                'extractor.search_data.{}'.format(Neo4jSearchDataExtractor.ENTITY_TYPE):
-                    'dashboard',
+                f'extractor.search_data.extractor.neo4j.{Neo4jExtractor.GRAPH_URL_CONFIG_KEY}': 'test-endpoint',
+                f'extractor.search_data.extractor.neo4j.{Neo4jExtractor.NEO4J_AUTH_USER}': 'test-user',
+                f'extractor.search_data.extractor.neo4j.{Neo4jExtractor.NEO4J_AUTH_PW}': 'test-passwd',
+                f'extractor.search_data.{Neo4jSearchDataExtractor.ENTITY_TYPE}': 'dashboard',
             })
             extractor.init(Scoped.get_scoped_conf(conf=conf,
                                                   scope=extractor.get_scope()))
@@ -48,16 +45,11 @@ class TestNeo4jExtractor(unittest.TestCase):
         with patch.object(Neo4jExtractor, '_get_driver'):
             extractor = Neo4jSearchDataExtractor()
             conf = ConfigFactory.from_dict({
-                'extractor.search_data.extractor.neo4j.{}'.format(Neo4jExtractor.GRAPH_URL_CONFIG_KEY):
-                    'test-endpoint',
-                'extractor.search_data.extractor.neo4j.{}'.format(Neo4jExtractor.NEO4J_AUTH_USER):
-                    'test-user',
-                'extractor.search_data.extractor.neo4j.{}'.format(Neo4jExtractor.NEO4J_AUTH_PW):
-                    'test-passwd',
-                'extractor.search_data.{}'.format(Neo4jSearchDataExtractor.ENTITY_TYPE):
-                    'dashboard',
-                'extractor.search_data.{}'.format(JOB_PUBLISH_TAG):
-                    'test-date',
+                f'extractor.search_data.extractor.neo4j.{Neo4jExtractor.GRAPH_URL_CONFIG_KEY}': 'test-endpoint',
+                f'extractor.search_data.extractor.neo4j.{Neo4jExtractor.NEO4J_AUTH_USER}': 'test-user',
+                f'extractor.search_data.extractor.neo4j.{Neo4jExtractor.NEO4J_AUTH_PW}': 'test-passwd',
+                f'extractor.search_data.{Neo4jSearchDataExtractor.ENTITY_TYPE}': 'dashboard',
+                f'extractor.search_data.{JOB_PUBLISH_TAG}': 'test-date',
             })
             extractor.init(Scoped.get_scoped_conf(conf=conf,
                                                   scope=extractor.get_scope()))

--- a/tests/unit/extractor/test_postgres_metadata_extractor.py
+++ b/tests/unit/extractor/test_postgres_metadata_extractor.py
@@ -5,12 +5,12 @@ import logging
 import unittest
 from typing import Any, Dict
 
-from mock import patch, MagicMock
+from mock import MagicMock, patch
 from pyhocon import ConfigFactory
 
 from databuilder.extractor.postgres_metadata_extractor import PostgresMetadataExtractor
 from databuilder.extractor.sql_alchemy_extractor import SQLAlchemyExtractor
-from databuilder.models.table_metadata import TableMetadata, ColumnMetadata
+from databuilder.models.table_metadata import ColumnMetadata, TableMetadata
 
 
 class TestPostgresMetadataExtractor(unittest.TestCase):

--- a/tests/unit/extractor/test_postgres_metadata_extractor.py
+++ b/tests/unit/extractor/test_postgres_metadata_extractor.py
@@ -3,10 +3,10 @@
 
 import logging
 import unittest
+from typing import Any, Dict
 
 from mock import patch, MagicMock
 from pyhocon import ConfigFactory
-from typing import Any, Dict
 
 from databuilder.extractor.postgres_metadata_extractor import PostgresMetadataExtractor
 from databuilder.extractor.sql_alchemy_extractor import SQLAlchemyExtractor
@@ -18,8 +18,7 @@ class TestPostgresMetadataExtractor(unittest.TestCase):
         logging.basicConfig(level=logging.INFO)
 
         config_dict = {
-            'extractor.sqlalchemy.{}'.format(SQLAlchemyExtractor.CONN_STRING):
-            'TEST_CONNECTION',
+            f'extractor.sqlalchemy.{SQLAlchemyExtractor.CONN_STRING}': 'TEST_CONNECTION',
             PostgresMetadataExtractor.CLUSTER_KEY: 'MY_CLUSTER',
             PostgresMetadataExtractor.USE_CATALOG_AS_CLUSTER_NAME: False,
             PostgresMetadataExtractor.DATABASE_KEY: 'postgres'
@@ -47,7 +46,7 @@ class TestPostgresMetadataExtractor(unittest.TestCase):
                      'name': 'test_table',
                      'description': 'a table for testing',
                      'cluster':
-                     self.conf[PostgresMetadataExtractor.CLUSTER_KEY]
+                         self.conf[PostgresMetadataExtractor.CLUSTER_KEY]
                      }
 
             sql_execute.return_value = [
@@ -107,21 +106,21 @@ class TestPostgresMetadataExtractor(unittest.TestCase):
                      'name': 'test_table1',
                      'description': 'test table 1',
                      'cluster':
-                     self.conf[PostgresMetadataExtractor.CLUSTER_KEY]
+                         self.conf[PostgresMetadataExtractor.CLUSTER_KEY]
                      }
 
             table1 = {'schema': 'test_schema1',
                       'name': 'test_table2',
                       'description': 'test table 2',
                       'cluster':
-                      self.conf[PostgresMetadataExtractor.CLUSTER_KEY]
+                          self.conf[PostgresMetadataExtractor.CLUSTER_KEY]
                       }
 
             table2 = {'schema': 'test_schema2',
                       'name': 'test_table3',
                       'description': 'test table 3',
                       'cluster':
-                      self.conf[PostgresMetadataExtractor.CLUSTER_KEY]
+                          self.conf[PostgresMetadataExtractor.CLUSTER_KEY]
                       }
 
             sql_execute.return_value = [
@@ -225,8 +224,7 @@ class TestPostgresMetadataExtractorWithWhereClause(unittest.TestCase):
 
         config_dict = {
             PostgresMetadataExtractor.WHERE_CLAUSE_SUFFIX_KEY: self.where_clause_suffix,
-            'extractor.sqlalchemy.{}'.format(SQLAlchemyExtractor.CONN_STRING):
-                'TEST_CONNECTION'
+            f'extractor.sqlalchemy.{SQLAlchemyExtractor.CONN_STRING}': 'TEST_CONNECTION'
         }
         self.conf = ConfigFactory.from_dict(config_dict)
 
@@ -248,8 +246,7 @@ class TestPostgresMetadataExtractorClusterKeyNoTableCatalog(unittest.TestCase):
 
         config_dict = {
             PostgresMetadataExtractor.CLUSTER_KEY: self.cluster_key,
-            'extractor.sqlalchemy.{}'.format(SQLAlchemyExtractor.CONN_STRING):
-                'TEST_CONNECTION',
+            f'extractor.sqlalchemy.{SQLAlchemyExtractor.CONN_STRING}': 'TEST_CONNECTION',
             PostgresMetadataExtractor.USE_CATALOG_AS_CLUSTER_NAME: False
         }
         self.conf = ConfigFactory.from_dict(config_dict)
@@ -270,8 +267,7 @@ class TestPostgresMetadataExtractorNoClusterKeyNoTableCatalog(unittest.TestCase)
         logging.basicConfig(level=logging.INFO)
 
         config_dict = {
-            'extractor.sqlalchemy.{}'.format(SQLAlchemyExtractor.CONN_STRING):
-                'TEST_CONNECTION',
+            f'extractor.sqlalchemy.{SQLAlchemyExtractor.CONN_STRING}': 'TEST_CONNECTION',
             PostgresMetadataExtractor.USE_CATALOG_AS_CLUSTER_NAME: False
         }
         self.conf = ConfigFactory.from_dict(config_dict)
@@ -294,8 +290,7 @@ class TestPostgresMetadataExtractorTableCatalogEnabled(unittest.TestCase):
 
         config_dict = {
             PostgresMetadataExtractor.CLUSTER_KEY: self.cluster_key,
-            'extractor.sqlalchemy.{}'.format(SQLAlchemyExtractor.CONN_STRING):
-                'TEST_CONNECTION',
+            f'extractor.sqlalchemy.{SQLAlchemyExtractor.CONN_STRING}': 'TEST_CONNECTION',
             PostgresMetadataExtractor.USE_CATALOG_AS_CLUSTER_NAME: True
         }
         self.conf = ConfigFactory.from_dict(config_dict)

--- a/tests/unit/extractor/test_presto_view_metadata_extractor.py
+++ b/tests/unit/extractor/test_presto_view_metadata_extractor.py
@@ -6,12 +6,12 @@ import json
 import logging
 import unittest
 
-from mock import patch, MagicMock
+from mock import MagicMock, patch
 from pyhocon import ConfigFactory
 
 from databuilder.extractor.presto_view_metadata_extractor import PrestoViewMetadataExtractor
 from databuilder.extractor.sql_alchemy_extractor import SQLAlchemyExtractor
-from databuilder.models.table_metadata import TableMetadata, ColumnMetadata
+from databuilder.models.table_metadata import ColumnMetadata, TableMetadata
 
 
 class TestPrestoViewMetadataExtractor(unittest.TestCase):

--- a/tests/unit/extractor/test_presto_view_metadata_extractor.py
+++ b/tests/unit/extractor/test_presto_view_metadata_extractor.py
@@ -19,8 +19,7 @@ class TestPrestoViewMetadataExtractor(unittest.TestCase):
         logging.basicConfig(level=logging.INFO)
 
         config_dict = {
-            'extractor.sqlalchemy.{}'.format(SQLAlchemyExtractor.CONN_STRING):
-            'TEST_CONNECTION'
+            f'extractor.sqlalchemy.{SQLAlchemyExtractor.CONN_STRING}': 'TEST_CONNECTION'
         }
         self.conf = ConfigFactory.from_dict(config_dict)
 

--- a/tests/unit/extractor/test_redshift_metadata_extractor.py
+++ b/tests/unit/extractor/test_redshift_metadata_extractor.py
@@ -5,12 +5,12 @@ import logging
 import unittest
 from typing import Any, Dict
 
-from mock import patch, MagicMock
+from mock import MagicMock, patch
 from pyhocon import ConfigFactory
 
 from databuilder.extractor.redshift_metadata_extractor import RedshiftMetadataExtractor
 from databuilder.extractor.sql_alchemy_extractor import SQLAlchemyExtractor
-from databuilder.models.table_metadata import TableMetadata, ColumnMetadata
+from databuilder.models.table_metadata import ColumnMetadata, TableMetadata
 
 
 class TestRedshiftMetadataExtractor(unittest.TestCase):

--- a/tests/unit/extractor/test_redshift_metadata_extractor.py
+++ b/tests/unit/extractor/test_redshift_metadata_extractor.py
@@ -3,10 +3,10 @@
 
 import logging
 import unittest
+from typing import Any, Dict
 
 from mock import patch, MagicMock
 from pyhocon import ConfigFactory
-from typing import Any, Dict
 
 from databuilder.extractor.redshift_metadata_extractor import RedshiftMetadataExtractor
 from databuilder.extractor.sql_alchemy_extractor import SQLAlchemyExtractor
@@ -18,8 +18,7 @@ class TestRedshiftMetadataExtractor(unittest.TestCase):
         logging.basicConfig(level=logging.INFO)
 
         config_dict = {
-            'extractor.sqlalchemy.{}'.format(SQLAlchemyExtractor.CONN_STRING):
-            'TEST_CONNECTION',
+            f'extractor.sqlalchemy.{SQLAlchemyExtractor.CONN_STRING}': 'TEST_CONNECTION',
             RedshiftMetadataExtractor.CLUSTER_KEY: 'MY_CLUSTER',
             RedshiftMetadataExtractor.USE_CATALOG_AS_CLUSTER_NAME: False,
             RedshiftMetadataExtractor.DATABASE_KEY: 'redshift'
@@ -47,7 +46,7 @@ class TestRedshiftMetadataExtractor(unittest.TestCase):
                      'name': 'test_table',
                      'description': 'a table for testing',
                      'cluster':
-                     self.conf[RedshiftMetadataExtractor.CLUSTER_KEY]
+                         self.conf[RedshiftMetadataExtractor.CLUSTER_KEY]
                      }
 
             sql_execute.return_value = [
@@ -113,7 +112,7 @@ class TestRedshiftMetadataExtractorWithWhereClause(unittest.TestCase):
 
         config_dict = {
             RedshiftMetadataExtractor.WHERE_CLAUSE_SUFFIX_KEY: self.where_clause_suffix,
-            'extractor.sqlalchemy.{}'.format(SQLAlchemyExtractor.CONN_STRING):
+            f'extractor.sqlalchemy.{SQLAlchemyExtractor.CONN_STRING}':
                 'TEST_CONNECTION'
         }
         self.conf = ConfigFactory.from_dict(config_dict)

--- a/tests/unit/extractor/test_snowflake_metadata_extractor.py
+++ b/tests/unit/extractor/test_snowflake_metadata_extractor.py
@@ -3,10 +3,10 @@
 
 import logging
 import unittest
+from typing import Any, Dict
 
 from mock import patch, MagicMock
 from pyhocon import ConfigFactory
-from typing import Any, Dict
 
 from databuilder.extractor.snowflake_metadata_extractor import SnowflakeMetadataExtractor
 from databuilder.extractor.sql_alchemy_extractor import SQLAlchemyExtractor
@@ -18,14 +18,10 @@ class TestSnowflakeMetadataExtractor(unittest.TestCase):
         logging.basicConfig(level=logging.INFO)
 
         config_dict = {
-            'extractor.sqlalchemy.{}'.format(SQLAlchemyExtractor.CONN_STRING):
-            'TEST_CONNECTION',
-            'extractor.snowflake_metadata.{}'.format(SnowflakeMetadataExtractor.CLUSTER_KEY):
-            'MY_CLUSTER',
-            'extractor.snowflake_metadata.{}'.format(SnowflakeMetadataExtractor.USE_CATALOG_AS_CLUSTER_NAME):
-            False,
-            'extractor.snowflake_metadata.{}'.format(SnowflakeMetadataExtractor.SNOWFLAKE_DATABASE_KEY):
-            'prod'
+            f'extractor.sqlalchemy.{SQLAlchemyExtractor.CONN_STRING}': 'TEST_CONNECTION',
+            f'extractor.snowflake_metadata.{SnowflakeMetadataExtractor.CLUSTER_KEY}': 'MY_CLUSTER',
+            f'extractor.snowflake_metadata.{SnowflakeMetadataExtractor.USE_CATALOG_AS_CLUSTER_NAME}': False,
+            f'extractor.snowflake_metadata.{SnowflakeMetadataExtractor.SNOWFLAKE_DATABASE_KEY}': 'prod'
         }
         self.conf = ConfigFactory.from_dict(config_dict)
 
@@ -49,8 +45,7 @@ class TestSnowflakeMetadataExtractor(unittest.TestCase):
             table = {'schema': 'test_schema',
                      'name': 'test_table',
                      'description': 'a table for testing',
-                     'cluster':
-                     self.conf['extractor.snowflake_metadata.{}'.format(SnowflakeMetadataExtractor.CLUSTER_KEY)],
+                     'cluster': self.conf[f'extractor.snowflake_metadata.{SnowflakeMetadataExtractor.CLUSTER_KEY}'],
                      'is_view': 'false'
                      }
 
@@ -112,7 +107,7 @@ class TestSnowflakeMetadataExtractor(unittest.TestCase):
                      'name': 'test_table1',
                      'description': 'test table 1',
                      'cluster':
-                     self.conf['extractor.snowflake_metadata.{}'.format(SnowflakeMetadataExtractor.CLUSTER_KEY)],
+                         self.conf[f'extractor.snowflake_metadata.{SnowflakeMetadataExtractor.CLUSTER_KEY}'],
                      'is_view': 'nottrue'
                      }
 
@@ -120,7 +115,7 @@ class TestSnowflakeMetadataExtractor(unittest.TestCase):
                       'name': 'test_table2',
                       'description': 'test table 2',
                       'cluster':
-                      self.conf['extractor.snowflake_metadata.{}'.format(SnowflakeMetadataExtractor.CLUSTER_KEY)],
+                          self.conf[f'extractor.snowflake_metadata.{SnowflakeMetadataExtractor.CLUSTER_KEY}'],
                       'is_view': 'false'
                       }
 
@@ -128,7 +123,7 @@ class TestSnowflakeMetadataExtractor(unittest.TestCase):
                       'name': 'test_table3',
                       'description': 'test table 3',
                       'cluster':
-                      self.conf['extractor.snowflake_metadata.{}'.format(SnowflakeMetadataExtractor.CLUSTER_KEY)],
+                          self.conf[f'extractor.snowflake_metadata.{SnowflakeMetadataExtractor.CLUSTER_KEY}'],
                       'is_view': 'true'
                       }
 
@@ -189,8 +184,8 @@ class TestSnowflakeMetadataExtractor(unittest.TestCase):
             extractor.init(self.conf)
 
             expected = TableMetadata('snowflake',
-                                     self.conf['extractor.snowflake_metadata.{}'.format(
-                                         SnowflakeMetadataExtractor.CLUSTER_KEY)],
+                                     self.conf[
+                                         f'extractor.snowflake_metadata.{SnowflakeMetadataExtractor.CLUSTER_KEY}'],
                                      'test_schema1', 'test_table1', 'test table 1',
                                      [ColumnMetadata('col_id1', 'description of col_id1', 'number', 0),
                                       ColumnMetadata('col_id2', 'description of col_id2', 'number', 1),
@@ -202,16 +197,16 @@ class TestSnowflakeMetadataExtractor(unittest.TestCase):
             self.assertEqual(expected.__repr__(), extractor.extract().__repr__())
 
             expected = TableMetadata('snowflake',
-                                     self.conf['extractor.snowflake_metadata.{}'.format(
-                                         SnowflakeMetadataExtractor.CLUSTER_KEY)],
+                                     self.conf[
+                                         f'extractor.snowflake_metadata.{SnowflakeMetadataExtractor.CLUSTER_KEY}'],
                                      'test_schema1', 'test_table2', 'test table 2',
                                      [ColumnMetadata('col_name', 'description of col_name', 'varchar', 0),
                                       ColumnMetadata('col_name2', 'description of col_name2', 'varchar', 1)])
             self.assertEqual(expected.__repr__(), extractor.extract().__repr__())
 
             expected = TableMetadata('snowflake',
-                                     self.conf['extractor.snowflake_metadata.{}'.format(
-                                         SnowflakeMetadataExtractor.CLUSTER_KEY)],
+                                     self.conf[
+                                         f'extractor.snowflake_metadata.{SnowflakeMetadataExtractor.CLUSTER_KEY}'],
                                      'test_schema2', 'test_table3', 'test table 3',
                                      [ColumnMetadata('col_id3', 'description of col_id3', 'varchar', 0),
                                       ColumnMetadata('col_name3', 'description of col_name3',
@@ -238,7 +233,7 @@ class TestSnowflakeMetadataExtractorWithWhereClause(unittest.TestCase):
 
         config_dict = {
             SnowflakeMetadataExtractor.WHERE_CLAUSE_SUFFIX_KEY: self.where_clause_suffix,
-            'extractor.sqlalchemy.{}'.format(SQLAlchemyExtractor.CONN_STRING):
+            f'extractor.sqlalchemy.{SQLAlchemyExtractor.CONN_STRING}':
                 'TEST_CONNECTION'
         }
         self.conf = ConfigFactory.from_dict(config_dict)
@@ -261,7 +256,7 @@ class TestSnowflakeMetadataExtractorClusterKeyNoTableCatalog(unittest.TestCase):
 
         config_dict = {
             SnowflakeMetadataExtractor.CLUSTER_KEY: self.cluster_key,
-            'extractor.sqlalchemy.{}'.format(SQLAlchemyExtractor.CONN_STRING):
+            f'extractor.sqlalchemy.{SQLAlchemyExtractor.CONN_STRING}':
                 'TEST_CONNECTION',
             SnowflakeMetadataExtractor.USE_CATALOG_AS_CLUSTER_NAME: False
         }
@@ -285,7 +280,7 @@ class TestSnowflakeMetadataExtractorDefaultSnowflakeDatabaseKey(unittest.TestCas
 
         config_dict = {
             SnowflakeMetadataExtractor.SNOWFLAKE_DATABASE_KEY: self.snowflake_database_key,
-            'extractor.sqlalchemy.{}'.format(SQLAlchemyExtractor.CONN_STRING):
+            f'extractor.sqlalchemy.{SQLAlchemyExtractor.CONN_STRING}':
                 'TEST_CONNECTION'
         }
         self.conf = ConfigFactory.from_dict(config_dict)
@@ -308,7 +303,7 @@ class TestSnowflakeMetadataExtractorDefaultDatabaseKey(unittest.TestCase):
 
         config_dict = {
             SnowflakeMetadataExtractor.DATABASE_KEY: self.database_key,
-            'extractor.sqlalchemy.{}'.format(SQLAlchemyExtractor.CONN_STRING):
+            f'extractor.sqlalchemy.{SQLAlchemyExtractor.CONN_STRING}':
                 'TEST_CONNECTION'
         }
         self.conf = ConfigFactory.from_dict(config_dict)
@@ -359,7 +354,7 @@ class TestSnowflakeMetadataExtractorNoClusterKeyNoTableCatalog(unittest.TestCase
         logging.basicConfig(level=logging.INFO)
 
         config_dict = {
-            'extractor.sqlalchemy.{}'.format(SQLAlchemyExtractor.CONN_STRING):
+            f'extractor.sqlalchemy.{SQLAlchemyExtractor.CONN_STRING}':
                 'TEST_CONNECTION',
             SnowflakeMetadataExtractor.USE_CATALOG_AS_CLUSTER_NAME: False
         }
@@ -383,7 +378,7 @@ class TestSnowflakeMetadataExtractorTableCatalogEnabled(unittest.TestCase):
 
         config_dict = {
             SnowflakeMetadataExtractor.CLUSTER_KEY: self.cluster_key,
-            'extractor.sqlalchemy.{}'.format(SQLAlchemyExtractor.CONN_STRING):
+            f'extractor.sqlalchemy.{SQLAlchemyExtractor.CONN_STRING}':
                 'TEST_CONNECTION',
             SnowflakeMetadataExtractor.USE_CATALOG_AS_CLUSTER_NAME: True
         }

--- a/tests/unit/extractor/test_snowflake_metadata_extractor.py
+++ b/tests/unit/extractor/test_snowflake_metadata_extractor.py
@@ -5,12 +5,12 @@ import logging
 import unittest
 from typing import Any, Dict
 
-from mock import patch, MagicMock
+from mock import MagicMock, patch
 from pyhocon import ConfigFactory
 
 from databuilder.extractor.snowflake_metadata_extractor import SnowflakeMetadataExtractor
 from databuilder.extractor.sql_alchemy_extractor import SQLAlchemyExtractor
-from databuilder.models.table_metadata import TableMetadata, ColumnMetadata
+from databuilder.models.table_metadata import ColumnMetadata, TableMetadata
 
 
 class TestSnowflakeMetadataExtractor(unittest.TestCase):

--- a/tests/unit/extractor/test_snowflake_table_last_updated_extractor.py
+++ b/tests/unit/extractor/test_snowflake_table_last_updated_extractor.py
@@ -3,7 +3,7 @@
 
 import unittest
 
-from mock import patch, MagicMock
+from mock import MagicMock, patch
 from pyhocon import ConfigFactory
 
 from databuilder.extractor.snowflake_table_last_updated_extractor import SnowflakeTableLastUpdatedExtractor

--- a/tests/unit/extractor/test_snowflake_table_last_updated_extractor.py
+++ b/tests/unit/extractor/test_snowflake_table_last_updated_extractor.py
@@ -14,15 +14,13 @@ from databuilder.models.table_last_updated import TableLastUpdated
 class TestSnowflakeTableLastUpdatedExtractor(unittest.TestCase):
     def setUp(self) -> None:
         config_dict = {
-            'extractor.sqlalchemy.{}'.format(SQLAlchemyExtractor.CONN_STRING):
+            f'extractor.sqlalchemy.{SQLAlchemyExtractor.CONN_STRING}':
                 'TEST_CONNECTION',
-            'extractor.snowflake_table_last_updated.{}'.format(SnowflakeTableLastUpdatedExtractor.CLUSTER_KEY):
+            f'extractor.snowflake_table_last_updated.{SnowflakeTableLastUpdatedExtractor.CLUSTER_KEY}':
                 'MY_CLUSTER',
-            'extractor.snowflake_table_last_updated.{}'.format(
-                SnowflakeTableLastUpdatedExtractor.USE_CATALOG_AS_CLUSTER_NAME):
+            f'extractor.snowflake_table_last_updated.{SnowflakeTableLastUpdatedExtractor.USE_CATALOG_AS_CLUSTER_NAME}':
                 False,
-            'extractor.snowflake_table_last_updated.{}'.format(
-                SnowflakeTableLastUpdatedExtractor.SNOWFLAKE_DATABASE_KEY):
+            f'extractor.snowflake_table_last_updated.{SnowflakeTableLastUpdatedExtractor.SNOWFLAKE_DATABASE_KEY}':
                 'prod'
         }
         self.conf = ConfigFactory.from_dict(config_dict)
@@ -51,8 +49,8 @@ class TestSnowflakeTableLastUpdatedExtractor(unittest.TestCase):
                 {'schema': 'test_schema',
                  'table_name': 'test_table',
                  'last_updated_time': 1000,
-                 'cluster': self.conf['extractor.snowflake_table_last_updated.{}'.format(
-                     SnowflakeTableLastUpdatedExtractor.CLUSTER_KEY)],
+                 'cluster': self.conf[
+                     f'extractor.snowflake_table_last_updated.{SnowflakeTableLastUpdatedExtractor.CLUSTER_KEY}'],
                  }
             ]
 
@@ -76,8 +74,8 @@ class TestSnowflakeTableLastUpdatedExtractor(unittest.TestCase):
             sql_execute = MagicMock()
             connection.execute = sql_execute
 
-            default_cluster = self.conf['extractor.snowflake_table_last_updated.{}'.format(
-                SnowflakeTableLastUpdatedExtractor.CLUSTER_KEY)]
+            default_cluster = self.conf[
+                f'extractor.snowflake_table_last_updated.{SnowflakeTableLastUpdatedExtractor.CLUSTER_KEY}']
 
             table = {'schema': 'test_schema1',
                      'table_name': 'test_table1',
@@ -124,6 +122,7 @@ class TestSnowflakeTableLastUpdatedExtractorWithWhereClause(unittest.TestCase):
     """
     Test 'where_clause' config key in extractor
     """
+
     def setUp(self) -> None:
         self.where_clause_suffix = """
         where table_schema in ('public') and table_name = 'movies'
@@ -131,8 +130,7 @@ class TestSnowflakeTableLastUpdatedExtractorWithWhereClause(unittest.TestCase):
 
         config_dict = {
             SnowflakeTableLastUpdatedExtractor.WHERE_CLAUSE_SUFFIX_KEY: self.where_clause_suffix,
-            'extractor.sqlalchemy.{}'.format(SQLAlchemyExtractor.CONN_STRING):
-                'TEST_CONNECTION'
+            f'extractor.sqlalchemy.{SQLAlchemyExtractor.CONN_STRING}': 'TEST_CONNECTION'
         }
         self.conf = ConfigFactory.from_dict(config_dict)
 
@@ -150,12 +148,13 @@ class TestSnowflakeTableLastUpdatedExtractorClusterKeyNoTableCatalog(unittest.Te
     """
     Test with 'USE_CATALOG_AS_CLUSTER_NAME' is false and 'CLUSTER_KEY' is specified
     """
+
     def setUp(self) -> None:
         self.cluster_key = "not_master"
 
         config_dict = {
             SnowflakeTableLastUpdatedExtractor.CLUSTER_KEY: self.cluster_key,
-            'extractor.sqlalchemy.{}'.format(SQLAlchemyExtractor.CONN_STRING):
+            f'extractor.sqlalchemy.{SQLAlchemyExtractor.CONN_STRING}':
                 'TEST_CONNECTION',
             SnowflakeTableLastUpdatedExtractor.USE_CATALOG_AS_CLUSTER_NAME: False
         }
@@ -175,13 +174,13 @@ class TestSnowflakeTableLastUpdatedExtractorDefaultSnowflakeDatabaseKey(unittest
     """
     Test with SNOWFLAKE_DATABASE_KEY config specified
     """
+
     def setUp(self) -> None:
         self.snowflake_database_key = "not_prod"
 
         config_dict = {
             SnowflakeTableLastUpdatedExtractor.SNOWFLAKE_DATABASE_KEY: self.snowflake_database_key,
-            'extractor.sqlalchemy.{}'.format(SQLAlchemyExtractor.CONN_STRING):
-                'TEST_CONNECTION'
+            f'extractor.sqlalchemy.{SQLAlchemyExtractor.CONN_STRING}': 'TEST_CONNECTION'
         }
         self.conf = ConfigFactory.from_dict(config_dict)
 
@@ -199,13 +198,13 @@ class TestSnowflakeTableLastUpdatedExtractorDefaultDatabaseKey(unittest.TestCase
     """
     Test with DATABASE_KEY config specified
     """
+
     def setUp(self) -> None:
         self.database_key = 'not_snowflake'
 
         config_dict = {
             SnowflakeTableLastUpdatedExtractor.DATABASE_KEY: self.database_key,
-            'extractor.sqlalchemy.{}'.format(SQLAlchemyExtractor.CONN_STRING):
-                'TEST_CONNECTION'
+            f'extractor.sqlalchemy.{SQLAlchemyExtractor.CONN_STRING}': 'TEST_CONNECTION'
         }
         self.conf = ConfigFactory.from_dict(config_dict)
 
@@ -250,10 +249,10 @@ class TestSnowflakeTableLastUpdatedExtractorNoClusterKeyNoTableCatalog(unittest.
     """
     Test when USE_CATALOG_AS_CLUSTER_NAME is false and CLUSTER_KEY is NOT specified
     """
+
     def setUp(self) -> None:
         config_dict = {
-            'extractor.sqlalchemy.{}'.format(SQLAlchemyExtractor.CONN_STRING):
-                'TEST_CONNECTION',
+            f'extractor.sqlalchemy.{SQLAlchemyExtractor.CONN_STRING}': 'TEST_CONNECTION',
             SnowflakeTableLastUpdatedExtractor.USE_CATALOG_AS_CLUSTER_NAME: False
         }
         self.conf = ConfigFactory.from_dict(config_dict)
@@ -272,13 +271,13 @@ class TestSnowflakeTableLastUpdatedExtractorTableCatalogEnabled(unittest.TestCas
     """
     Test when USE_CATALOG_AS_CLUSTER_NAME is true (CLUSTER_KEY should be ignored)
     """
+
     def setUp(self) -> None:
         self.cluster_key = "not_master"
 
         config_dict = {
             SnowflakeTableLastUpdatedExtractor.CLUSTER_KEY: self.cluster_key,
-            'extractor.sqlalchemy.{}'.format(SQLAlchemyExtractor.CONN_STRING):
-                'TEST_CONNECTION',
+            f'extractor.sqlalchemy.{SQLAlchemyExtractor.CONN_STRING}': 'TEST_CONNECTION',
             SnowflakeTableLastUpdatedExtractor.USE_CATALOG_AS_CLUSTER_NAME: True
         }
         self.conf = ConfigFactory.from_dict(config_dict)

--- a/tests/unit/extractor/test_sql_alchemy_extractor.py
+++ b/tests/unit/extractor/test_sql_alchemy_extractor.py
@@ -2,10 +2,10 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import unittest
+from typing import Any
 
 from mock import patch
 from pyhocon import ConfigFactory
-from typing import Any
 
 from databuilder import Scoped
 from databuilder.extractor.sql_alchemy_extractor import SQLAlchemyExtractor

--- a/tests/unit/extractor/test_sql_server_metadata_extractor.py
+++ b/tests/unit/extractor/test_sql_server_metadata_extractor.py
@@ -5,12 +5,12 @@ import logging
 import unittest
 from typing import Any, Dict
 
-from mock import patch, MagicMock
+from mock import MagicMock, patch
 from pyhocon import ConfigFactory
 
 from databuilder.extractor.mssql_metadata_extractor import MSSQLMetadataExtractor
 from databuilder.extractor.sql_alchemy_extractor import SQLAlchemyExtractor
-from databuilder.models.table_metadata import TableMetadata, ColumnMetadata
+from databuilder.models.table_metadata import ColumnMetadata, TableMetadata
 
 
 class TestMSSQLMetadataExtractor(unittest.TestCase):

--- a/tests/unit/extractor/test_sql_server_metadata_extractor.py
+++ b/tests/unit/extractor/test_sql_server_metadata_extractor.py
@@ -3,10 +3,10 @@
 
 import logging
 import unittest
+from typing import Any, Dict
 
 from mock import patch, MagicMock
 from pyhocon import ConfigFactory
-from typing import Any, Dict
 
 from databuilder.extractor.mssql_metadata_extractor import MSSQLMetadataExtractor
 from databuilder.extractor.sql_alchemy_extractor import SQLAlchemyExtractor
@@ -18,14 +18,10 @@ class TestMSSQLMetadataExtractor(unittest.TestCase):
         logging.basicConfig(level=logging.INFO)
 
         config_dict = {
-            'extractor.sqlalchemy.{}'.format(SQLAlchemyExtractor.CONN_STRING):
-            'TEST_CONNECTION',
-            'extractor.mssql_metadata.{}'.format(MSSQLMetadataExtractor.CLUSTER_KEY):
-            'MY_CLUSTER',
-            'extractor.mssql_metadata.{}'.format(MSSQLMetadataExtractor.USE_CATALOG_AS_CLUSTER_NAME):
-            False,
-            'extractor.mssql_metadata.{}'.format(MSSQLMetadataExtractor.DATABASE_KEY):
-            'mssql'
+            f'extractor.sqlalchemy.{SQLAlchemyExtractor.CONN_STRING}': 'TEST_CONNECTION',
+            f'extractor.mssql_metadata.{MSSQLMetadataExtractor.CLUSTER_KEY}': 'MY_CLUSTER',
+            f'extractor.mssql_metadata.{MSSQLMetadataExtractor.USE_CATALOG_AS_CLUSTER_NAME}': False,
+            f'extractor.mssql_metadata.{MSSQLMetadataExtractor.DATABASE_KEY}': 'mssql'
         }
         self.conf = ConfigFactory.from_dict(config_dict)
 
@@ -50,7 +46,7 @@ class TestMSSQLMetadataExtractor(unittest.TestCase):
                      'name': 'test_table',
                      'description': 'a table for testing',
                      'cluster':
-                     self.conf['extractor.mssql_metadata.{}'.format(MSSQLMetadataExtractor.CLUSTER_KEY)]
+                         self.conf[f'extractor.mssql_metadata.{MSSQLMetadataExtractor.CLUSTER_KEY}']
                      }
 
             sql_execute.return_value = [
@@ -112,21 +108,21 @@ class TestMSSQLMetadataExtractor(unittest.TestCase):
                      'name': 'test_table1',
                      'description': 'test table 1',
                      'cluster':
-                     self.conf['extractor.mssql_metadata.{}'.format(MSSQLMetadataExtractor.CLUSTER_KEY)]
+                         self.conf[f'extractor.mssql_metadata.{MSSQLMetadataExtractor.CLUSTER_KEY}']
                      }
 
             table1 = {'schema_name': 'test_schema1',
                       'name': 'test_table2',
                       'description': 'test table 2',
                       'cluster':
-                      self.conf['extractor.mssql_metadata.{}'.format(MSSQLMetadataExtractor.CLUSTER_KEY)]
+                          self.conf[f'extractor.mssql_metadata.{MSSQLMetadataExtractor.CLUSTER_KEY}']
                       }
 
             table2 = {'schema_name': 'test_schema2',
                       'name': 'test_table3',
                       'description': 'test table 3',
                       'cluster':
-                      self.conf['extractor.mssql_metadata.{}'.format(MSSQLMetadataExtractor.CLUSTER_KEY)]
+                          self.conf[f'extractor.mssql_metadata.{MSSQLMetadataExtractor.CLUSTER_KEY}']
                       }
 
             sql_execute.return_value = [
@@ -187,8 +183,7 @@ class TestMSSQLMetadataExtractor(unittest.TestCase):
 
             expected = TableMetadata(
                 'mssql',
-                self.conf['extractor.mssql_metadata.{}'.format(
-                    MSSQLMetadataExtractor.CLUSTER_KEY)],
+                self.conf[f'extractor.mssql_metadata.{MSSQLMetadataExtractor.CLUSTER_KEY}'],
                 'test_schema1', 'test_table1', 'test table 1',
                 [ColumnMetadata('col_id1', 'description of col_id1', 'bigint', 0),
                  ColumnMetadata('col_id2', 'description of col_id2', 'bigint', 1),
@@ -206,8 +201,7 @@ class TestMSSQLMetadataExtractor(unittest.TestCase):
 
             expected = TableMetadata(
                 'mssql',
-                self.conf['extractor.mssql_metadata.{}'.format(
-                    MSSQLMetadataExtractor.CLUSTER_KEY)],
+                self.conf[f'extractor.mssql_metadata.{MSSQLMetadataExtractor.CLUSTER_KEY}'],
                 'test_schema1', 'test_table2', 'test table 2',
                 [ColumnMetadata('col_name', 'description of col_name', 'varchar', 0),
                  ColumnMetadata('col_name2', 'description of col_name2', 'varchar', 1)],
@@ -218,8 +212,7 @@ class TestMSSQLMetadataExtractor(unittest.TestCase):
 
             expected = TableMetadata(
                 'mssql',
-                self.conf['extractor.mssql_metadata.{}'.format(
-                    MSSQLMetadataExtractor.CLUSTER_KEY)],
+                self.conf[f'extractor.mssql_metadata.{MSSQLMetadataExtractor.CLUSTER_KEY}'],
                 'test_schema2', 'test_table3', 'test table 3',
                 [ColumnMetadata('col_id3', 'description of col_id3', 'varchar', 0),
                  ColumnMetadata('col_name3', 'description of col_name3',
@@ -247,8 +240,7 @@ class TestMSSQLMetadataExtractorWithWhereClause(unittest.TestCase):
 
         config_dict = {
             MSSQLMetadataExtractor.WHERE_CLAUSE_SUFFIX_KEY: self.where_clause_suffix,
-            'extractor.sqlalchemy.{}'.format(SQLAlchemyExtractor.CONN_STRING):
-                'TEST_CONNECTION'
+            f'extractor.sqlalchemy.{SQLAlchemyExtractor.CONN_STRING}': 'TEST_CONNECTION'
         }
         self.conf = ConfigFactory.from_dict(config_dict)
 
@@ -270,7 +262,7 @@ class TestMSSQLMetadataExtractorClusterKeyNoTableCatalog(unittest.TestCase):
 
         config_dict = {
             MSSQLMetadataExtractor.CLUSTER_KEY: self.cluster_key,
-            'extractor.sqlalchemy.{}'.format(SQLAlchemyExtractor.CONN_STRING):
+            f'extractor.sqlalchemy.{SQLAlchemyExtractor.CONN_STRING}':
                 'TEST_CONNECTION',
             MSSQLMetadataExtractor.USE_CATALOG_AS_CLUSTER_NAME: False
         }
@@ -292,8 +284,7 @@ class TestMSSQLMetadataExtractorNoClusterKeyNoTableCatalog(unittest.TestCase):
         logging.basicConfig(level=logging.INFO)
 
         config_dict = {
-            'extractor.sqlalchemy.{}'.format(SQLAlchemyExtractor.CONN_STRING):
-                'TEST_CONNECTION',
+            f'extractor.sqlalchemy.{SQLAlchemyExtractor.CONN_STRING}': 'TEST_CONNECTION',
             MSSQLMetadataExtractor.USE_CATALOG_AS_CLUSTER_NAME: False
         }
         self.conf = ConfigFactory.from_dict(config_dict)
@@ -316,8 +307,7 @@ class TestMSSQLMetadataExtractorTableCatalogEnabled(unittest.TestCase):
 
         config_dict = {
             MSSQLMetadataExtractor.CLUSTER_KEY: self.cluster_key,
-            'extractor.sqlalchemy.{}'.format(SQLAlchemyExtractor.CONN_STRING):
-                'TEST_CONNECTION',
+            f'extractor.sqlalchemy.{SQLAlchemyExtractor.CONN_STRING}': 'TEST_CONNECTION',
             MSSQLMetadataExtractor.USE_CATALOG_AS_CLUSTER_NAME: True
         }
         self.conf = ConfigFactory.from_dict(config_dict)

--- a/tests/unit/extractor/user/bamboohr/test_bamboohr_user_extractor.py
+++ b/tests/unit/extractor/user/bamboohr/test_bamboohr_user_extractor.py
@@ -2,15 +2,14 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import io
-import unittest
-
 import os
+import unittest
 
 import responses
 from pyhocon import ConfigFactory
 
-from databuilder.models.user import User
 from databuilder.extractor.user.bamboohr.bamboohr_user_extractor import BamboohrUserExtractor
+from databuilder.models.user import User
 
 
 class TestBamboohrUserExtractor(unittest.TestCase):

--- a/tests/unit/loader/test_file_system_csv_loader.py
+++ b/tests/unit/loader/test_file_system_csv_loader.py
@@ -17,7 +17,7 @@ class TestFileSystemCSVLoader(unittest.TestCase):
 
     def setUp(self) -> None:
         self.temp_dir_path = tempfile.mkdtemp()
-        self.dest_file_name = '{}/test_file.csv'.format(self.temp_dir_path)
+        self.dest_file_name = f'{self.temp_dir_path}/test_file.csv'
         self.file_mode = 'w'
         config_dict = {'loader.filesystem.csv.file_path': self.dest_file_name,
                        'loader.filesystem.csv.mode': self.file_mode}

--- a/tests/unit/loader/test_file_system_csv_loader.py
+++ b/tests/unit/loader/test_file_system_csv_loader.py
@@ -4,9 +4,9 @@
 import shutil
 import tempfile
 import unittest
+from typing import List
 
 from pyhocon import ConfigFactory
-from typing import List
 
 from databuilder import Scoped
 from databuilder.loader.file_system_csv_loader import FileSystemCSVLoader

--- a/tests/unit/loader/test_file_system_elasticsearch_json_loader.py
+++ b/tests/unit/loader/test_file_system_elasticsearch_json_loader.py
@@ -18,7 +18,7 @@ class TestFSElasticsearchJSONLoader(unittest.TestCase):
 
     def setUp(self) -> None:
         self.temp_dir_path = tempfile.mkdtemp()
-        self.dest_file_name = '{}/test_file.json'.format(self.temp_dir_path)
+        self.dest_file_name = f'{self.temp_dir_path}/test_file.json'
         self.file_mode = 'w'
         config_dict = {'loader.filesystem.elasticsearch.file_path': self.dest_file_name,
                        'loader.filesystem.elasticsearch.mode': self.file_mode}

--- a/tests/unit/loader/test_file_system_elasticsearch_json_loader.py
+++ b/tests/unit/loader/test_file_system_elasticsearch_json_loader.py
@@ -5,9 +5,9 @@ import json
 import shutil
 import tempfile
 import unittest
+from typing import List
 
 from pyhocon import ConfigFactory
-from typing import List
 
 from databuilder import Scoped
 from databuilder.loader.file_system_elasticsearch_json_loader import FSElasticsearchJSONLoader

--- a/tests/unit/loader/test_fs_neo4j_csv_loader.py
+++ b/tests/unit/loader/test_fs_neo4j_csv_loader.py
@@ -6,17 +6,19 @@ import csv
 import logging
 import os
 import unittest
+from operator import itemgetter
 from os import listdir
 from os.path import isfile, join
-
-from pyhocon import ConfigFactory, ConfigTree
 from typing import Dict, Iterable, Any, Callable, Optional, Union
 
-from databuilder.models.graph_serializable import GraphSerializable, GraphNode, GraphRelationship
+from pyhocon import ConfigFactory, ConfigTree
+
 from databuilder.job.base_job import Job
 from databuilder.loader.file_system_neo4j_csv_loader import FsNeo4jCSVLoader
+from databuilder.models.graph_serializable import GraphSerializable, GraphNode, GraphRelationship
 from tests.unit.models.test_graph_serializable import Movie, Actor, City
-from operator import itemgetter
+
+here = os.path.dirname(__file__)
 
 
 class TestFsNeo4jCSVLoader(unittest.TestCase):
@@ -40,16 +42,13 @@ class TestFsNeo4jCSVLoader(unittest.TestCase):
         loader.load(movie)
         loader.close()
 
-        expected_node_path = '{}/../resources/fs_neo4j_csv_loader/{}/nodes'\
-            .format(os.path.join(os.path.dirname(__file__)), folder)
+        expected_node_path = os.path.join(here, f'../resources/fs_neo4j_csv_loader/{folder}/nodes')
         expected_nodes = self._get_csv_rows(expected_node_path, itemgetter('KEY'))
         actual_nodes = self._get_csv_rows(conf.get_string(FsNeo4jCSVLoader.NODE_DIR_PATH),
                                           itemgetter('KEY'))
         self.assertEqual(expected_nodes, actual_nodes)
 
-        expected_rel_path = \
-            '{}/../resources/fs_neo4j_csv_loader/{}/relationships' \
-            .format(os.path.join(os.path.dirname(__file__)), folder)
+        expected_rel_path = os.path.join(here, f'../resources/fs_neo4j_csv_loader/{folder}/relationships')
         expected_relations = self._get_csv_rows(expected_rel_path, itemgetter('START_KEY', 'END_KEY'))
         actual_relations = self._get_csv_rows(conf.get_string(FsNeo4jCSVLoader.RELATION_DIR_PATH),
                                               itemgetter('START_KEY', 'END_KEY'))
@@ -71,8 +70,7 @@ class TestFsNeo4jCSVLoader(unittest.TestCase):
         loader.load(people[1])
         loader.close()
 
-        expected_node_path = '{}/../resources/fs_neo4j_csv_loader/{}/nodes'\
-            .format(os.path.join(os.path.dirname(__file__)), folder)
+        expected_node_path = os.path.join(here, f'../resources/fs_neo4j_csv_loader/{folder}/nodes')
         expected_nodes = self._get_csv_rows(expected_node_path, itemgetter('KEY'))
         actual_nodes = self._get_csv_rows(conf.get_string(FsNeo4jCSVLoader.NODE_DIR_PATH),
                                           itemgetter('KEY'))
@@ -81,11 +79,11 @@ class TestFsNeo4jCSVLoader(unittest.TestCase):
     def _make_conf(self, test_name: str) -> ConfigTree:
         prefix = '/var/tmp/TestFsNeo4jCSVLoader'
 
-        return ConfigFactory.from_dict(
-            {FsNeo4jCSVLoader.NODE_DIR_PATH: '{}/{}/{}'.format(prefix, test_name, 'nodes'),
-             FsNeo4jCSVLoader.RELATION_DIR_PATH: '{}/{}/{}'
-             .format(prefix, test_name, 'relationships'),
-             FsNeo4jCSVLoader.SHOULD_DELETE_CREATED_DIR: True})
+        return ConfigFactory.from_dict({
+            FsNeo4jCSVLoader.NODE_DIR_PATH: f'{prefix}/{test_name}/{"nodes"}',
+            FsNeo4jCSVLoader.RELATION_DIR_PATH: f'{prefix}/{test_name}/{"relationships"}',
+            FsNeo4jCSVLoader.SHOULD_DELETE_CREATED_DIR: True
+        })
 
     def _get_csv_rows(self,
                       path: str,

--- a/tests/unit/loader/test_fs_neo4j_csv_loader.py
+++ b/tests/unit/loader/test_fs_neo4j_csv_loader.py
@@ -9,14 +9,20 @@ import unittest
 from operator import itemgetter
 from os import listdir
 from os.path import isfile, join
-from typing import Dict, Iterable, Any, Callable, Optional, Union
+from typing import (
+    Any, Callable, Dict, Iterable, Optional, Union,
+)
 
 from pyhocon import ConfigFactory, ConfigTree
 
 from databuilder.job.base_job import Job
 from databuilder.loader.file_system_neo4j_csv_loader import FsNeo4jCSVLoader
-from databuilder.models.graph_serializable import GraphSerializable, GraphNode, GraphRelationship
-from tests.unit.models.test_graph_serializable import Movie, Actor, City
+from databuilder.models.graph_serializable import (
+    GraphNode, GraphRelationship, GraphSerializable,
+)
+from tests.unit.models.test_graph_serializable import (
+    Actor, City, Movie,
+)
 
 here = os.path.dirname(__file__)
 

--- a/tests/unit/loader/test_generic_loader.py
+++ b/tests/unit/loader/test_generic_loader.py
@@ -6,7 +6,7 @@ import unittest
 from mock import MagicMock
 from pyhocon import ConfigFactory
 
-from databuilder.loader.generic_loader import GenericLoader, CALLBACK_FUNCTION
+from databuilder.loader.generic_loader import CALLBACK_FUNCTION, GenericLoader
 
 
 class TestGenericLoader(unittest.TestCase):

--- a/tests/unit/models/dashboard/test_dashboard_chart.py
+++ b/tests/unit/models/dashboard/test_dashboard_chart.py
@@ -2,12 +2,13 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import unittest
-
 from typing import Any, Dict
 
 from databuilder.models.dashboard.dashboard_chart import DashboardChart
-from databuilder.models.graph_serializable import RELATION_START_KEY, RELATION_START_LABEL, RELATION_END_KEY, \
-    RELATION_END_LABEL, RELATION_TYPE, RELATION_REVERSE_TYPE
+from databuilder.models.graph_serializable import (
+    RELATION_END_KEY, RELATION_END_LABEL, RELATION_REVERSE_TYPE, RELATION_START_KEY, RELATION_START_LABEL,
+    RELATION_TYPE,
+)
 from databuilder.serializers import neo4_serializer
 
 

--- a/tests/unit/models/dashboard/test_dashboard_last_modified.py
+++ b/tests/unit/models/dashboard/test_dashboard_last_modified.py
@@ -2,12 +2,13 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import unittest
-
 from typing import Any, Dict
 
 from databuilder.models.dashboard.dashboard_last_modified import DashboardLastModifiedTimestamp
-from databuilder.models.graph_serializable import RELATION_START_KEY, RELATION_START_LABEL, RELATION_END_KEY, \
-    RELATION_END_LABEL, RELATION_TYPE, RELATION_REVERSE_TYPE
+from databuilder.models.graph_serializable import (
+    RELATION_END_KEY, RELATION_END_LABEL, RELATION_REVERSE_TYPE, RELATION_START_KEY, RELATION_START_LABEL,
+    RELATION_TYPE,
+)
 from databuilder.serializers import neo4_serializer
 
 

--- a/tests/unit/models/dashboard/test_dashboard_owner.py
+++ b/tests/unit/models/dashboard/test_dashboard_owner.py
@@ -4,8 +4,10 @@
 import unittest
 
 from databuilder.models.dashboard.dashboard_owner import DashboardOwner
-from databuilder.models.graph_serializable import RELATION_START_KEY, RELATION_START_LABEL, RELATION_END_KEY, \
-    RELATION_END_LABEL, RELATION_TYPE, RELATION_REVERSE_TYPE
+from databuilder.models.graph_serializable import (
+    RELATION_END_KEY, RELATION_END_LABEL, RELATION_REVERSE_TYPE, RELATION_START_KEY, RELATION_START_LABEL,
+    RELATION_TYPE,
+)
 from databuilder.serializers import neo4_serializer
 
 

--- a/tests/unit/models/dashboard/test_dashboard_query.py
+++ b/tests/unit/models/dashboard/test_dashboard_query.py
@@ -4,9 +4,10 @@
 import unittest
 
 from databuilder.models.dashboard.dashboard_query import DashboardQuery
-from databuilder.models.graph_serializable import NODE_KEY, \
-    NODE_LABEL, RELATION_START_KEY, RELATION_START_LABEL, RELATION_END_KEY, \
-    RELATION_END_LABEL, RELATION_TYPE, RELATION_REVERSE_TYPE
+from databuilder.models.graph_serializable import (
+    NODE_KEY, NODE_LABEL, RELATION_END_KEY, RELATION_END_LABEL, RELATION_REVERSE_TYPE, RELATION_START_KEY,
+    RELATION_START_LABEL, RELATION_TYPE,
+)
 from databuilder.serializers import neo4_serializer
 
 

--- a/tests/unit/models/dashboard/test_dashboard_table.py
+++ b/tests/unit/models/dashboard/test_dashboard_table.py
@@ -4,8 +4,10 @@
 import unittest
 
 from databuilder.models.dashboard.dashboard_table import DashboardTable
-from databuilder.models.graph_serializable import RELATION_START_KEY, RELATION_START_LABEL, RELATION_END_KEY, \
-    RELATION_END_LABEL, RELATION_TYPE, RELATION_REVERSE_TYPE
+from databuilder.models.graph_serializable import (
+    RELATION_END_KEY, RELATION_END_LABEL, RELATION_REVERSE_TYPE, RELATION_START_KEY, RELATION_START_LABEL,
+    RELATION_TYPE,
+)
 from databuilder.serializers import neo4_serializer
 
 

--- a/tests/unit/models/dashboard/test_dashboard_usage.py
+++ b/tests/unit/models/dashboard/test_dashboard_usage.py
@@ -2,12 +2,13 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import unittest
-
 from typing import Any, Dict
 
 from databuilder.models.dashboard.dashboard_usage import DashboardUsage
-from databuilder.models.graph_serializable import RELATION_START_KEY, RELATION_START_LABEL, RELATION_END_KEY, \
-    RELATION_END_LABEL, RELATION_TYPE, RELATION_REVERSE_TYPE
+from databuilder.models.graph_serializable import (
+    RELATION_END_KEY, RELATION_END_LABEL, RELATION_REVERSE_TYPE, RELATION_START_KEY, RELATION_START_LABEL,
+    RELATION_TYPE,
+)
 from databuilder.serializers import neo4_serializer
 
 

--- a/tests/unit/models/test_application.py
+++ b/tests/unit/models/test_application.py
@@ -2,12 +2,12 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import unittest
+
 from databuilder.models.application import Application
-
-from databuilder.models.graph_serializable import NODE_KEY, \
-    NODE_LABEL, RELATION_START_KEY, RELATION_START_LABEL, RELATION_END_KEY, \
-    RELATION_END_LABEL, RELATION_TYPE, RELATION_REVERSE_TYPE
-
+from databuilder.models.graph_serializable import (
+    NODE_KEY, NODE_LABEL, RELATION_END_KEY, RELATION_END_LABEL, RELATION_REVERSE_TYPE, RELATION_START_KEY,
+    RELATION_START_LABEL, RELATION_TYPE,
+)
 from databuilder.models.table_metadata import TableMetadata
 from databuilder.serializers import neo4_serializer
 

--- a/tests/unit/models/test_badge.py
+++ b/tests/unit/models/test_badge.py
@@ -2,10 +2,13 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import unittest
+
 from databuilder.models.badge import Badge, BadgeMetadata
+from databuilder.models.graph_serializable import (
+    NODE_KEY, NODE_LABEL, RELATION_END_KEY, RELATION_END_LABEL, RELATION_REVERSE_TYPE, RELATION_START_KEY,
+    RELATION_START_LABEL, RELATION_TYPE,
+)
 from databuilder.serializers import neo4_serializer
-from databuilder.models.graph_serializable import RELATION_START_KEY, RELATION_START_LABEL, RELATION_END_KEY, \
-    RELATION_END_LABEL, RELATION_TYPE, RELATION_REVERSE_TYPE, NODE_KEY, NODE_LABEL
 
 db = 'hive'
 SCHEMA = 'BASE'

--- a/tests/unit/models/test_graph_serializable.py
+++ b/tests/unit/models/test_graph_serializable.py
@@ -2,12 +2,11 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import unittest
+from typing import Iterable, Union
 
-from typing import Union, Iterable
-
-from databuilder.models.graph_serializable import GraphSerializable
-from databuilder.models.graph_relationship import GraphRelationship
 from databuilder.models.graph_node import GraphNode
+from databuilder.models.graph_relationship import GraphRelationship
+from databuilder.models.graph_serializable import GraphSerializable
 from databuilder.serializers import neo4_serializer
 
 

--- a/tests/unit/models/test_neo4j_es_last_updated.py
+++ b/tests/unit/models/test_neo4j_es_last_updated.py
@@ -2,10 +2,9 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import unittest
-from databuilder.models.neo4j_es_last_updated import Neo4jESLastUpdated
 
-from databuilder.models.graph_serializable import NODE_KEY, \
-    NODE_LABEL
+from databuilder.models.graph_serializable import NODE_KEY, NODE_LABEL
+from databuilder.models.neo4j_es_last_updated import Neo4jESLastUpdated
 from databuilder.serializers import neo4_serializer
 
 

--- a/tests/unit/models/test_table_column_usage.py
+++ b/tests/unit/models/test_table_column_usage.py
@@ -2,9 +2,9 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import unittest
+from typing import no_type_check
 
 from databuilder.models.table_column_usage import ColumnReader, TableColumnUsage
-from typing import no_type_check
 from databuilder.serializers import neo4_serializer
 
 

--- a/tests/unit/models/test_table_last_updated.py
+++ b/tests/unit/models/test_table_last_updated.py
@@ -3,9 +3,10 @@
 
 import unittest
 
-from databuilder.models.graph_serializable import NODE_KEY, \
-    NODE_LABEL, RELATION_START_KEY, RELATION_START_LABEL, RELATION_END_KEY, \
-    RELATION_END_LABEL, RELATION_TYPE, RELATION_REVERSE_TYPE
+from databuilder.models.graph_serializable import (
+    NODE_KEY, NODE_LABEL, RELATION_END_KEY, RELATION_END_LABEL, RELATION_REVERSE_TYPE, RELATION_START_KEY,
+    RELATION_START_LABEL, RELATION_TYPE,
+)
 from databuilder.models.table_last_updated import TableLastUpdated
 from databuilder.models.timestamp import timestamp_constants
 from databuilder.serializers import neo4_serializer

--- a/tests/unit/models/test_table_lineage.py
+++ b/tests/unit/models/test_table_lineage.py
@@ -3,8 +3,10 @@
 
 import unittest
 
-from databuilder.models.graph_serializable import RELATION_START_KEY, RELATION_START_LABEL, RELATION_END_KEY, \
-    RELATION_END_LABEL, RELATION_TYPE, RELATION_REVERSE_TYPE
+from databuilder.models.graph_serializable import (
+    RELATION_END_KEY, RELATION_END_LABEL, RELATION_REVERSE_TYPE, RELATION_START_KEY, RELATION_START_LABEL,
+    RELATION_TYPE,
+)
 from databuilder.models.table_lineage import TableLineage
 from databuilder.serializers import neo4_serializer
 

--- a/tests/unit/models/test_table_lineage.py
+++ b/tests/unit/models/test_table_lineage.py
@@ -3,11 +3,10 @@
 
 import unittest
 
-from databuilder.models.table_lineage import TableLineage
 from databuilder.models.graph_serializable import RELATION_START_KEY, RELATION_START_LABEL, RELATION_END_KEY, \
     RELATION_END_LABEL, RELATION_TYPE, RELATION_REVERSE_TYPE
+from databuilder.models.table_lineage import TableLineage
 from databuilder.serializers import neo4_serializer
-
 
 DB = 'hive'
 SCHEMA = 'base'
@@ -41,14 +40,8 @@ class TestTableLineage(unittest.TestCase):
         relations = self.table_lineage.create_relation()
         self.assertEqual(len(relations), 2)
 
-        start_key = '{db}://{cluster}.{schema}/{tbl}'.format(db=DB,
-                                                             schema=SCHEMA,
-                                                             tbl=TABLE,
-                                                             cluster=CLUSTER)
-        end_key1 = '{db}://{cluster}.{schema}/{tbl}'.format(db=DB,
-                                                            schema='test_schema',
-                                                            tbl='test_table1',
-                                                            cluster=CLUSTER)
+        start_key = f'{DB}://{CLUSTER}.{SCHEMA}/{TABLE}'
+        end_key1 = f'{DB}://{CLUSTER}.test_schema/test_table1'
 
         relation = {
             RELATION_START_KEY: start_key,

--- a/tests/unit/models/test_table_owner.py
+++ b/tests/unit/models/test_table_owner.py
@@ -2,15 +2,14 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import unittest
-from databuilder.models.user import User
+
+from databuilder.models.graph_serializable import (
+    NODE_KEY, NODE_LABEL, RELATION_END_KEY, RELATION_END_LABEL, RELATION_REVERSE_TYPE, RELATION_START_KEY,
+    RELATION_START_LABEL, RELATION_TYPE,
+)
 from databuilder.models.table_owner import TableOwner
-
-
-from databuilder.models.graph_serializable import NODE_KEY, NODE_LABEL, \
-    RELATION_START_KEY, RELATION_START_LABEL, RELATION_END_KEY, \
-    RELATION_END_LABEL, RELATION_TYPE, RELATION_REVERSE_TYPE
+from databuilder.models.user import User
 from databuilder.serializers import neo4_serializer
-
 
 db = 'hive'
 SCHEMA = 'BASE'

--- a/tests/unit/models/test_table_source.py
+++ b/tests/unit/models/test_table_source.py
@@ -28,11 +28,7 @@ class TestTableSource(unittest.TestCase):
 
     def test_get_source_model_key(self) -> None:
         source = self.table_source.get_source_model_key()
-        self.assertEqual(source, '{db}://{cluster}.{schema}/{tbl}/_source'.format(db=DB,
-                                                                                  schema=SCHEMA,
-                                                                                  tbl=TABLE,
-                                                                                  cluster=CLUSTER,
-                                                                                  ))
+        self.assertEqual(source, f'{DB}://{CLUSTER}.{SCHEMA}/{TABLE}/_source')
 
     def test_get_metadata_model_key(self) -> None:
         metadata = self.table_source.get_metadata_model_key()
@@ -47,14 +43,8 @@ class TestTableSource(unittest.TestCase):
         self.assertEquals(len(relations), 1)
         serialized_relation = neo4_serializer.serialize_relationship(relations[0])
 
-        start_key = '{db}://{cluster}.{schema}/{tbl}/_source'.format(db=DB,
-                                                                     schema=SCHEMA,
-                                                                     tbl=TABLE,
-                                                                     cluster=CLUSTER)
-        end_key = '{db}://{cluster}.{schema}/{tbl}'.format(db=DB,
-                                                           schema=SCHEMA,
-                                                           tbl=TABLE,
-                                                           cluster=CLUSTER)
+        start_key = f'{DB}://{CLUSTER}.{SCHEMA}/{TABLE}/_source'
+        end_key = f'{DB}://{CLUSTER}.{SCHEMA}/{TABLE}'
 
         expected_relation = {
             RELATION_START_KEY: start_key,

--- a/tests/unit/models/test_table_source.py
+++ b/tests/unit/models/test_table_source.py
@@ -3,11 +3,12 @@
 
 import unittest
 
+from databuilder.models.graph_serializable import (
+    RELATION_END_KEY, RELATION_END_LABEL, RELATION_REVERSE_TYPE, RELATION_START_KEY, RELATION_START_LABEL,
+    RELATION_TYPE,
+)
 from databuilder.models.table_source import TableSource
-from databuilder.models.graph_serializable import RELATION_START_KEY, RELATION_START_LABEL, RELATION_END_KEY, \
-    RELATION_END_LABEL, RELATION_TYPE, RELATION_REVERSE_TYPE
 from databuilder.serializers import neo4_serializer
-
 
 DB = 'hive'
 SCHEMA = 'base'

--- a/tests/unit/models/test_table_stats.py
+++ b/tests/unit/models/test_table_stats.py
@@ -2,11 +2,12 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import unittest
-from databuilder.models.table_stats import TableColumnStats
 
-from databuilder.models.graph_serializable import NODE_KEY, \
-    NODE_LABEL, RELATION_START_KEY, RELATION_START_LABEL, RELATION_END_KEY, \
-    RELATION_END_LABEL, RELATION_TYPE, RELATION_REVERSE_TYPE
+from databuilder.models.graph_serializable import (
+    NODE_KEY, NODE_LABEL, RELATION_END_KEY, RELATION_END_LABEL, RELATION_REVERSE_TYPE, RELATION_START_KEY,
+    RELATION_START_LABEL, RELATION_TYPE,
+)
+from databuilder.models.table_stats import TableColumnStats
 from databuilder.serializers import neo4_serializer
 
 

--- a/tests/unit/models/test_user.py
+++ b/tests/unit/models/test_user.py
@@ -28,7 +28,7 @@ class TestUser(unittest.TestCase):
 
     def test_get_user_model_key(self) -> None:
         user_email = User.get_user_model_key(email=self.user.email)
-        self.assertEqual(user_email, '{email}'.format(email='test@email.com'))
+        self.assertEqual(user_email, 'test@email.com')
 
     def test_create_nodes(self) -> None:
         nodes = self.user.create_nodes()
@@ -58,8 +58,8 @@ class TestUser(unittest.TestCase):
         relations = self.user.create_relation()
         self.assertEqual(len(relations), 1)
 
-        start_key = '{email}'.format(email='test@email.com')
-        end_key = '{email}'.format(email='test_manager@email.com')
+        start_key = 'test@email.com'
+        end_key = 'test_manager@email.com'
 
         expected_relation = {
             RELATION_START_KEY: start_key,

--- a/tests/unit/models/test_user.py
+++ b/tests/unit/models/test_user.py
@@ -3,8 +3,10 @@
 
 import unittest
 
-from databuilder.models.graph_serializable import RELATION_START_KEY, RELATION_START_LABEL, RELATION_END_KEY, \
-    RELATION_END_LABEL, RELATION_TYPE, RELATION_REVERSE_TYPE
+from databuilder.models.graph_serializable import (
+    RELATION_END_KEY, RELATION_END_LABEL, RELATION_REVERSE_TYPE, RELATION_START_KEY, RELATION_START_LABEL,
+    RELATION_TYPE,
+)
 from databuilder.models.user import User
 from databuilder.serializers import neo4_serializer
 

--- a/tests/unit/models/test_watermark.py
+++ b/tests/unit/models/test_watermark.py
@@ -2,8 +2,9 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import unittest
-from databuilder.models.watermark import Watermark
 
+from databuilder.models.graph_node import GraphNode
+from databuilder.models.graph_relationship import GraphRelationship
 from databuilder.models.graph_serializable import (
     NODE_KEY,
     NODE_LABEL,
@@ -14,8 +15,7 @@ from databuilder.models.graph_serializable import (
     RELATION_TYPE,
     RELATION_REVERSE_TYPE
 )
-from databuilder.models.graph_node import GraphNode
-from databuilder.models.graph_relationship import GraphRelationship
+from databuilder.models.watermark import Watermark
 from databuilder.serializers import neo4_serializer
 
 CREATE_TIME = '2017-09-18T00:00:00'
@@ -40,19 +40,8 @@ class TestWatermark(unittest.TestCase):
             part_type=PART_TYPE,
             part_name=NESTED_PART
         )
-        start_key = '{database}://{cluster}.{schema}/{table}/{part_type}/'.format(
-            database=DATABASE,
-            cluster=CLUSTER,
-            schema=SCHEMA,
-            table=TABLE,
-            part_type=PART_TYPE
-        )
-        end_key = '{database}://{cluster}.{schema}/{table}'.format(
-            database=DATABASE,
-            cluster=CLUSTER,
-            schema=SCHEMA,
-            table=TABLE
-        )
+        start_key = f'{DATABASE}://{CLUSTER}.{SCHEMA}/{TABLE}/{PART_TYPE}/'
+        end_key = f'{DATABASE}://{CLUSTER}.{SCHEMA}/{TABLE}'
         self.expected_node_result = GraphNode(
             key=start_key,
             label='Watermark',
@@ -92,21 +81,11 @@ class TestWatermark(unittest.TestCase):
 
     def test_get_watermark_model_key(self) -> None:
         watermark = self.watermark.get_watermark_model_key()
-        self.assertEqual(
-            watermark, '{database}://{cluster}.{schema}/{table}/{part_type}/'
-            .format(database=DATABASE,
-                    cluster=CLUSTER,
-                    schema=SCHEMA,
-                    table=TABLE,
-                    part_type=PART_TYPE))
+        self.assertEqual(watermark, f'{DATABASE}://{CLUSTER}.{SCHEMA}/{TABLE}/{PART_TYPE}/')
 
     def test_get_metadata_model_key(self) -> None:
         metadata = self.watermark.get_metadata_model_key()
-        self.assertEqual(metadata, '{database}://{cluster}.{schema}/{table}'
-                         .format(database=DATABASE,
-                                 cluster=CLUSTER,
-                                 schema=SCHEMA,
-                                 table=TABLE))
+        self.assertEqual(metadata, f'{DATABASE}://{CLUSTER}.{SCHEMA}/{TABLE}')
 
     def test_create_nodes(self) -> None:
         nodes = self.watermark.create_nodes()

--- a/tests/unit/models/test_watermark.py
+++ b/tests/unit/models/test_watermark.py
@@ -6,14 +6,8 @@ import unittest
 from databuilder.models.graph_node import GraphNode
 from databuilder.models.graph_relationship import GraphRelationship
 from databuilder.models.graph_serializable import (
-    NODE_KEY,
-    NODE_LABEL,
-    RELATION_START_KEY,
-    RELATION_START_LABEL,
-    RELATION_END_KEY,
-    RELATION_END_LABEL,
-    RELATION_TYPE,
-    RELATION_REVERSE_TYPE
+    NODE_KEY, NODE_LABEL, RELATION_END_KEY, RELATION_END_LABEL, RELATION_REVERSE_TYPE, RELATION_START_KEY,
+    RELATION_START_LABEL, RELATION_TYPE,
 )
 from databuilder.models.watermark import Watermark
 from databuilder.serializers import neo4_serializer

--- a/tests/unit/publisher/test_elasticsearch_publisher.py
+++ b/tests/unit/publisher/test_elasticsearch_publisher.py
@@ -2,9 +2,11 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import json
-from mock import MagicMock, mock_open, patch
 import unittest
 
+from mock import (
+    MagicMock, mock_open, patch,
+)
 from pyhocon import ConfigFactory
 
 from databuilder import Scoped

--- a/tests/unit/publisher/test_neo4j_csv_publisher.py
+++ b/tests/unit/publisher/test_neo4j_csv_publisher.py
@@ -13,13 +13,14 @@ from pyhocon import ConfigFactory
 from databuilder.publisher import neo4j_csv_publisher
 from databuilder.publisher.neo4j_csv_publisher import Neo4jCsvPublisher
 
+here = os.path.dirname(__file__)
+
 
 class TestPublish(unittest.TestCase):
 
     def setUp(self) -> None:
         logging.basicConfig(level=logging.INFO)
-        self._resource_path = '{}/../resources/csv_publisher' \
-            .format(os.path.join(os.path.dirname(__file__)))
+        self._resource_path = os.path.join(here, f'../resources/csv_publisher')
 
     def test_publisher(self) -> None:
         with patch.object(GraphDatabase, 'driver') as mock_driver:
@@ -38,11 +39,11 @@ class TestPublish(unittest.TestCase):
 
             conf = ConfigFactory.from_dict(
                 {neo4j_csv_publisher.NEO4J_END_POINT_KEY: 'dummy://999.999.999.999:7687/',
-                 neo4j_csv_publisher.NODE_FILES_DIR: '{}/nodes'.format(self._resource_path),
-                 neo4j_csv_publisher.RELATION_FILES_DIR: '{}/relations'.format(self._resource_path),
+                 neo4j_csv_publisher.NODE_FILES_DIR: f'{self._resource_path}/nodes',
+                 neo4j_csv_publisher.RELATION_FILES_DIR: f'{self._resource_path}/relations',
                  neo4j_csv_publisher.NEO4J_USER: 'neo4j_user',
                  neo4j_csv_publisher.NEO4J_PASSWORD: 'neo4j_password',
-                 neo4j_csv_publisher.JOB_PUBLISH_TAG: '{}'.format(uuid.uuid4())}
+                 neo4j_csv_publisher.JOB_PUBLISH_TAG: str(uuid.uuid4())}
             )
             publisher.init(conf)
             publisher.publish()
@@ -73,12 +74,12 @@ class TestPublish(unittest.TestCase):
 
             conf = ConfigFactory.from_dict(
                 {neo4j_csv_publisher.NEO4J_END_POINT_KEY: 'dummy://999.999.999.999:7687/',
-                 neo4j_csv_publisher.NODE_FILES_DIR: '{}/nodes'.format(self._resource_path),
-                 neo4j_csv_publisher.RELATION_FILES_DIR: '{}/relations'.format(self._resource_path),
+                 neo4j_csv_publisher.NODE_FILES_DIR: f'{self._resource_path}/nodes',
+                 neo4j_csv_publisher.RELATION_FILES_DIR: f'{self._resource_path}/relations',
                  neo4j_csv_publisher.RELATION_PREPROCESSOR: mock_preprocessor,
                  neo4j_csv_publisher.NEO4J_USER: 'neo4j_user',
                  neo4j_csv_publisher.NEO4J_PASSWORD: 'neo4j_password',
-                 neo4j_csv_publisher.JOB_PUBLISH_TAG: '{}'.format(uuid.uuid4())}
+                 neo4j_csv_publisher.JOB_PUBLISH_TAG: str(uuid.uuid4())}
             )
             publisher.init(conf)
             publisher.publish()

--- a/tests/unit/publisher/test_neo4j_csv_publisher.py
+++ b/tests/unit/publisher/test_neo4j_csv_publisher.py
@@ -6,7 +6,7 @@ import os
 import unittest
 import uuid
 
-from mock import patch, MagicMock
+from mock import MagicMock, patch
 from neo4j import GraphDatabase
 from pyhocon import ConfigFactory
 

--- a/tests/unit/publisher/test_neo4j_preprocessor.py
+++ b/tests/unit/publisher/test_neo4j_preprocessor.py
@@ -5,7 +5,7 @@ import textwrap
 import unittest
 import uuid
 
-from databuilder.publisher.neo4j_preprocessor import NoopRelationPreprocessor, DeleteRelationPreprocessor
+from databuilder.publisher.neo4j_preprocessor import DeleteRelationPreprocessor, NoopRelationPreprocessor
 
 
 class TestNeo4jPreprocessor(unittest.TestCase):

--- a/tests/unit/publisher/test_publisher.py
+++ b/tests/unit/publisher/test_publisher.py
@@ -6,7 +6,7 @@ import unittest
 from mock import MagicMock
 from pyhocon import ConfigTree
 
-from databuilder.publisher.base_publisher import Publisher, NoopPublisher
+from databuilder.publisher.base_publisher import NoopPublisher, Publisher
 
 
 class TestPublisher(unittest.TestCase):

--- a/tests/unit/rest_api/mode_analytics/test_mode_paginated_rest_api_query.py
+++ b/tests/unit/rest_api/mode_analytics/test_mode_paginated_rest_api_query.py
@@ -4,7 +4,7 @@
 import logging
 import unittest
 
-from mock import patch, call
+from mock import call, patch
 
 from databuilder.rest_api.base_rest_api_query import RestApiQuerySeed
 from databuilder.rest_api.mode_analytics.mode_paginated_rest_api_query import ModePaginatedRestApiQuery

--- a/tests/unit/rest_api/test_rest_api_failure_handlers.py
+++ b/tests/unit/rest_api/test_rest_api_failure_handlers.py
@@ -3,8 +3,9 @@
 
 import unittest
 
-from databuilder.rest_api.rest_api_failure_handlers import HttpFailureSkipOnStatus
 from mock import MagicMock
+
+from databuilder.rest_api.rest_api_failure_handlers import HttpFailureSkipOnStatus
 
 
 class TestHttpFailureSkipOnStatus(unittest.TestCase):

--- a/tests/unit/rest_api/test_rest_api_query.py
+++ b/tests/unit/rest_api/test_rest_api_query.py
@@ -5,7 +5,7 @@ import unittest
 
 from mock import patch
 
-from databuilder.rest_api.base_rest_api_query import RestApiQuerySeed, EmptyRestApiQuerySeed
+from databuilder.rest_api.base_rest_api_query import EmptyRestApiQuerySeed, RestApiQuerySeed
 from databuilder.rest_api.rest_api_query import RestApiQuery
 
 

--- a/tests/unit/task/test_neo4j_staleness_removal_task.py
+++ b/tests/unit/task/test_neo4j_staleness_removal_task.py
@@ -27,15 +27,11 @@ class TestRemoveStaleData(unittest.TestCase):
         with patch.object(GraphDatabase, 'driver'):
             task = Neo4jStalenessRemovalTask()
             job_config = ConfigFactory.from_dict({
-                'job.identifier': 'remove_stale_data_job',
-                '{}.{}'.format(task.get_scope(), neo4j_staleness_removal_task.NEO4J_END_POINT_KEY):
-                    'foobar',
-                '{}.{}'.format(task.get_scope(), neo4j_staleness_removal_task.NEO4J_USER):
-                    'foo',
-                '{}.{}'.format(task.get_scope(), neo4j_staleness_removal_task.NEO4J_PASSWORD):
-                    'bar',
-                '{}.{}'.format(task.get_scope(), neo4j_staleness_removal_task.STALENESS_MAX_PCT):
-                    90,
+                f'job.identifier': 'remove_stale_data_job',
+                f'{task.get_scope()}.{neo4j_staleness_removal_task.NEO4J_END_POINT_KEY}': 'foobar',
+                f'{task.get_scope()}.{neo4j_staleness_removal_task.NEO4J_USER}': 'foo',
+                f'{task.get_scope()}.{neo4j_staleness_removal_task.NEO4J_PASSWORD}': 'bar',
+                f'{task.get_scope()}.{neo4j_staleness_removal_task.STALENESS_MAX_PCT}': 90,
                 neo4j_csv_publisher.JOB_PUBLISH_TAG: 'foo'
             })
 
@@ -50,15 +46,11 @@ class TestRemoveStaleData(unittest.TestCase):
         with patch.object(GraphDatabase, 'driver'):
             task = Neo4jStalenessRemovalTask()
             job_config = ConfigFactory.from_dict({
-                'job.identifier': 'remove_stale_data_job',
-                '{}.{}'.format(task.get_scope(), neo4j_staleness_removal_task.NEO4J_END_POINT_KEY):
-                    'foobar',
-                '{}.{}'.format(task.get_scope(), neo4j_staleness_removal_task.NEO4J_USER):
-                    'foo',
-                '{}.{}'.format(task.get_scope(), neo4j_staleness_removal_task.NEO4J_PASSWORD):
-                    'bar',
-                '{}.{}'.format(task.get_scope(), neo4j_staleness_removal_task.STALENESS_MAX_PCT):
-                    5,
+                f'job.identifier': 'remove_stale_data_job',
+                f'{task.get_scope()}.{neo4j_staleness_removal_task.NEO4J_END_POINT_KEY}': 'foobar',
+                f'{task.get_scope()}.{neo4j_staleness_removal_task.NEO4J_USER}': 'foo',
+                f'{task.get_scope()}.{neo4j_staleness_removal_task.NEO4J_PASSWORD}': 'bar',
+                f'{task.get_scope()}.{neo4j_staleness_removal_task.STALENESS_MAX_PCT}': 5,
                 neo4j_csv_publisher.JOB_PUBLISH_TAG: 'foo'
             })
 
@@ -73,17 +65,12 @@ class TestRemoveStaleData(unittest.TestCase):
         with patch.object(GraphDatabase, 'driver'):
             task = Neo4jStalenessRemovalTask()
             job_config = ConfigFactory.from_dict({
-                'job.identifier': 'remove_stale_data_job',
-                '{}.{}'.format(task.get_scope(), neo4j_staleness_removal_task.NEO4J_END_POINT_KEY):
-                    'foobar',
-                '{}.{}'.format(task.get_scope(), neo4j_staleness_removal_task.NEO4J_USER):
-                    'foo',
-                '{}.{}'.format(task.get_scope(), neo4j_staleness_removal_task.NEO4J_PASSWORD):
-                    'bar',
-                '{}.{}'.format(task.get_scope(), neo4j_staleness_removal_task.STALENESS_MAX_PCT):
-                    5,
-                '{}.{}'.format(task.get_scope(), neo4j_staleness_removal_task.STALENESS_PCT_MAX_DICT):
-                    {'foo': 51},
+                f'job.identifier': 'remove_stale_data_job',
+                f'{task.get_scope()}.{neo4j_staleness_removal_task.NEO4J_END_POINT_KEY}': 'foobar',
+                f'{task.get_scope()}.{neo4j_staleness_removal_task.NEO4J_USER}': 'foo',
+                f'{task.get_scope()}.{neo4j_staleness_removal_task.NEO4J_PASSWORD}': 'bar',
+                f'{task.get_scope()}.{neo4j_staleness_removal_task.STALENESS_MAX_PCT}': 5,
+                f'{task.get_scope()}.{neo4j_staleness_removal_task.STALENESS_PCT_MAX_DICT}': {'foo': 51},
                 neo4j_csv_publisher.JOB_PUBLISH_TAG: 'foo'
             })
 
@@ -99,15 +86,11 @@ class TestRemoveStaleData(unittest.TestCase):
         with patch.object(GraphDatabase, 'driver'):
             task = Neo4jStalenessRemovalTask()
             job_config = ConfigFactory.from_dict({
-                'job.identifier': 'remove_stale_data_job',
-                '{}.{}'.format(task.get_scope(), neo4j_staleness_removal_task.NEO4J_END_POINT_KEY):
-                    'foobar',
-                '{}.{}'.format(task.get_scope(), neo4j_staleness_removal_task.NEO4J_USER):
-                    'foo',
-                '{}.{}'.format(task.get_scope(), neo4j_staleness_removal_task.NEO4J_PASSWORD):
-                    'bar',
-                '{}.{}'.format(task.get_scope(), neo4j_staleness_removal_task.STALENESS_MAX_PCT):
-                    5,
+                f'job.identifier': 'remove_stale_data_job',
+                f'{task.get_scope()}.{neo4j_staleness_removal_task.NEO4J_END_POINT_KEY}': 'foobar',
+                f'{task.get_scope()}.{neo4j_staleness_removal_task.NEO4J_USER}': 'foo',
+                f'{task.get_scope()}.{neo4j_staleness_removal_task.NEO4J_PASSWORD}': 'bar',
+                f'{task.get_scope()}.{neo4j_staleness_removal_task.STALENESS_MAX_PCT}': 5,
                 neo4j_csv_publisher.JOB_PUBLISH_TAG: 'foo'
             })
 
@@ -117,17 +100,12 @@ class TestRemoveStaleData(unittest.TestCase):
 
             task = Neo4jStalenessRemovalTask()
             job_config = ConfigFactory.from_dict({
-                'job.identifier': 'remove_stale_data_job',
-                '{}.{}'.format(task.get_scope(), neo4j_staleness_removal_task.NEO4J_END_POINT_KEY):
-                    'foobar',
-                '{}.{}'.format(task.get_scope(), neo4j_staleness_removal_task.NEO4J_USER):
-                    'foo',
-                '{}.{}'.format(task.get_scope(), neo4j_staleness_removal_task.NEO4J_PASSWORD):
-                    'bar',
-                '{}.{}'.format(task.get_scope(), neo4j_staleness_removal_task.STALENESS_MAX_PCT):
-                    5,
-                '{}.{}'.format(task.get_scope(), neo4j_staleness_removal_task.MS_TO_EXPIRE):
-                    86400000,
+                f'job.identifier': 'remove_stale_data_job',
+                f'{task.get_scope()}.{neo4j_staleness_removal_task.NEO4J_END_POINT_KEY}': 'foobar',
+                f'{task.get_scope()}.{neo4j_staleness_removal_task.NEO4J_USER}': 'foo',
+                f'{task.get_scope()}.{neo4j_staleness_removal_task.NEO4J_PASSWORD}': 'bar',
+                f'{task.get_scope()}.{neo4j_staleness_removal_task.STALENESS_MAX_PCT}': 5,
+                f'{task.get_scope()}.{neo4j_staleness_removal_task.MS_TO_EXPIRE}': 86400000,
             })
 
             task.init(job_config)
@@ -139,17 +117,12 @@ class TestRemoveStaleData(unittest.TestCase):
                 as mock_execute:
             task = Neo4jStalenessRemovalTask()
             job_config = ConfigFactory.from_dict({
-                'job.identifier': 'remove_stale_data_job',
-                '{}.{}'.format(task.get_scope(), neo4j_staleness_removal_task.NEO4J_END_POINT_KEY):
-                    'foobar',
-                '{}.{}'.format(task.get_scope(), neo4j_staleness_removal_task.NEO4J_USER):
-                    'foo',
-                '{}.{}'.format(task.get_scope(), neo4j_staleness_removal_task.NEO4J_PASSWORD):
-                    'bar',
-                '{}.{}'.format(task.get_scope(), neo4j_staleness_removal_task.STALENESS_MAX_PCT):
-                    5,
-                '{}.{}'.format(task.get_scope(), neo4j_staleness_removal_task.TARGET_NODES):
-                    ['Foo'],
+                f'job.identifier': 'remove_stale_data_job',
+                f'{task.get_scope()}.{neo4j_staleness_removal_task.NEO4J_END_POINT_KEY}': 'foobar',
+                f'{task.get_scope()}.{neo4j_staleness_removal_task.NEO4J_USER}': 'foo',
+                f'{task.get_scope()}.{neo4j_staleness_removal_task.NEO4J_PASSWORD}': 'bar',
+                f'{task.get_scope()}.{neo4j_staleness_removal_task.STALENESS_MAX_PCT}': 5,
+                f'{task.get_scope()}.{neo4j_staleness_removal_task.TARGET_NODES}': ['Foo'],
                 neo4j_csv_publisher.JOB_PUBLISH_TAG: 'foo',
             })
 
@@ -188,17 +161,12 @@ class TestRemoveStaleData(unittest.TestCase):
                 as mock_execute:
             task = Neo4jStalenessRemovalTask()
             job_config = ConfigFactory.from_dict({
-                'job.identifier': 'remove_stale_data_job',
-                '{}.{}'.format(task.get_scope(), neo4j_staleness_removal_task.NEO4J_END_POINT_KEY):
-                    'foobar',
-                '{}.{}'.format(task.get_scope(), neo4j_staleness_removal_task.NEO4J_USER):
-                    'foo',
-                '{}.{}'.format(task.get_scope(), neo4j_staleness_removal_task.NEO4J_PASSWORD):
-                    'bar',
-                '{}.{}'.format(task.get_scope(), neo4j_staleness_removal_task.STALENESS_MAX_PCT):
-                    5,
-                '{}.{}'.format(task.get_scope(), neo4j_staleness_removal_task.MS_TO_EXPIRE):
-                    9876543210
+                f'job.identifier': 'remove_stale_data_job',
+                f'{task.get_scope()}.{neo4j_staleness_removal_task.NEO4J_END_POINT_KEY}': 'foobar',
+                f'{task.get_scope()}.{neo4j_staleness_removal_task.NEO4J_USER}': 'foo',
+                f'{task.get_scope()}.{neo4j_staleness_removal_task.NEO4J_PASSWORD}': 'bar',
+                f'{task.get_scope()}.{neo4j_staleness_removal_task.STALENESS_MAX_PCT}': 5,
+                f'{task.get_scope()}.{neo4j_staleness_removal_task.MS_TO_EXPIRE}': 9876543210
             })
 
             task.init(job_config)
@@ -237,19 +205,13 @@ class TestRemoveStaleData(unittest.TestCase):
             mock_execute.return_value.single.return_value = {'count': 0}
             task = Neo4jStalenessRemovalTask()
             job_config = ConfigFactory.from_dict({
-                'job.identifier': 'remove_stale_data_job',
-                '{}.{}'.format(task.get_scope(), neo4j_staleness_removal_task.NEO4J_END_POINT_KEY):
-                    'foobar',
-                '{}.{}'.format(task.get_scope(), neo4j_staleness_removal_task.NEO4J_USER):
-                    'foo',
-                '{}.{}'.format(task.get_scope(), neo4j_staleness_removal_task.NEO4J_PASSWORD):
-                    'bar',
-                '{}.{}'.format(task.get_scope(), neo4j_staleness_removal_task.STALENESS_MAX_PCT):
-                    5,
-                '{}.{}'.format(task.get_scope(), neo4j_staleness_removal_task.TARGET_NODES):
-                    ['Foo'],
-                '{}.{}'.format(task.get_scope(), neo4j_staleness_removal_task.TARGET_RELATIONS):
-                    ['BAR'],
+                f'job.identifier': 'remove_stale_data_job',
+                f'{task.get_scope()}.{neo4j_staleness_removal_task.NEO4J_END_POINT_KEY}': 'foobar',
+                f'{task.get_scope()}.{neo4j_staleness_removal_task.NEO4J_USER}': 'foo',
+                f'{task.get_scope()}.{neo4j_staleness_removal_task.NEO4J_PASSWORD}': 'bar',
+                f'{task.get_scope()}.{neo4j_staleness_removal_task.STALENESS_MAX_PCT}': 5,
+                f'{task.get_scope()}.{neo4j_staleness_removal_task.TARGET_NODES}': ['Foo'],
+                f'{task.get_scope()}.{neo4j_staleness_removal_task.TARGET_RELATIONS}': ['BAR'],
                 neo4j_csv_publisher.JOB_PUBLISH_TAG: 'foo',
             })
 
@@ -287,21 +249,14 @@ class TestRemoveStaleData(unittest.TestCase):
             mock_execute.return_value.single.return_value = {'count': 0}
             task = Neo4jStalenessRemovalTask()
             job_config = ConfigFactory.from_dict({
-                'job.identifier': 'remove_stale_data_job',
-                '{}.{}'.format(task.get_scope(), neo4j_staleness_removal_task.NEO4J_END_POINT_KEY):
-                    'foobar',
-                '{}.{}'.format(task.get_scope(), neo4j_staleness_removal_task.NEO4J_USER):
-                    'foo',
-                '{}.{}'.format(task.get_scope(), neo4j_staleness_removal_task.NEO4J_PASSWORD):
-                    'bar',
-                '{}.{}'.format(task.get_scope(), neo4j_staleness_removal_task.STALENESS_MAX_PCT):
-                    5,
-                '{}.{}'.format(task.get_scope(), neo4j_staleness_removal_task.TARGET_NODES):
-                    ['Foo'],
-                '{}.{}'.format(task.get_scope(), neo4j_staleness_removal_task.TARGET_RELATIONS):
-                    ['BAR'],
-                '{}.{}'.format(task.get_scope(), neo4j_staleness_removal_task.MS_TO_EXPIRE):
-                    9876543210
+                f'job.identifier': 'remove_stale_data_job',
+                f'{task.get_scope()}.{neo4j_staleness_removal_task.NEO4J_END_POINT_KEY}': 'foobar',
+                f'{task.get_scope()}.{neo4j_staleness_removal_task.NEO4J_USER}': 'foo',
+                f'{task.get_scope()}.{neo4j_staleness_removal_task.NEO4J_PASSWORD}': 'bar',
+                f'{task.get_scope()}.{neo4j_staleness_removal_task.STALENESS_MAX_PCT}': 5,
+                f'{task.get_scope()}.{neo4j_staleness_removal_task.TARGET_NODES}': ['Foo'],
+                f'{task.get_scope()}.{neo4j_staleness_removal_task.TARGET_RELATIONS}': ['BAR'],
+                f'{task.get_scope()}.{neo4j_staleness_removal_task.MS_TO_EXPIRE}': 9876543210
             })
 
             task.init(job_config)
@@ -336,21 +291,14 @@ class TestRemoveStaleData(unittest.TestCase):
         with patch.object(GraphDatabase, 'driver'):
             task = Neo4jStalenessRemovalTask()
             job_config = ConfigFactory.from_dict({
-                'job.identifier': 'remove_stale_data_job',
-                '{}.{}'.format(task.get_scope(), neo4j_staleness_removal_task.NEO4J_END_POINT_KEY):
-                    'foobar',
-                '{}.{}'.format(task.get_scope(), neo4j_staleness_removal_task.NEO4J_USER):
-                    'foo',
-                '{}.{}'.format(task.get_scope(), neo4j_staleness_removal_task.NEO4J_PASSWORD):
-                    'bar',
-                '{}.{}'.format(task.get_scope(), neo4j_staleness_removal_task.STALENESS_MAX_PCT):
-                    5,
-                '{}.{}'.format(task.get_scope(), neo4j_staleness_removal_task.TARGET_NODES):
-                    ['Foo'],
-                '{}.{}'.format(task.get_scope(), neo4j_staleness_removal_task.TARGET_RELATIONS):
-                    ['BAR'],
-                '{}.{}'.format(task.get_scope(), neo4j_staleness_removal_task.MS_TO_EXPIRE):
-                    24 * 60 * 60 * 100 - 10
+                f'job.identifier': 'remove_stale_data_job',
+                f'{task.get_scope()}.{neo4j_staleness_removal_task.NEO4J_END_POINT_KEY}': 'foobar',
+                f'{task.get_scope()}.{neo4j_staleness_removal_task.NEO4J_USER}': 'foo',
+                f'{task.get_scope()}.{neo4j_staleness_removal_task.NEO4J_PASSWORD}': 'bar',
+                f'{task.get_scope()}.{neo4j_staleness_removal_task.STALENESS_MAX_PCT}': 5,
+                f'{task.get_scope()}.{neo4j_staleness_removal_task.TARGET_NODES}': ['Foo'],
+                f'{task.get_scope()}.{neo4j_staleness_removal_task.TARGET_RELATIONS}': ['BAR'],
+                f'{task.get_scope()}.{neo4j_staleness_removal_task.MS_TO_EXPIRE}': 24 * 60 * 60 * 100 - 10
             })
 
             try:
@@ -362,21 +310,14 @@ class TestRemoveStaleData(unittest.TestCase):
         with patch.object(GraphDatabase, 'driver'):
             task = Neo4jStalenessRemovalTask()
             job_config = ConfigFactory.from_dict({
-                'job.identifier': 'remove_stale_data_job',
-                '{}.{}'.format(task.get_scope(), neo4j_staleness_removal_task.NEO4J_END_POINT_KEY):
-                    'foobar',
-                '{}.{}'.format(task.get_scope(), neo4j_staleness_removal_task.NEO4J_USER):
-                    'foo',
-                '{}.{}'.format(task.get_scope(), neo4j_staleness_removal_task.NEO4J_PASSWORD):
-                    'bar',
-                '{}.{}'.format(task.get_scope(), neo4j_staleness_removal_task.STALENESS_MAX_PCT):
-                    5,
-                '{}.{}'.format(task.get_scope(), neo4j_staleness_removal_task.TARGET_NODES):
-                    ['Foo'],
-                '{}.{}'.format(task.get_scope(), neo4j_staleness_removal_task.TARGET_RELATIONS):
-                    ['BAR'],
-                '{}.{}'.format(task.get_scope(), neo4j_staleness_removal_task.MS_TO_EXPIRE):
-                    24 * 60 * 60 * 1000,
+                f'job.identifier': 'remove_stale_data_job',
+                f'{task.get_scope()}.{neo4j_staleness_removal_task.NEO4J_END_POINT_KEY}': 'foobar',
+                f'{task.get_scope()}.{neo4j_staleness_removal_task.NEO4J_USER}': 'foo',
+                f'{task.get_scope()}.{neo4j_staleness_removal_task.NEO4J_PASSWORD}': 'bar',
+                f'{task.get_scope()}.{neo4j_staleness_removal_task.STALENESS_MAX_PCT}': 5,
+                f'{task.get_scope()}.{neo4j_staleness_removal_task.TARGET_NODES}': ['Foo'],
+                f'{task.get_scope()}.{neo4j_staleness_removal_task.TARGET_RELATIONS}': ['BAR'],
+                f'{task.get_scope()}.{neo4j_staleness_removal_task.MS_TO_EXPIRE}': 24 * 60 * 60 * 1000,
             })
             task.init(job_config)
 
@@ -386,21 +327,14 @@ class TestRemoveStaleData(unittest.TestCase):
 
             task = Neo4jStalenessRemovalTask()
             job_config = ConfigFactory.from_dict({
-                'job.identifier': 'remove_stale_data_job',
-                '{}.{}'.format(task.get_scope(), neo4j_staleness_removal_task.NEO4J_END_POINT_KEY):
-                    'foobar',
-                '{}.{}'.format(task.get_scope(), neo4j_staleness_removal_task.NEO4J_USER):
-                    'foo',
-                '{}.{}'.format(task.get_scope(), neo4j_staleness_removal_task.NEO4J_PASSWORD):
-                    'bar',
-                '{}.{}'.format(task.get_scope(), neo4j_staleness_removal_task.STALENESS_MAX_PCT):
-                    5,
-                '{}.{}'.format(task.get_scope(), neo4j_staleness_removal_task.TARGET_NODES):
-                    ['Foo'],
-                '{}.{}'.format(task.get_scope(), neo4j_staleness_removal_task.TARGET_RELATIONS):
-                    ['BAR'],
-                '{}.{}'.format(task.get_scope(), neo4j_staleness_removal_task.DRY_RUN):
-                    True,
+                f'job.identifier': 'remove_stale_data_job',
+                f'{task.get_scope()}.{neo4j_staleness_removal_task.NEO4J_END_POINT_KEY}': 'foobar',
+                f'{task.get_scope()}.{neo4j_staleness_removal_task.NEO4J_USER}': 'foo',
+                f'{task.get_scope()}.{neo4j_staleness_removal_task.NEO4J_PASSWORD}': 'bar',
+                f'{task.get_scope()}.{neo4j_staleness_removal_task.STALENESS_MAX_PCT}': 5,
+                f'{task.get_scope()}.{neo4j_staleness_removal_task.TARGET_NODES}': ['Foo'],
+                f'{task.get_scope()}.{neo4j_staleness_removal_task.TARGET_RELATIONS}': ['BAR'],
+                f'{task.get_scope()}.{neo4j_staleness_removal_task.DRY_RUN}': True,
                 neo4j_csv_publisher.JOB_PUBLISH_TAG: 'foo',
             })
 

--- a/tests/unit/test_base_job.py
+++ b/tests/unit/test_base_job.py
@@ -2,13 +2,14 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import json
+import logging
 import shutil
 import tempfile
 import unittest
-from mock import patch
-
-from pyhocon import ConfigTree, ConfigFactory
 from typing import Any
+
+from mock import patch
+from pyhocon import ConfigTree, ConfigFactory
 
 from databuilder.extractor.base_extractor import Extractor
 from databuilder.job.job import DefaultJob
@@ -16,20 +17,20 @@ from databuilder.loader.base_loader import Loader
 from databuilder.task.task import DefaultTask
 from databuilder.transformer.base_transformer import Transformer
 
+LOGGER = logging.getLogger(__name__)
+
 
 class TestJob(unittest.TestCase):
 
     def setUp(self) -> None:
         self.temp_dir_path = tempfile.mkdtemp()
-        self.dest_file_name = '{}/superhero.json'.format(self.temp_dir_path)
-        self.conf = ConfigFactory.from_dict(
-            {'loader.superhero.dest_file': self.dest_file_name})
+        self.dest_file_name = f'{self.temp_dir_path}/superhero.json'
+        self.conf = ConfigFactory.from_dict({'loader.superhero.dest_file': self.dest_file_name})
 
     def tearDown(self) -> None:
         shutil.rmtree(self.temp_dir_path)
 
     def test_job(self) -> None:
-
         with patch("databuilder.job.job.StatsClient") as mock_statsd:
             task = DefaultTask(SuperHeroExtractor(),
                                SuperHeroLoader(),
@@ -53,7 +54,7 @@ class TestJobNoTransform(unittest.TestCase):
 
     def setUp(self) -> None:
         self.temp_dir_path = tempfile.mkdtemp()
-        self.dest_file_name = '{}/superhero.json'.format(self.temp_dir_path)
+        self.dest_file_name = f'{self.temp_dir_path}/superhero.json'
         self.conf = ConfigFactory.from_dict(
             {'loader.superhero.dest_file': self.dest_file_name})
 
@@ -79,7 +80,7 @@ class TestJobStatsd(unittest.TestCase):
 
     def setUp(self) -> None:
         self.temp_dir_path = tempfile.mkdtemp()
-        self.dest_file_name = '{}/superhero.json'.format(self.temp_dir_path)
+        self.dest_file_name = f'{self.temp_dir_path}/superhero.json'
         self.conf = ConfigFactory.from_dict(
             {'loader.superhero.dest_file': self.dest_file_name,
              'job.is_statsd_enabled': True,
@@ -133,7 +134,7 @@ class SuperHero:
         self.name = name
 
     def __repr__(self) -> str:
-        return "SuperHero(hero={0}, name={1})".format(self.hero, self.name)
+        return f'SuperHero(hero={self.hero}, name={self.name})'
 
 
 class SuperHeroReverseNameTransformer(Transformer):
@@ -155,13 +156,13 @@ class SuperHeroLoader(Loader):
     def init(self, conf: ConfigTree) -> None:
         self.conf = conf
         dest_file_path = self.conf.get_string('dest_file')
-        print('Loading to {}'.format(dest_file_path))
+        LOGGER.info('Loading to %s', dest_file_path)
         self.dest_file_obj = open(self.conf.get_string('dest_file'), 'w')
 
     def load(self, record: Any) -> None:
-        str = json.dumps(record.__dict__, sort_keys=True)
-        print('Writing record: {}'.format(str))
-        self.dest_file_obj.write('{}\n'.format(str))
+        rec = json.dumps(record.__dict__, sort_keys=True)
+        LOGGER.info('Writing record: %s', rec)
+        self.dest_file_obj.write(f'{rec}\n')
         self.dest_file_obj.flush()
 
     def get_scope(self) -> str:

--- a/tests/unit/test_base_job.py
+++ b/tests/unit/test_base_job.py
@@ -9,7 +9,7 @@ import unittest
 from typing import Any
 
 from mock import patch
-from pyhocon import ConfigTree, ConfigFactory
+from pyhocon import ConfigFactory, ConfigTree
 
 from databuilder.extractor.base_extractor import Extractor
 from databuilder.job.job import DefaultJob

--- a/tests/unit/transformer/test_bigquery_usage_transformer.py
+++ b/tests/unit/transformer/test_bigquery_usage_transformer.py
@@ -5,9 +5,9 @@ import unittest
 
 from pyhocon import ConfigFactory
 
-from databuilder.transformer.bigquery_usage_transformer import BigqueryUsageTransformer
 from databuilder.extractor.bigquery_usage_extractor import TableColumnUsageTuple
 from databuilder.models.table_column_usage import TableColumnUsage
+from databuilder.transformer.bigquery_usage_transformer import BigqueryUsageTransformer
 
 
 class TestBigQueryUsageTransform(unittest.TestCase):

--- a/tests/unit/transformer/test_dict_to_model_transformer.py
+++ b/tests/unit/transformer/test_dict_to_model_transformer.py
@@ -5,8 +5,8 @@ import unittest
 
 from pyhocon import ConfigFactory
 
-from databuilder.transformer.dict_to_model import DictToModel, MODEL_CLASS
 from databuilder.models.dashboard.dashboard_execution import DashboardExecution
+from databuilder.transformer.dict_to_model import MODEL_CLASS, DictToModel
 
 
 class TestDictToModel(unittest.TestCase):

--- a/tests/unit/transformer/test_regex_str_replace_transformer.py
+++ b/tests/unit/transformer/test_regex_str_replace_transformer.py
@@ -2,12 +2,13 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import unittest
-
-from pyhocon import ConfigFactory
 from typing import Any
 
-from databuilder.transformer.regex_str_replace_transformer import RegexStrReplaceTransformer, \
-    REGEX_REPLACE_TUPLE_LIST, ATTRIBUTE_NAME
+from pyhocon import ConfigFactory
+
+from databuilder.transformer.regex_str_replace_transformer import (
+    ATTRIBUTE_NAME, REGEX_REPLACE_TUPLE_LIST, RegexStrReplaceTransformer,
+)
 
 
 class TestRegexReplacement(unittest.TestCase):

--- a/tests/unit/transformer/test_remove_field_transformer.py
+++ b/tests/unit/transformer/test_remove_field_transformer.py
@@ -5,7 +5,7 @@ import unittest
 
 from pyhocon import ConfigFactory
 
-from databuilder.transformer.remove_field_transformer import RemoveFieldTransformer, FIELD_NAMES
+from databuilder.transformer.remove_field_transformer import FIELD_NAMES, RemoveFieldTransformer
 
 
 class TestRemoveFieldTransformer(unittest.TestCase):

--- a/tests/unit/transformer/test_table_tag_transformer.py
+++ b/tests/unit/transformer/test_table_tag_transformer.py
@@ -5,8 +5,8 @@ import unittest
 
 from pyhocon import ConfigFactory
 
-from databuilder.transformer.table_tag_transformer import TableTagTransformer
 from databuilder.models.table_metadata import TableMetadata
+from databuilder.transformer.table_tag_transformer import TableTagTransformer
 
 
 class TestTableTagTransformer(unittest.TestCase):

--- a/tests/unit/transformer/test_template_variable_substitution_transformer.py
+++ b/tests/unit/transformer/test_template_variable_substitution_transformer.py
@@ -5,8 +5,9 @@ import unittest
 
 from pyhocon import ConfigFactory
 
-from databuilder.transformer.template_variable_substitution_transformer import \
-    TemplateVariableSubstitutionTransformer, FIELD_NAME, TEMPLATE
+from databuilder.transformer.template_variable_substitution_transformer import (
+    FIELD_NAME, TEMPLATE, TemplateVariableSubstitutionTransformer,
+)
 
 
 class TestTemplateVariableSubstitutionTransformer(unittest.TestCase):

--- a/tests/unit/transformer/test_timestamp_string_to_epoch_transformer.py
+++ b/tests/unit/transformer/test_timestamp_string_to_epoch_transformer.py
@@ -5,7 +5,9 @@ import unittest
 
 from pyhocon import ConfigFactory
 
-from databuilder.transformer.timestamp_string_to_epoch import TimestampStringToEpoch, FIELD_NAME, TIMESTAMP_FORMAT
+from databuilder.transformer.timestamp_string_to_epoch import (
+    FIELD_NAME, TIMESTAMP_FORMAT, TimestampStringToEpoch,
+)
 
 
 class TestTimestampStrToEpoch(unittest.TestCase):


### PR DESCRIPTION
Signed-off-by: Đặng Minh Dũng <dungdm93@live.com>

### Summary of Changes

Currently, our repo is `string.format` heavy-using. Some of them are unnecessary like:
https://github.com/amundsen-io/amundsendatabuilder/blob/453a18b9f70b94226bf01180d7e44b915ca2ddcf/databuilder/extractor/athena_metadata_extractor.py#L48
This PR is all about clean that up and make the code more concise by using f-string instead of string.format
![Screenshot from 2020-12-14 14-19-21](https://user-images.githubusercontent.com/6848311/102051619-6c797080-3e17-11eb-864e-abcdefecbc50.png)


### Tests

No tests change. Already pass `make test`

### Documentation

N/A

### CheckList

Make sure you have checked **all** steps below to ensure a timely review.

- [x] PR title addresses the issue accurately and concisely. Example: "Updates the version of Flask to v1.0.2"
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
- [x] PR includes a summary of changes.
- [ ] PR adds unit tests, updates existing unit tests, **OR** documents why no test additions or modifications are needed.
- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
- [x] PR passes `make test`
