### PR TITLE
fix: Move grouped_tables into _retrieve_tables() in bigquery_metadata_extractor

### DIFF
--- a/databuilder/extractor/base_bigquery_extractor.py
+++ b/databuilder/extractor/base_bigquery_extractor.py
@@ -33,7 +33,6 @@ class BaseBigQueryExtractor(Extractor):
     DEFAULT_PAGE_SIZE = 300
     NUM_RETRIES = 3
     DATE_LENGTH = 8
-    SHARDED_TABLE_KEY_FORMAT = '{dataset_id}/{table_id}'
 
     def init(self, conf: ConfigTree) -> None:
         # should use key_path, or cred_key if the former doesn't exist


### PR DESCRIPTION
Signed-off-by: xuans <xuan_shen@outlook.com>

<!---
Provide a general summary of your changes in the Title above
Include one of these prefixes:
  fix – Fixes an unexpected problem or unintended behavior
  feat – Adds a new feature
  docs – A documentation improvement task
  build – A task related to our build system
  ci – A task related to our ci system
  perf – A performance improvement
  refactor – A code refactor PR
  style – A task about styling
  test – A PR that improve test coverage
  chore – A regular maintenance chore or task
  other – Any other kind of PR
-->

### Summary of Changes

It is an update for my previous PR(https://github.com/amundsen-io/amundsendatabuilder/pull/421) which uses dataset/table_prefix as the key of grouped_tables to solve the table key missing issue since some tables can share the same table_prefix in different datasets. I just noticed the Set self.grouped_tables is only used for a single function `_retrieve_tables()` in bigquery_metadata_extractor. If so, for fixing that issue, I would like to just move grouped_tables into `_retrieve_tables()` which only works for a given dataset so that this set can still use table_prefix as the key. It is going to make the code change conciser.

### Tests


### Documentation


### CheckList

Make sure you have checked **all** steps below to ensure a timely review.

- [ ] PR title addresses the issue accurately and concisely. Example: "Updates the version of Flask to v1.0.2"
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
- [ ] PR includes a summary of changes.
- [ ] PR adds unit tests, updates existing unit tests, **OR** documents why no test additions or modifications are needed.
- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
- [ ] PR passes `make test`
