### PR TITLE
fix: Address PyAthena dependency problem

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ snowflake = [
     'snowflake-sqlalchemy'
 ]
 
-athena = ['PyAthena[SQLAlchemy]>=1.0.0']
+athena = ['PyAthena[SQLAlchemy]>=1.0.0, <2.0.0']
 
 # Python API client for google
 # License: Apache Software License


### PR DESCRIPTION
### Summary of Changes

As seen here: https://github.com/laughingman7743/PyAthena/issues/189
The 2.0.0 version of PyAthena doesn't install SQLAlchemy for some reason
This PR fixes that

This issue can be reproduced in a similar way to the linked Issue:
```bash
$ mkdir /tmp/test
$ cd /tmp/test
$ python3 -m venv venv
$ source venv/bin/activate
(venv) $ echo 'amundsen-databuilder[athena]==4.0.3' > requirements.txt
(venv) $ pip3 install -r requirements.txt 2>/dev/null | grep Ignoring
  Ignoring sqlalchemy: markers 'extra == "SQLAlchemy"' don't match your environment
```

This fix just ignores version 2.0.0 for now, presumably until that dependency issue is fixed.

### Tests

As this is a dependency issue I don't think there's a test that can be run 🤷‍♂️ 

### CheckList

- [x] PR title addresses the issue accurately and concisely. Example: "Updates the version of Flask to v1.0.2"
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
- [x] PR includes a summary of changes.
- [x] PR adds unit tests, updates existing unit tests, **OR** documents why no test additions or modifications are needed.
- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
- [ ] PR passes `make test`

The `make test` fails for me. But that "shouldn't" be because of this dep change, I would guess more likely a setup issue :/.