### PR TITLE
fix: Don't overwrite Amundsen descriptions if MySQL descriptions don't exist.

### DIFF
--- a/databuilder/extractor/mysql_metadata_extractor.py
+++ b/databuilder/extractor/mysql_metadata_extractor.py
@@ -107,13 +107,17 @@ class MysqlMetadataExtractor(Extractor):
 
             for row in group:
                 last_row = row
-                columns.append(ColumnMetadata(row['col_name'], row['col_description'],
-                                              row['col_type'], row['col_sort_order']))
+                columns.append(ColumnMetadata(
+                    row['col_name'],
+                    row['col_description'] if row['col_description'] else None,
+                    row['col_type'],
+                    row['col_sort_order'])
+                )
 
             yield TableMetadata(self._database, last_row['cluster'],
                                 last_row['schema'],
                                 last_row['name'],
-                                last_row['description'],
+                                last_row['description'] if last_row['description'] else None,
                                 columns,
                                 is_view=last_row['is_view'])
 


### PR DESCRIPTION
### Summary of Changes

When using the MysqlMetadataExtractor class to populate Amundsen, we've been seeing our user-submitted descriptions via amundsenfrontend disappear on every extract-and-publish job we run, but weren't seeing the same behaviour on our Snowflake extract/publish jobs. Turns out that the Snowflake extractor does this when creating a ColumnMetadata object:

```python
unidecode(row['col_description']) if row['col_description'] else None
```

...while the MySQL extractor simply uses the column description without checking for falsy values. I've updated the MysqlMetadataExtractor to mirror what the Snowflake extractor does, thus preventing errant overwrites with blank strings.


### Tests

I didn't see any tests referencing MysqlMetadataExtractor, but would be happy to furnish a new one if it's needed.

### CheckList

Make sure you have checked **all** steps below to ensure a timely review.

- [x] PR title addresses the issue accurately and concisely. Example: "Updates the version of Flask to v1.0.2"
- [x] PR includes a summary of changes.
- [x] PR adds unit tests, updates existing unit tests, **OR** documents why no test additions or modifications are needed.
- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
- [x] PR passes `make test`
