### PR TITLE
fix: Ignore Tableau dashboards of insufficient privileges

### DIFF
--- a/databuilder/extractor/dashboard/tableau/tableau_dashboard_extractor.py
+++ b/databuilder/extractor/dashboard/tableau/tableau_dashboard_extractor.py
@@ -40,6 +40,10 @@ class TableauGraphQLApiMetadataExtractor(TableauGraphQLApiExtractor):
                           self._conf.get_list(TableauGraphQLApiMetadataExtractor.EXCLUDED_PROJECTS)]
         base_url = self._conf.get(TableauGraphQLApiMetadataExtractor.TABLEAU_BASE_URL)
         for workbook in workbooks_data:
+            if None in (workbook['projectName'], workbook['name']):
+                LOGGER.warning(f'Ignoring workbook (ID:{workbook["vizportalUrlId"]}) ' +
+                               f'in project (ID:{workbook["projectVizportalUrlId"]}) because of a lack of permission')
+                continue
             data = {
                 'dashboard_group': workbook['projectName'],
                 'dashboard_name': TableauDashboardUtils.sanitize_workbook_name(workbook['name']),

--- a/databuilder/extractor/dashboard/tableau/tableau_dashboard_last_modified_extractor.py
+++ b/databuilder/extractor/dashboard/tableau/tableau_dashboard_last_modified_extractor.py
@@ -39,6 +39,10 @@ class TableauGraphQLApiLastModifiedExtractor(TableauGraphQLApiExtractor):
                           self._conf.get_list(TableauGraphQLApiLastModifiedExtractor.EXCLUDED_PROJECTS)]
 
         for workbook in workbooks_data:
+            if None in (workbook['projectName'], workbook['name']):
+                LOGGER.warning(f'Ignoring workbook (ID:{workbook["vizportalUrlId"]}) ' +
+                               f'in project (ID:{workbook["projectVizportalUrlId"]}) because of a lack of permission')
+                continue
             data = {
                 'dashboard_group_id': workbook['projectName'],
                 'dashboard_id': TableauDashboardUtils.sanitize_workbook_name(workbook['name']),
@@ -73,6 +77,8 @@ class TableauDashboardLastModifiedExtractor(Extractor):
                 name
                 projectName
                 updatedAt
+                projectVizportalUrlId
+                vizportalUrlId
             }
         }"""
 

--- a/tests/unit/extractor/dashboard/tableau/test_tableau_dashboard_extractor.py
+++ b/tests/unit/extractor/dashboard/tableau/test_tableau_dashboard_extractor.py
@@ -28,6 +28,15 @@ def mock_query(*_args: Any, **_kwargs: Any) -> Dict[str, Any]:
                 'projectName': 'Test Project',
                 'projectVizportalUrlId': 123,
                 'vizportalUrlId': 456
+            },
+            {
+                'id': 'fake-id',
+                'name': None,
+                'createdAt': '2020-04-08T05:32:01Z',
+                'description': '',
+                'projectName': None,
+                'projectVizportalUrlId': 123,
+                'vizportalUrlId': 456
             }
         ]
     }
@@ -62,8 +71,8 @@ class TestTableauDashboardExtractor(unittest.TestCase):
 
         extractor = TableauDashboardExtractor()
         extractor.init(Scoped.get_scoped_conf(conf=config, scope=extractor.get_scope()))
-        record = extractor.extract()
 
+        record = extractor.extract()
         self.assertEqual(record.dashboard_id, 'Test Workbook')
         self.assertEqual(record.dashboard_name, 'Test Workbook')
         self.assertEqual(record.dashboard_group_id, 'Test Project')
@@ -71,6 +80,9 @@ class TestTableauDashboardExtractor(unittest.TestCase):
         self.assertEqual(record.product, 'tableau')
         self.assertEqual(record.cluster, 'tableau_dashboard_cluster')
         self.assertEqual(record.created_timestamp, 1586323921)
+
+        record = extractor.extract()
+        self.assertIsNone(record)
 
 
 if __name__ == '__main__':

--- a/tests/unit/extractor/dashboard/tableau/test_tableau_dashboard_last_modified_extractor.py
+++ b/tests/unit/extractor/dashboard/tableau/test_tableau_dashboard_last_modified_extractor.py
@@ -26,7 +26,17 @@ def mock_query(*_args: Any, **_kwargs: Any) -> Dict[str, Any]:
                 'id': 'fake-workbook-id',
                 'name': 'Test Workbook',
                 'projectName': 'Test Project',
-                'updatedAt': '2020-08-04T20:16:05Z'
+                'updatedAt': '2020-08-04T20:16:05Z',
+                'projectVizportalUrlId': 123,
+                'vizportalUrlId': 456
+            },
+            {
+                'id': 'fake-workbook-id',
+                'name': None,
+                'projectName': None,
+                'createdAt': '2020-08-04T20:16:05Z',
+                'projectVizportalUrlId': 123,
+                'vizportalUrlId': 456
             }
         ]
     }
@@ -60,13 +70,16 @@ class TestTableauDashboardLastModified(unittest.TestCase):
 
         extractor = TableauDashboardLastModifiedExtractor()
         extractor.init(Scoped.get_scoped_conf(conf=config, scope=extractor.get_scope()))
-        record = extractor.extract()
 
+        record = extractor.extract()
         self.assertEqual(record._dashboard_id, 'Test Workbook')
         self.assertEqual(record._dashboard_group_id, 'Test Project')
         self.assertEqual(record._product, 'tableau')
         self.assertEqual(record._cluster, 'tableau_dashboard_cluster')
         self.assertEqual(record._last_modified_timestamp, 1596572165)
+
+        record = extractor.extract()
+        self.assertIsNone(record)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
### Summary of Changes

Closes: amundsen-io/amundsen#911

Tableau API returns null for dashboard name or project name when the user token does not have access privilege for the dashboard or the project.
The sanitizers in `TableauDashboardUtils` will raise `TypeError` when the value is None.
If these names are None, we should ignore them and shows some warnings.

### Tests

No feature added.

### CheckList

Make sure you have checked **all** steps below to ensure a timely review.

- [x] PR title addresses the issue accurately and concisely. Example: "Updates the version of Flask to v1.0.2"
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
- [x] PR includes a summary of changes.
- [x] PR adds unit tests, updates existing unit tests, **OR** documents why no test additions or modifications are needed.
- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
- [x] PR passes `make test`
