### PR TITLE
fix: Change logging formatting typo

### DIFF
--- a/databuilder/extractor/hive_table_metadata_extractor.py
+++ b/databuilder/extractor/hive_table_metadata_extractor.py
@@ -105,7 +105,7 @@ class HiveTableMetadataExtractor(Extractor):
 
         self.sql_stmt = conf.get_string(HiveTableMetadataExtractor.EXTRACT_SQL, default=default_sql)
 
-        LOGGER.info('SQL for hive metastore: %i', self.sql_stmt)
+        LOGGER.info('SQL for hive metastore: %s', self.sql_stmt)
 
         sql_alch_conf = sql_alch_conf.with_fallback(ConfigFactory.from_dict(
             {SQLAlchemyExtractor.EXTRACT_SQL: self.sql_stmt}))


### PR DESCRIPTION
Signed-off-by: benrifkind <ben.rifkind@gmail.com>

<!---
Provide a general summary of your changes in the Title above
Include one of these prefixes:
  fix – Fixes an unexpected problem or unintended behavior
  feat – Adds a new feature
  docs – A documentation improvement task
  build – A task related to our build system
  ci – A task related to our ci system
  perf – A performance improvement
  refactor – A code refactor PR
  style – A task about styling
  test – A PR that improve test coverage
  chore – A regular maintenance chore or task
  other – Any other kind of PR
-->

### Summary of Changes

Changed the logging of the SQL query to format as string instead of integer. I am pretty sure this was a typo. This is to fix this error I get when running a HiveTableMetadataExtractor job.
```
TypeError: %i format: a number is required, not str
```


### Tests

No tests. This is a typo fix.

### Documentation

None,

### CheckList

Make sure you have checked **all** steps below to ensure a timely review.

- [x] PR title addresses the issue accurately and concisely. Example: "Updates the version of Flask to v1.0.2"
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
- [x] PR includes a summary of changes.
- [x] PR adds unit tests, updates existing unit tests, **OR** documents why no test additions or modifications are needed.
- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
- [x] PR passes `make test`
