### PR TITLE
fix: Use Redash Version to determine API URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -724,7 +724,8 @@ job_config = ConfigFactory.from_dict({
 	'extractor.redash_dashboard.redash_base_url': redash_base_url, # ex: https://redash.example.org
 	'extractor.redash_dashboard.api_base_url': api_base_url, # ex: https://redash.example.org/api
 	'extractor.redash_dashboard.api_key': api_key, # ex: abc1234
-	'extractor.redash_dashboard.table_parser': table_parser # ex: my_library.module.parse_tables
+	'extractor.redash_dashboard.table_parser': table_parser, # ex: my_library.module.parse_tables
+	'extractor.redash_dashboard.redash_version': redash_version # ex: 8. optional, default=9 
 })
 
 job = DefaultJob(conf=job_config,

--- a/tests/unit/extractor/dashboard/redash/test_redash_dashboard_extractor.py
+++ b/tests/unit/extractor/dashboard/redash/test_redash_dashboard_extractor.py
@@ -161,6 +161,124 @@ class TestRedashDashboardExtractor(unittest.TestCase):
             )
             self.assertEqual(record.__repr__(), expected_table.__repr__())
 
+    def test_with_verion_8(self) -> None:
+        def mock_api_get(url: str, *args: Any, **kwargs: Any) -> MockApiResponse:
+            if 'test-dash' in url:
+                return MockApiResponse({
+                    'id': 1000,
+                    'widgets': [
+                        {
+                            'visualization': {
+                                'query': {
+                                    'data_source_id': 1,
+                                    'id': 1234,
+                                    'name': 'Test Query',
+                                    'query': 'SELECT id FROM users'
+                                },
+                                'id': 12345,
+                                'name': 'test_widget',
+                                'type': 'CHART',
+                            },
+                            'options': {}
+                        }
+                    ]
+                })
+
+            return MockApiResponse({
+                'page': 1,
+                'count': 1,
+                'page_size': 50,
+                'results': [
+                    {
+                        'id': 1000,
+                        'name': 'Test Dash',
+                        'slug': 'test-dash',
+                        'created_at': '2020-01-01T00:00:00.000Z',
+                        'updated_at': '2020-01-02T00:00:00.000Z',
+                        'is_archived': False,
+                        'is_draft': False,
+                        'user': {'email': 'asdf@example.com'}
+                    }
+                ]
+            })
+
+        redash_base_url = 'https://redash.example.com'
+        config = ConfigFactory.from_dict({
+            'extractor.redash_dashboard.redash_base_url': redash_base_url,
+            'extractor.redash_dashboard.api_base_url': redash_base_url,  # probably not but doesn't matter
+            'extractor.redash_dashboard.api_key': 'abc123',
+            'extractor.redash_dashboard.table_parser':
+                'tests.unit.extractor.dashboard.redash.test_redash_dashboard_extractor.dummy_tables',
+            'extractor.redash_dashboard.redash_version': 8
+        })
+
+        with patch('databuilder.rest_api.rest_api_query.requests.get') as mock_get:
+            mock_get.side_effect = mock_api_get
+
+            extractor = RedashDashboardExtractor()
+            extractor.init(Scoped.get_scoped_conf(conf=config, scope=extractor.get_scope()))
+
+            # DashboardMetadata
+            record = extractor.extract()
+            self.assertEqual(record.dashboard_id, '1000')
+            self.assertEqual(record.dashboard_name, 'Test Dash')
+            self.assertEqual(record.dashboard_group_id, RedashDashboardExtractor.DASHBOARD_GROUP_ID)
+            self.assertEqual(record.dashboard_group, RedashDashboardExtractor.DASHBOARD_GROUP_NAME)
+            self.assertEqual(record.product, RedashDashboardExtractor.PRODUCT)
+            self.assertEqual(record.cluster, RedashDashboardExtractor.DEFAULT_CLUSTER)
+            self.assertEqual(record.created_timestamp, 1577836800)
+            self.assertTrue(redash_base_url in record.dashboard_url)
+            self.assertTrue('test-dash' in record.dashboard_url)
+
+            # DashboardLastModified
+            record = extractor.extract()
+            identity: Dict[str, Any] = {
+                'dashboard_id': '1000',
+                'dashboard_group_id': RedashDashboardExtractor.DASHBOARD_GROUP_ID,
+                'product': RedashDashboardExtractor.PRODUCT,
+                'cluster': u'prod'
+            }
+            expected_timestamp = DashboardLastModifiedTimestamp(
+                last_modified_timestamp=1577923200,
+                **identity
+            )
+            self.assertEqual(record.__repr__(), expected_timestamp.__repr__())
+
+            # DashboardOwner
+            record = extractor.extract()
+            expected_owner = DashboardOwner(email='asdf@example.com', **identity)
+            self.assertEqual(record.__repr__(), expected_owner.__repr__())
+
+            # DashboardQuery
+            record = extractor.extract()
+            expected_query = DashboardQuery(
+                query_id='1234',
+                query_name='Test Query',
+                url=f'{redash_base_url}/queries/1234',
+                query_text='SELECT id FROM users',
+                **identity
+            )
+            self.assertEqual(record.__repr__(), expected_query.__repr__())
+
+            # DashboardChart
+            record = extractor.extract()
+            expected_chart = DashboardChart(
+                query_id='1234',
+                chart_id='12345',
+                chart_name='test_widget',
+                chart_type='CHART',
+                **identity
+            )
+            self.assertEqual(record.__repr__(), expected_chart.__repr__())
+
+            # DashboardTable
+            record = extractor.extract()
+            expected_table = DashboardTable(
+                table_ids=[TableRelationData('some_db', 'prod', 'public', 'users').key],
+                **identity
+            )
+            self.assertEqual(record.__repr__(), expected_table.__repr__())
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
<!---
Provide a general summary of your changes in the Title above
Include one of these prefixes:
  fix – Fixes an unexpected problem or unintended behavior
  feat – Adds a new feature
  docs – A documentation improvement task
  build – A task related to our build system
  ci – A task related to our ci system
  perf – A performance improvement
  refactor – A code refactor PR
  style – A task about styling
  test – A PR that improve test coverage
  chore – A regular maintenance chore or task
  other – Any other kind of PR
-->

### Summary of Changes

Redash v8 and v9 have different resource urls for dashboards. The current behaviour is consistent with v9, which is currently in beta.

This adds `redash_version` as an optional config parameter to `RedashDashboardExtractor`, and uses the value of this parameter to determine the urls for dashboards.


### Tests

A test was added to [tests/unit/extractor/dashboard/redash/test_redash_dashboard_extractor.py](tests/unit/extractor/dashboard/redash/test_redash_dashboard_extractor.py) to test that the correct api url is called when `redash_version` is set to `8`


### Documentation

`redash_version` was added to the README.md

### CheckList

Make sure you have checked **all** steps below to ensure a timely review.

- [X] PR title addresses the issue accurately and concisely. Example: "Updates the version of Flask to v1.0.2"
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
- [X] PR includes a summary of changes.
- [X] PR adds unit tests, updates existing unit tests, **OR** documents why no test additions or modifications are needed.
- [X] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
- [X] PR passes `make test`
