### PR TITLE
refactor: Use yield instead of return for all node/relation iterators in databuilder

### DIFF
--- a/databuilder/models/application.py
+++ b/databuilder/models/application.py
@@ -1,7 +1,7 @@
 # Copyright Contributors to the Amundsen project.
 # SPDX-License-Identifier: Apache-2.0
 
-from typing import List, Union
+from typing import Iterator, Union
 
 from databuilder.models.graph_node import GraphNode
 from databuilder.models.graph_relationship import GraphRelationship
@@ -44,8 +44,8 @@ class Application(GraphSerializable):
 
         self.dag = dag_id
 
-        self._node_iter = iter(self.create_nodes())
-        self._relation_iter = iter(self.create_relation())
+        self._node_iter = self._create_node_iterator()
+        self._relation_iter = self._create_relation_iterator()
 
     def create_next_node(self) -> Union[GraphNode, None]:
         # creates new node
@@ -73,12 +73,11 @@ class Application(GraphSerializable):
                                                          dag=self.dag,
                                                          task=self.task)
 
-    def create_nodes(self) -> List[GraphNode]:
+    def _create_node_iterator(self) -> Iterator[GraphNode]:
         """
-        Create a list of Neo4j node records
+        Create an application node
         :return:
         """
-        results = []
         application_description = '{app_type} with id {id}'.format(
             app_type=Application.APPLICATION_TYPE,
             id=Application.APPLICATION_ID_FORMAT.format(dag_id=self.dag, task_id=self.task)
@@ -97,13 +96,11 @@ class Application(GraphSerializable):
                 Application.APPLICATION_ID: application_id
             }
         )
-        results.append(application_node)
+        yield application_node
 
-        return results
-
-    def create_relation(self) -> List[GraphRelationship]:
+    def _create_relation_iterator(self) -> Iterator[GraphRelationship]:
         """
-        Create a list of relations between application and table nodes
+        Create relations between application and table nodes
         :return:
         """
         graph_relationship = GraphRelationship(
@@ -115,5 +112,4 @@ class Application(GraphSerializable):
             reverse_type=Application.APPLICATION_TABLE_RELATION_TYPE,
             attributes={}
         )
-        results = [graph_relationship]
-        return results
+        yield graph_relationship

--- a/databuilder/models/badge.py
+++ b/databuilder/models/badge.py
@@ -2,7 +2,9 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import re
-from typing import List, Optional
+from typing import (
+    Iterator, List, Optional,
+)
 
 from databuilder.models.graph_node import GraphNode
 from databuilder.models.graph_relationship import GraphRelationship
@@ -60,8 +62,8 @@ class BadgeMetadata(GraphSerializable):
         else:
             raise Exception(start_label + ' is not a valid start_label for a Badge relation')
 
-        self._node_iter = iter(self.create_nodes())
-        self._relation_iter = iter(self.create_relation())
+        self._node_iter = self._create_node_iterator()
+        self._relation_iter = self._create_relation_iterator()
 
     def __repr__(self) -> str:
         return f'BadgeMetadata({self.start_label!r}, {self.start_key!r})'
@@ -88,12 +90,8 @@ class BadgeMetadata(GraphSerializable):
     def get_metadata_model_key(self) -> str:
         return self.start_key
 
-    def create_nodes(self) -> List[GraphNode]:
-        """
-        Create a list of `GraphNode` records
-        :return:
-        """
-        results = []
+    def get_badge_nodes(self) -> List[GraphNode]:
+        nodes = []
         for badge in self.badges:
             if badge:
                 node = GraphNode(
@@ -103,11 +101,11 @@ class BadgeMetadata(GraphSerializable):
                         self.BADGE_CATEGORY: badge.category
                     }
                 )
-                results.append(node)
-        return results
+                nodes.append(node)
+        return nodes
 
-    def create_relation(self) -> List[GraphRelationship]:
-        results: List[GraphRelationship] = []
+    def get_badge_relations(self) -> List[GraphRelationship]:
+        relations = []
         for badge in self.badges:
             relation = GraphRelationship(
                 start_label=self.start_label,
@@ -118,5 +116,19 @@ class BadgeMetadata(GraphSerializable):
                 reverse_type=self.INVERSE_BADGE_RELATION_TYPE,
                 attributes={}
             )
-            results.append(relation)
-        return results
+            relations.append(relation)
+        return relations
+
+    def _create_node_iterator(self) -> Iterator[GraphNode]:
+        """
+        Create badge nodes
+        :return:
+        """
+        nodes = self.get_badge_nodes()
+        for node in nodes:
+            yield node
+
+    def _create_relation_iterator(self) -> Iterator[GraphRelationship]:
+        relations = self.get_badge_relations()
+        for relation in relations:
+            yield relation

--- a/databuilder/models/es_last_updated.py
+++ b/databuilder/models/es_last_updated.py
@@ -1,7 +1,7 @@
 # Copyright Contributors to the Amundsen project.
 # SPDX-License-Identifier: Apache-2.0
 
-from typing import List, Union
+from typing import Iterator, Union
 
 from databuilder.models.graph_node import GraphNode
 from databuilder.models.graph_relationship import GraphRelationship
@@ -25,8 +25,8 @@ class ESLastUpdated(GraphSerializable):
         :param timestamp: epoch for latest updated timestamp for neo4j an es
         """
         self.timestamp = timestamp
-        self._node_iter = iter(self.create_nodes())
-        self._rel_iter = iter(self.create_relation())
+        self._node_iter = self._create_node_iterator()
+        self._rel_iter = self._create_relation_iterator()
 
     def create_next_node(self) -> Union[GraphNode, None]:
         """
@@ -37,9 +37,9 @@ class ESLastUpdated(GraphSerializable):
         except StopIteration:
             return None
 
-    def create_nodes(self) -> List[GraphNode]:
+    def _create_node_iterator(self) -> Iterator[GraphNode]:
         """
-        Create a list of Neo4j node records.
+        Create an es_updated_timestamp node
         """
         node = GraphNode(
             key=ESLastUpdated.KEY,
@@ -48,7 +48,7 @@ class ESLastUpdated(GraphSerializable):
                 ESLastUpdated.LATEST_TIMESTAMP: self.timestamp
             }
         )
-        return [node]
+        yield node
 
     def create_next_relation(self) -> Union[GraphRelationship, None]:
         try:
@@ -56,5 +56,6 @@ class ESLastUpdated(GraphSerializable):
         except StopIteration:
             return None
 
-    def create_relation(self) -> List[GraphRelationship]:
-        return []
+    def _create_relation_iterator(self) -> Iterator[GraphRelationship]:
+        return
+        yield

--- a/databuilder/models/table_column_usage.py
+++ b/databuilder/models/table_column_usage.py
@@ -73,7 +73,8 @@ class TableColumnUsage(GraphSerializable):
         for col_reader in self.col_readers:
             if col_reader.column == '*':
                 # using yield for better memory efficiency
-                yield User(email=col_reader.user_email).create_nodes()[0]
+                user_node = User(email=col_reader.user_email).get_user_node()
+                yield user_node
 
     def create_next_relation(self) -> Union[GraphRelationship, None]:
         try:

--- a/databuilder/models/table_last_updated.py
+++ b/databuilder/models/table_last_updated.py
@@ -1,7 +1,7 @@
 # Copyright Contributors to the Amundsen project.
 # SPDX-License-Identifier: Apache-2.0
 
-from typing import List, Union
+from typing import Iterator, Union
 
 from databuilder.models.graph_node import GraphNode
 from databuilder.models.graph_relationship import GraphRelationship
@@ -33,8 +33,8 @@ class TableLastUpdated(GraphSerializable):
         self.db = db
         self.cluster = cluster
 
-        self._node_iter = iter(self.create_nodes())
-        self._relation_iter = iter(self.create_relation())
+        self._node_iter = self._create_node_iterator()
+        self._relation_iter = self._create_relation_iterator()
 
     def __repr__(self) -> str:
         return f"TableLastUpdated(table_name={self.table_name!r}, last_updated_time={self.last_updated_time!r}, " \
@@ -67,13 +67,11 @@ class TableLastUpdated(GraphSerializable):
                                                                schema=self.schema,
                                                                tbl=self.table_name)
 
-    def create_nodes(self) -> List[GraphNode]:
+    def _create_node_iterator(self) -> Iterator[GraphNode]:
         """
-        Create a list of graph node records
+        Create a last_updated node
         :return:
         """
-        results = []
-
         node = GraphNode(
             key=self.get_last_updated_model_key(),
             label=TableLastUpdated.LAST_UPDATED_NODE_LABEL,
@@ -83,14 +81,11 @@ class TableLastUpdated(GraphSerializable):
                 TableLastUpdated.TIMESTAMP_NAME_PROPERTY: timestamp_constants.TimestampName.last_updated_timestamp.name
             }
         )
+        yield node
 
-        results.append(node)
-
-        return results
-
-    def create_relation(self) -> List[GraphRelationship]:
+    def _create_relation_iterator(self) -> Iterator[GraphRelationship]:
         """
-        Create a list of relations mapping last updated node with table node
+        Create relations mapping last updated node with table node
         :return:
         """
         relationship = GraphRelationship(
@@ -102,6 +97,4 @@ class TableLastUpdated(GraphSerializable):
             reverse_type=TableLastUpdated.LASTUPDATED_TABLE_RELATION_TYPE,
             attributes={}
         )
-        results = [relationship]
-
-        return results
+        yield relationship

--- a/databuilder/models/table_lineage.py
+++ b/databuilder/models/table_lineage.py
@@ -2,7 +2,9 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import re
-from typing import List, Union
+from typing import (
+    Iterator, List, Union,
+)
 
 from databuilder.models.graph_node import GraphNode
 from databuilder.models.graph_relationship import GraphRelationship
@@ -33,8 +35,8 @@ class TableLineage(GraphSerializable):
         # a list of downstream dependencies, each of which will follow
         # the same key
         self.downstream_deps = downstream_deps or []
-        self._node_iter = iter(self.create_nodes())
-        self._relation_iter = iter(self.create_relation())
+        self._node_iter = self._create_node_iterator()
+        self._relation_iter = self._create_rel_iterator()
 
     def create_next_node(self) -> Union[GraphNode, None]:
         # return the string representation of the data
@@ -57,19 +59,19 @@ class TableLineage(GraphSerializable):
                             ) -> str:
         return f'{db}://{cluster}.{schema}/{table}'
 
-    def create_nodes(self) -> List[Union[GraphNode, None]]:
+    def _create_node_iterator(self) -> Iterator[GraphNode]:
         """
         It won't create any node for this model
         :return:
         """
-        return []
+        return
+        yield
 
-    def create_relation(self) -> List[GraphRelationship]:
+    def _create_rel_iterator(self) -> Iterator[GraphRelationship]:
         """
-        Create a list of relation between source table and all the downstream tables
+        Create relations between source table and all the downstream tables
         :return:
         """
-        results = []
         for downstream_tab in self.downstream_deps:
             # every deps should follow '{db}://{cluster}.{schema}/{table}'
             # todo: if we change the table uri, we should change here.
@@ -95,8 +97,7 @@ class TableLineage(GraphSerializable):
                     reverse_type=TableLineage.DEPENDENCY_ORIGIN_RELATION_TYPE,
                     attributes={}
                 )
-                results.append(relationship)
-        return results
+                yield relationship
 
     def __repr__(self) -> str:
         return f'TableLineage({self.db!r}, {self.cluster!r}, {self.schema!r}, {self.table!r})'

--- a/databuilder/models/table_metadata.py
+++ b/databuilder/models/table_metadata.py
@@ -364,7 +364,8 @@ class TableMetadata(GraphSerializable):
                     start_label=ColumnMetadata.COLUMN_NODE_LABEL,
                     start_key=self._get_col_key(col),
                     badges=col.badges)
-                for node in col_badge_metadata.create_nodes():
+                badge_nodes = col_badge_metadata.get_badge_nodes()
+                for node in badge_nodes:
                     yield node
 
         # Database, cluster, schema
@@ -472,7 +473,7 @@ class TableMetadata(GraphSerializable):
                 badge_metadata = BadgeMetadata(start_label=ColumnMetadata.COLUMN_NODE_LABEL,
                                                start_key=self._get_col_key(col),
                                                badges=col.badges)
-                badge_relations = badge_metadata.create_relation()
+                badge_relations = badge_metadata.get_badge_relations()
                 for relation in badge_relations:
                     yield relation
 

--- a/databuilder/models/table_source.py
+++ b/databuilder/models/table_source.py
@@ -1,7 +1,7 @@
 # Copyright Contributors to the Amundsen project.
 # SPDX-License-Identifier: Apache-2.0
 
-from typing import List, Optional
+from typing import Iterator, Optional
 
 from databuilder.models.graph_node import GraphNode
 from databuilder.models.graph_relationship import GraphRelationship
@@ -34,8 +34,8 @@ class TableSource(GraphSerializable):
         # source is the source file location
         self.source = source
         self.source_type = source_type
-        self._node_iter = iter(self.create_nodes())
-        self._relation_iter = iter(self.create_relation())
+        self._node_iter = self._create_node_iterator()
+        self._relation_iter = self._create_relation_iterator()
 
     def create_next_node(self) -> Optional[GraphNode]:
         # return the string representation of the data
@@ -59,9 +59,9 @@ class TableSource(GraphSerializable):
     def get_metadata_model_key(self) -> str:
         return f'{self.db}://{self.cluster}.{self.schema}/{self.table}'
 
-    def create_nodes(self) -> List[GraphNode]:
+    def _create_node_iterator(self) -> Iterator[GraphNode]:
         """
-        Create a list of Neo4j node records
+        Create a table source node
         :return:
         """
         node = GraphNode(
@@ -72,12 +72,11 @@ class TableSource(GraphSerializable):
                 'source_type': self.source_type
             }
         )
-        results = [node]
-        return results
+        yield node
 
-    def create_relation(self) -> List[GraphRelationship]:
+    def _create_relation_iterator(self) -> Iterator[GraphRelationship]:
         """
-        Create a list of relation map between owner record with original hive table
+        Create relation map between owner record with original hive table
         :return:
         """
         relationship = GraphRelationship(
@@ -89,8 +88,7 @@ class TableSource(GraphSerializable):
             reverse_type=TableSource.TABLE_SOURCE_RELATION_TYPE,
             attributes={}
         )
-        results = [relationship]
-        return results
+        yield relationship
 
     def __repr__(self) -> str:
         return f'TableSource({self.db!r}, {self.cluster!r}, {self.schema!r}, {self.table!r}, {self.source!r})'

--- a/databuilder/models/table_stats.py
+++ b/databuilder/models/table_stats.py
@@ -1,6 +1,6 @@
 # Copyright Contributors to the Amundsen project.
 # SPDX-License-Identifier: Apache-2.0
-from typing import List, Optional
+from typing import Iterator, Optional
 
 from databuilder.models.graph_node import GraphNode
 from databuilder.models.graph_relationship import GraphRelationship
@@ -42,8 +42,8 @@ class TableColumnStats(GraphSerializable):
         self.cluster = cluster
         self.stat_name = stat_name
         self.stat_val = str(stat_val)
-        self._node_iter = iter(self.create_nodes())
-        self._relation_iter = iter(self.create_relation())
+        self._node_iter = self._create_node_iterator()
+        self._relation_iter = self._create_relation_iterator()
 
     def create_next_node(self) -> Optional[GraphNode]:
         # return the string representation of the data
@@ -74,9 +74,9 @@ class TableColumnStats(GraphSerializable):
                                                        tbl=self.table,
                                                        col=self.col_name)
 
-    def create_nodes(self) -> List[GraphNode]:
+    def _create_node_iterator(self) -> Iterator[GraphNode]:
         """
-        Create a list of Neo4j node records
+        Create a table stat node
         :return:
         """
         node = GraphNode(
@@ -89,12 +89,11 @@ class TableColumnStats(GraphSerializable):
                 'end_epoch': self.end_epoch,
             }
         )
-        results = [node]
-        return results
+        yield node
 
-    def create_relation(self) -> List[GraphRelationship]:
+    def _create_relation_iterator(self) -> Iterator[GraphRelationship]:
         """
-        Create a list of relation map between table stat record with original hive table
+        Create relation map between table stat record with original hive table
         :return:
         """
         relationship = GraphRelationship(
@@ -106,5 +105,4 @@ class TableColumnStats(GraphSerializable):
             reverse_type=TableColumnStats.Column_STAT_RELATION_TYPE,
             attributes={}
         )
-        results = [relationship]
-        return results
+        yield relationship

--- a/tests/unit/models/test_application.py
+++ b/tests/unit/models/test_application.py
@@ -30,33 +30,51 @@ class TestApplication(unittest.TestCase):
                                        table_name='test_table',
                                        application_url_template='airflow_host.net/admin/airflow/tree?dag_id={dag_id}')
 
-        self.expected_node_result = {
+        self.expected_node_results = [{
             NODE_KEY: 'application://gold.airflow/event_test/hive.default.test_table',
             NODE_LABEL: 'Application',
             'application_url': 'airflow_host.net/admin/airflow/tree?dag_id=event_test',
             'id': 'event_test/hive.default.test_table',
             'name': 'Airflow',
             'description': 'Airflow with id event_test/hive.default.test_table'
-        }
+        }]
 
-        self.expected_relation_result = {
+        self.expected_relation_results = [{
             RELATION_START_KEY: 'hive://gold.default/test_table',
             RELATION_START_LABEL: TableMetadata.TABLE_NODE_LABEL,
             RELATION_END_KEY: 'application://gold.airflow/event_test/hive.default.test_table',
             RELATION_END_LABEL: 'Application',
             RELATION_TYPE: 'DERIVED_FROM',
             RELATION_REVERSE_TYPE: 'GENERATES'
-        }
+        }]
 
-    def test_create_next_node(self) -> None:
-        next_node = self.application.create_next_node()
-        serialized_next_node = neo4_serializer.serialize_node(next_node)
-        self.assertEquals(serialized_next_node, self.expected_node_result)
+    def test_get_table_model_key(self) -> None:
+        table = self.application.get_table_model_key()
+        self.assertEqual(table, 'hive://gold.default/test_table')
 
-    def test_create_next_node_neptune(self) -> None:
+    def test_get_application_model_key(self) -> None:
+        application = self.application.get_application_model_key()
+        self.assertEqual(application, self.expected_node_results[0][NODE_KEY])
+
+    def test_create_nodes(self) -> None:
+        actual = []
+        node = self.application.create_next_node()
+        while node:
+            serialized_next_node = neo4_serializer.serialize_node(node)
+            actual.append(serialized_next_node)
+            node = self.application.create_next_node()
+
+        self.assertEquals(actual, self.expected_node_results)
+
+    def test_create_nodes_neptune(self) -> None:
+        actual = []
         next_node = self.application.create_next_node()
-        serialized_next_node = neptune_serializer.convert_node(next_node)
-        neptune_expected = {
+        while next_node:
+            serialized_next_node = neptune_serializer.convert_node(next_node)
+            actual.append(serialized_next_node)
+            next_node = self.application.create_next_node()
+
+        neptune_expected = [{
             NEPTUNE_HEADER_ID: 'application://gold.airflow/event_test/hive.default.test_table',
             NEPTUNE_HEADER_LABEL: 'Application',
             NEPTUNE_LAST_EXTRACTED_AT_RELATIONSHIP_PROPERTY_NAME_BULK_LOADER_FORMAT: ANY,
@@ -65,16 +83,20 @@ class TestApplication(unittest.TestCase):
             'id:String(single)': 'event_test/hive.default.test_table',
             'name:String(single)': 'Airflow',
             'description:String(single)': 'Airflow with id event_test/hive.default.test_table',
-        }
-        self.assertDictEqual(neptune_expected, serialized_next_node)
+        }]
+        self.assertEqual(neptune_expected, actual)
 
-    def test_create_next_relation(self) -> None:
-        next_relation = self.application.create_next_relation()
-        serialized_next_relation = neo4_serializer.serialize_relationship(next_relation)
-        self.assertEquals(serialized_next_relation, self.expected_relation_result)
+    def test_create_relation(self) -> None:
+        actual = []
+        relation = self.application.create_next_relation()
+        while relation:
+            serialized_relation = neo4_serializer.serialize_relationship(relation)
+            actual.append(serialized_relation)
+            relation = self.application.create_next_relation()
 
-    def test_create_next_relation_neptune(self) -> None:
+        self.assertEquals(actual, self.expected_relation_results)
 
+    def test_create_relation_neptune(self) -> None:
         neptune_forward_expected = {
             NEPTUNE_HEADER_ID: "{from_vertex_id}_{to_vertex_id}_{label}".format(
                 from_vertex_id='hive://gold.default/test_table',
@@ -100,27 +122,13 @@ class TestApplication(unittest.TestCase):
             NEPTUNE_LAST_EXTRACTED_AT_RELATIONSHIP_PROPERTY_NAME_BULK_LOADER_FORMAT: ANY,
             NEPTUNE_CREATION_TYPE_RELATIONSHIP_PROPERTY_NAME_BULK_LOADER_FORMAT: NEPTUNE_CREATION_TYPE_JOB
         }
+        neptune_expected = [[neptune_forward_expected, neptune_reversed_expected]]
 
+        actual = []
         next_relation = self.application.create_next_relation()
-        serialized_next_relations = neptune_serializer.convert_relationship(next_relation)
-        self.assertDictEqual(serialized_next_relations[0], neptune_forward_expected)
-        self.assertDictEqual(serialized_next_relations[1], neptune_reversed_expected)
+        while next_relation:
+            serialized_next_relation = neptune_serializer.convert_relationship(next_relation)
+            actual.append(serialized_next_relation)
+            next_relation = self.application.create_next_relation()
 
-    def test_get_table_model_key(self) -> None:
-        table = self.application.get_table_model_key()
-        self.assertEqual(table, 'hive://gold.default/test_table')
-
-    def test_get_application_model_key(self) -> None:
-        application = self.application.get_application_model_key()
-        self.assertEqual(application, self.expected_node_result[NODE_KEY])
-
-    def test_create_nodes(self) -> None:
-        nodes = self.application.create_nodes()
-        self.assertEquals(len(nodes), 1)
-        serialized_next_node = neo4_serializer.serialize_node(nodes[0])
-        self.assertEquals(serialized_next_node, self.expected_node_result)
-
-    def test_create_relation(self) -> None:
-        relation = self.application.create_relation()
-        self.assertEquals(len(relation), 1)
-        self.assertEquals(neo4_serializer.serialize_relationship(relation[0]), self.expected_relation_result)
+        self.assertEqual(actual, neptune_expected)

--- a/tests/unit/models/test_badge.py
+++ b/tests/unit/models/test_badge.py
@@ -2,7 +2,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import unittest
-from typing import Dict, List
 from unittest.mock import ANY
 
 from databuilder.models.badge import Badge, BadgeMetadata
@@ -38,9 +37,6 @@ class TestBadge(unittest.TestCase):
         self.assertEqual(badge_key, badge1.name)
 
     def test_create_nodes(self) -> None:
-        nodes = self.badge_metada.create_nodes()
-        self.assertEqual(len(nodes), 2)
-
         node1 = {
             NODE_KEY: BadgeMetadata.BADGE_KEY_FORMAT.format(badge=badge1.name),
             NODE_LABEL: BadgeMetadata.BADGE_NODE_LABEL,
@@ -51,21 +47,18 @@ class TestBadge(unittest.TestCase):
             NODE_LABEL: BadgeMetadata.BADGE_NODE_LABEL,
             BadgeMetadata.BADGE_CATEGORY: badge2.category
         }
-        serialized_nodes = [
-            neo4_serializer.serialize_node(node)
-            for node in nodes
-        ]
+        expected = [node1, node2]
 
-        self.assertTrue(node1 in serialized_nodes)
-        self.assertTrue(node2 in serialized_nodes)
+        actual = []
+        node = self.badge_metada.create_next_node()
+        while node:
+            serialized_node = neo4_serializer.serialize_node(node)
+            actual.append(serialized_node)
+            node = self.badge_metada.create_next_node()
+
+        self.assertEqual(expected, actual)
 
     def test_create_nodes_neptune(self) -> None:
-        nodes = self.badge_metada.create_nodes()
-        serialized_nodes = [
-            neptune_serializer.convert_node(node)
-            for node in nodes
-        ]
-
         expected_node1 = {
             NEPTUNE_HEADER_ID: BadgeMetadata.BADGE_KEY_FORMAT.format(badge=badge1.name),
             NEPTUNE_HEADER_LABEL: BadgeMetadata.BADGE_NODE_LABEL,
@@ -81,9 +74,16 @@ class TestBadge(unittest.TestCase):
             NEPTUNE_CREATION_TYPE_NODE_PROPERTY_NAME_BULK_LOADER_FORMAT: NEPTUNE_CREATION_TYPE_JOB,
             BadgeMetadata.BADGE_CATEGORY + ':String(single)': badge2.category
         }
+        expected = [expected_node1, expected_node2]
 
-        self.assertTrue(expected_node1 in serialized_nodes)
-        self.assertTrue(expected_node2 in serialized_nodes)
+        actual = []
+        node = self.badge_metada.create_next_node()
+        while node:
+            serialized_node = neptune_serializer.convert_node(node)
+            actual.append(serialized_node)
+            node = self.badge_metada.create_next_node()
+
+        self.assertEqual(expected, actual)
 
     def test_bad_key_entity_match(self) -> None:
         column_label = 'Column'
@@ -105,13 +105,6 @@ class TestBadge(unittest.TestCase):
                           badges=[badge1, badge2])
 
     def test_create_relation(self) -> None:
-        relations = self.badge_metada.create_relation()
-        serialized_relations = [
-            neo4_serializer.serialize_relationship(relation)
-            for relation in relations
-        ]
-        self.assertEqual(len(relations), 2)
-
         relation1 = {
             RELATION_START_LABEL: self.badge_metada.start_label,
             RELATION_END_LABEL: BadgeMetadata.BADGE_NODE_LABEL,
@@ -128,16 +121,18 @@ class TestBadge(unittest.TestCase):
             RELATION_TYPE: BadgeMetadata.BADGE_RELATION_TYPE,
             RELATION_REVERSE_TYPE: BadgeMetadata.INVERSE_BADGE_RELATION_TYPE,
         }
+        expected = [relation1, relation2]
 
-        self.assertTrue(relation1 in serialized_relations)
-        self.assertTrue(relation2 in serialized_relations)
+        actual = []
+        relation = self.badge_metada.create_next_relation()
+        while relation:
+            serialized_relation = neo4_serializer.serialize_relationship(relation)
+            actual.append(serialized_relation)
+            relation = self.badge_metada.create_next_relation()
+
+        self.assertEqual(expected, actual)
 
     def test_create_relation_neptune(self) -> None:
-        relations = self.badge_metada.create_relation()
-        serialized_relations: List[Dict] = sum([
-            neptune_serializer.convert_relationship(rel) for rel in relations
-        ], [])
-
         neptune_forward_expected_1 = {
             NEPTUNE_HEADER_ID: "{from_vertex_id}_{to_vertex_id}_{label}".format(
                 from_vertex_id=self.badge_metada.start_key,
@@ -189,8 +184,14 @@ class TestBadge(unittest.TestCase):
             NEPTUNE_LAST_EXTRACTED_AT_RELATIONSHIP_PROPERTY_NAME_BULK_LOADER_FORMAT: ANY,
             NEPTUNE_CREATION_TYPE_RELATIONSHIP_PROPERTY_NAME_BULK_LOADER_FORMAT: NEPTUNE_CREATION_TYPE_JOB
         }
+        expected = [[neptune_forward_expected_1, neptune_reversed_expected_1],
+                    [neptune_forward_expected_2, neptune_reversed_expected_2]]
 
-        self.assertTrue(neptune_forward_expected_1 in serialized_relations)
-        self.assertTrue(neptune_reversed_expected_1 in serialized_relations)
-        self.assertTrue(neptune_forward_expected_2 in serialized_relations)
-        self.assertTrue(neptune_reversed_expected_2 in serialized_relations)
+        actual = []
+        relation = self.badge_metada.create_next_relation()
+        while relation:
+            serialized_relations = neptune_serializer.convert_relationship(relation)
+            actual.append(serialized_relations)
+            relation = self.badge_metada.create_next_relation()
+
+        self.assertEqual(expected, actual)

--- a/tests/unit/models/test_es_last_updated.py
+++ b/tests/unit/models/test_es_last_updated.py
@@ -12,23 +12,23 @@ class TestNeo4jESLastUpdated(unittest.TestCase):
 
     def setUp(self) -> None:
         super(TestNeo4jESLastUpdated, self).setUp()
-        self.neo4j_es_last_updated = ESLastUpdated(timestamp=100)
+        self.es_last_updated = ESLastUpdated(timestamp=100)
 
-        self.expected_node_result = {
+        self.expected_node_results = [{
             NODE_KEY: 'amundsen_updated_timestamp',
             NODE_LABEL: 'Updatedtimestamp',
             'latest_timestmap:UNQUOTED': 100,
-        }
+        }]
 
     def test_create_nodes(self) -> None:
-        nodes = self.neo4j_es_last_updated.create_nodes()
-        self.assertEquals(len(nodes), 1)
-        serialized_node = neo4_serializer.serialize_node(nodes[0])
-        self.assertEquals(serialized_node, self.expected_node_result)
+        actual = []
+        node = self.es_last_updated.create_next_node()
+        while node:
+            serialized_node = neo4_serializer.serialize_node(node)
+            actual.append(serialized_node)
+            node = self.es_last_updated.create_next_node()
 
-    def test_create_next_node(self) -> None:
-        next_node = self.neo4j_es_last_updated.create_next_node()
-        self.assertEquals(neo4_serializer.serialize_node(next_node), self.expected_node_result)
+        self.assertEquals(actual, self.expected_node_results)
 
-    def test_create_next_relation(self) -> None:
-        self.assertIs(self.neo4j_es_last_updated.create_next_relation(), None)
+    def test_create_relation(self) -> None:
+        self.assertIs(self.es_last_updated.create_next_relation(), None)

--- a/tests/unit/models/test_table_last_updated.py
+++ b/tests/unit/models/test_table_last_updated.py
@@ -28,78 +28,22 @@ class TestTableLastUpdated(unittest.TestCase):
                                                  last_updated_time_epoch=25195665,
                                                  schema='default')
 
-        self.expected_node_result = {
+        self.expected_node_results = [{
             NODE_KEY: 'hive://gold.default/test_table/timestamp',
             NODE_LABEL: 'Timestamp',
             'last_updated_timestamp:UNQUOTED': 25195665,
             timestamp_constants.TIMESTAMP_PROPERTY + ":UNQUOTED": 25195665,
             'name': 'last_updated_timestamp'
-        }
+        }]
 
-        self.expected_relation_result = {
+        self.expected_relation_results = [{
             RELATION_START_KEY: 'hive://gold.default/test_table',
             RELATION_START_LABEL: 'Table',
             RELATION_END_KEY: 'hive://gold.default/test_table/timestamp',
             RELATION_END_LABEL: 'Timestamp',
             RELATION_TYPE: 'LAST_UPDATED_AT',
             RELATION_REVERSE_TYPE: 'LAST_UPDATED_TIME_OF'
-        }
-
-    def test_create_next_node(self) -> None:
-        next_node = self.tableLastUpdated.create_next_node()
-        next_node_serialized = neo4_serializer.serialize_node(next_node)
-        self.assertEqual(next_node_serialized, self.expected_node_result)
-
-    def test_create_next_node_neptune(self) -> None:
-        expected_node = {
-            NEPTUNE_HEADER_ID: self.tableLastUpdated.get_last_updated_model_key(),
-            NEPTUNE_HEADER_LABEL: TableLastUpdated.LAST_UPDATED_NODE_LABEL,
-            NEPTUNE_LAST_EXTRACTED_AT_RELATIONSHIP_PROPERTY_NAME_BULK_LOADER_FORMAT: ANY,
-            NEPTUNE_CREATION_TYPE_NODE_PROPERTY_NAME_BULK_LOADER_FORMAT: NEPTUNE_CREATION_TYPE_JOB,
-            'name:String(single)': 'last_updated_timestamp',
-            'last_updated_timestamp:Long(single)': 25195665,
-            timestamp_constants.TIMESTAMP_PROPERTY + ":Long(single)": 25195665,
-        }
-
-        next_node = self.tableLastUpdated.create_next_node()
-        next_node_serialized = neptune_serializer.convert_node(next_node)
-        self.assertEqual(next_node_serialized, expected_node)
-
-    def test_create_next_relation(self) -> None:
-        next_relation = self.tableLastUpdated.create_next_relation()
-        next_relation_serialized = neo4_serializer.serialize_relationship(next_relation)
-        self.assertEqual(next_relation_serialized, self.expected_relation_result)
-
-    def test_create_next_relation_neptune(self) -> None:
-        next_relation = self.tableLastUpdated.create_next_relation()
-        next_relation_serialized = neptune_serializer.convert_relationship(next_relation)
-        expected = [
-            {
-                NEPTUNE_HEADER_ID: "{from_vertex_id}_{to_vertex_id}_{label}".format(
-                    from_vertex_id='hive://gold.default/test_table',
-                    to_vertex_id='hive://gold.default/test_table/timestamp',
-                    label='LAST_UPDATED_AT'
-                ),
-                NEPTUNE_RELATIONSHIP_HEADER_FROM: 'hive://gold.default/test_table',
-                NEPTUNE_RELATIONSHIP_HEADER_TO: 'hive://gold.default/test_table/timestamp',
-                NEPTUNE_HEADER_LABEL: 'LAST_UPDATED_AT',
-                NEPTUNE_LAST_EXTRACTED_AT_RELATIONSHIP_PROPERTY_NAME_BULK_LOADER_FORMAT: ANY,
-                NEPTUNE_CREATION_TYPE_RELATIONSHIP_PROPERTY_NAME_BULK_LOADER_FORMAT: NEPTUNE_CREATION_TYPE_JOB
-            },
-            {
-                NEPTUNE_HEADER_ID: "{from_vertex_id}_{to_vertex_id}_{label}".format(
-                    from_vertex_id='hive://gold.default/test_table/timestamp',
-                    to_vertex_id='hive://gold.default/test_table',
-                    label='LAST_UPDATED_TIME_OF'
-                ),
-                NEPTUNE_RELATIONSHIP_HEADER_FROM: 'hive://gold.default/test_table/timestamp',
-                NEPTUNE_RELATIONSHIP_HEADER_TO: 'hive://gold.default/test_table',
-                NEPTUNE_HEADER_LABEL: 'LAST_UPDATED_TIME_OF',
-                NEPTUNE_LAST_EXTRACTED_AT_RELATIONSHIP_PROPERTY_NAME_BULK_LOADER_FORMAT: ANY,
-                NEPTUNE_CREATION_TYPE_RELATIONSHIP_PROPERTY_NAME_BULK_LOADER_FORMAT: NEPTUNE_CREATION_TYPE_JOB
-            }
-        ]
-        self.assertEqual(next_relation_serialized, expected)
+        }]
 
     def test_get_table_model_key(self) -> None:
         table = self.tableLastUpdated.get_table_model_key()
@@ -110,13 +54,80 @@ class TestTableLastUpdated(unittest.TestCase):
         self.assertEqual(last_updated, 'hive://gold.default/test_table/timestamp')
 
     def test_create_nodes(self) -> None:
-        nodes = self.tableLastUpdated.create_nodes()
-        self.assertEquals(len(nodes), 1)
-        serialize_node = neo4_serializer.serialize_node(nodes[0])
-        self.assertEquals(serialize_node, self.expected_node_result)
+        actual = []
+        node = self.tableLastUpdated.create_next_node()
+        while node:
+            serialize_node = neo4_serializer.serialize_node(node)
+            actual.append(serialize_node)
+            node = self.tableLastUpdated.create_next_node()
+
+        self.assertEquals(actual, self.expected_node_results)
+
+    def test_create_nodes_neptune(self) -> None:
+        expected_nodes = [{
+            NEPTUNE_HEADER_ID: self.tableLastUpdated.get_last_updated_model_key(),
+            NEPTUNE_HEADER_LABEL: TableLastUpdated.LAST_UPDATED_NODE_LABEL,
+            NEPTUNE_LAST_EXTRACTED_AT_RELATIONSHIP_PROPERTY_NAME_BULK_LOADER_FORMAT: ANY,
+            NEPTUNE_CREATION_TYPE_NODE_PROPERTY_NAME_BULK_LOADER_FORMAT: NEPTUNE_CREATION_TYPE_JOB,
+            'name:String(single)': 'last_updated_timestamp',
+            'last_updated_timestamp:Long(single)': 25195665,
+            timestamp_constants.TIMESTAMP_PROPERTY + ":Long(single)": 25195665,
+        }]
+
+        actual = []
+        next_node = self.tableLastUpdated.create_next_node()
+        while next_node:
+            next_node_serialized = neptune_serializer.convert_node(next_node)
+            actual.append(next_node_serialized)
+            next_node = self.tableLastUpdated.create_next_node()
+
+        self.assertEqual(actual, expected_nodes)
 
     def test_create_relation(self) -> None:
-        relation = self.tableLastUpdated.create_relation()
-        self.assertEquals(len(relation), 1)
-        serialized_relation = neo4_serializer.serialize_relationship(relation[0])
-        self.assertEquals(serialized_relation, self.expected_relation_result)
+        actual = []
+        relation = self.tableLastUpdated.create_next_relation()
+        while relation:
+            serialized_relation = neo4_serializer.serialize_relationship(relation)
+            actual.append(serialized_relation)
+            relation = self.tableLastUpdated.create_next_relation()
+
+        self.assertEquals(actual, self.expected_relation_results)
+
+    def test_create_relation_neptune(self) -> None:
+        expected = [
+            [
+                {
+                    NEPTUNE_HEADER_ID: "{from_vertex_id}_{to_vertex_id}_{label}".format(
+                        from_vertex_id='hive://gold.default/test_table',
+                        to_vertex_id='hive://gold.default/test_table/timestamp',
+                        label='LAST_UPDATED_AT'
+                    ),
+                    NEPTUNE_RELATIONSHIP_HEADER_FROM: 'hive://gold.default/test_table',
+                    NEPTUNE_RELATIONSHIP_HEADER_TO: 'hive://gold.default/test_table/timestamp',
+                    NEPTUNE_HEADER_LABEL: 'LAST_UPDATED_AT',
+                    NEPTUNE_LAST_EXTRACTED_AT_RELATIONSHIP_PROPERTY_NAME_BULK_LOADER_FORMAT: ANY,
+                    NEPTUNE_CREATION_TYPE_RELATIONSHIP_PROPERTY_NAME_BULK_LOADER_FORMAT: NEPTUNE_CREATION_TYPE_JOB
+                },
+                {
+                    NEPTUNE_HEADER_ID: "{from_vertex_id}_{to_vertex_id}_{label}".format(
+                        from_vertex_id='hive://gold.default/test_table/timestamp',
+                        to_vertex_id='hive://gold.default/test_table',
+                        label='LAST_UPDATED_TIME_OF'
+                    ),
+                    NEPTUNE_RELATIONSHIP_HEADER_FROM: 'hive://gold.default/test_table/timestamp',
+                    NEPTUNE_RELATIONSHIP_HEADER_TO: 'hive://gold.default/test_table',
+                    NEPTUNE_HEADER_LABEL: 'LAST_UPDATED_TIME_OF',
+                    NEPTUNE_LAST_EXTRACTED_AT_RELATIONSHIP_PROPERTY_NAME_BULK_LOADER_FORMAT: ANY,
+                    NEPTUNE_CREATION_TYPE_RELATIONSHIP_PROPERTY_NAME_BULK_LOADER_FORMAT: NEPTUNE_CREATION_TYPE_JOB
+                }
+            ]
+        ]
+
+        actual = []
+        next_relation = self.tableLastUpdated.create_next_relation()
+        while next_relation:
+            next_relation_serialized = neptune_serializer.convert_relationship(next_relation)
+            actual.append(next_relation_serialized)
+            next_relation = self.tableLastUpdated.create_next_relation()
+
+        self.assertEqual(actual, expected)

--- a/tests/unit/models/test_table_lineage.py
+++ b/tests/unit/models/test_table_lineage.py
@@ -34,7 +34,8 @@ class TestTableLineage(unittest.TestCase):
                                                            'hive://default.test_schema/test_table2'])
 
         self.start_key = f'{DB}://{CLUSTER}.{SCHEMA}/{TABLE}'
-        self.end_key = f'{DB}://{CLUSTER}.test_schema/test_table1'
+        self.end_key1 = f'{DB}://{CLUSTER}.test_schema/test_table1'
+        self.end_key2 = f'{DB}://{CLUSTER}.test_schema/test_table2'
 
     def test_get_table_model_key(self) -> None:
         metadata = self.table_lineage.get_table_model_key(db=DB,
@@ -44,59 +45,105 @@ class TestTableLineage(unittest.TestCase):
         self.assertEqual(metadata, 'hive://default.base/test')
 
     def test_create_nodes(self) -> None:
-        nodes = self.table_lineage.create_nodes()
-        self.assertEqual(len(nodes), 0)
+        actual = []
+        node = self.table_lineage.create_next_node()
+        while node:
+            serialized_node = neo4_serializer.serialize_node(node)
+            actual.append(serialized_node)
+            node = self.table_lineage.create_next_node()
+
+        self.assertEqual(len(actual), 0)
 
     def test_create_relation(self) -> None:
-        relations = self.table_lineage.create_relation()
-        self.assertEqual(len(relations), 2)
-
-        expected_relation = {
-            RELATION_START_KEY: self.start_key,
-            RELATION_START_LABEL: 'Table',
-            RELATION_END_KEY: self.end_key,
-            RELATION_END_LABEL: 'Table',
-            RELATION_TYPE: TableLineage.ORIGIN_DEPENDENCY_RELATION_TYPE,
-            RELATION_REVERSE_TYPE: TableLineage.DEPENDENCY_ORIGIN_RELATION_TYPE
-        }
-        actual_relations = [
-            neo4_serializer.serialize_relationship(relation)
-            for relation in relations
-        ]
-        self.assertTrue(len(relations), 2)
-        self.assertTrue(expected_relation in actual_relations)
-
-    def test_create_relation_neptune(self) -> None:
-        relations = self.table_lineage.create_relation()
-
-        expected = [
+        expected_relations = [
             {
-                NEPTUNE_HEADER_ID: "{from_vertex_id}_{to_vertex_id}_{label}".format(
-                    from_vertex_id=self.start_key,
-                    to_vertex_id=self.end_key,
-                    label=TableLineage.ORIGIN_DEPENDENCY_RELATION_TYPE,
-                ),
-                NEPTUNE_RELATIONSHIP_HEADER_FROM: self.start_key,
-                NEPTUNE_RELATIONSHIP_HEADER_TO: self.end_key,
-                NEPTUNE_HEADER_LABEL: TableLineage.ORIGIN_DEPENDENCY_RELATION_TYPE,
-                NEPTUNE_LAST_EXTRACTED_AT_RELATIONSHIP_PROPERTY_NAME_BULK_LOADER_FORMAT: ANY,
-                NEPTUNE_CREATION_TYPE_RELATIONSHIP_PROPERTY_NAME_BULK_LOADER_FORMAT: NEPTUNE_CREATION_TYPE_JOB
+                RELATION_START_KEY: self.start_key,
+                RELATION_START_LABEL: 'Table',
+                RELATION_END_KEY: self.end_key1,
+                RELATION_END_LABEL: 'Table',
+                RELATION_TYPE: TableLineage.ORIGIN_DEPENDENCY_RELATION_TYPE,
+                RELATION_REVERSE_TYPE: TableLineage.DEPENDENCY_ORIGIN_RELATION_TYPE
             },
             {
-                NEPTUNE_HEADER_ID: "{from_vertex_id}_{to_vertex_id}_{label}".format(
-                    from_vertex_id=self.end_key,
-                    to_vertex_id=self.start_key,
-                    label=TableLineage.DEPENDENCY_ORIGIN_RELATION_TYPE
-                ),
-                NEPTUNE_RELATIONSHIP_HEADER_FROM: self.end_key,
-                NEPTUNE_RELATIONSHIP_HEADER_TO: self.start_key,
-                NEPTUNE_HEADER_LABEL: TableLineage.DEPENDENCY_ORIGIN_RELATION_TYPE,
-                NEPTUNE_LAST_EXTRACTED_AT_RELATIONSHIP_PROPERTY_NAME_BULK_LOADER_FORMAT: ANY,
-                NEPTUNE_CREATION_TYPE_RELATIONSHIP_PROPERTY_NAME_BULK_LOADER_FORMAT: NEPTUNE_CREATION_TYPE_JOB
+                RELATION_START_KEY: self.start_key,
+                RELATION_START_LABEL: 'Table',
+                RELATION_END_KEY: self.end_key2,
+                RELATION_END_LABEL: 'Table',
+                RELATION_TYPE: TableLineage.ORIGIN_DEPENDENCY_RELATION_TYPE,
+                RELATION_REVERSE_TYPE: TableLineage.DEPENDENCY_ORIGIN_RELATION_TYPE
             }
         ]
-        actual_relations = [
-            neptune_serializer.convert_relationship(relation)
-            for relation in relations
+
+        actual = []
+        relation = self.table_lineage.create_next_relation()
+        while relation:
+            serialized_relation = neo4_serializer.serialize_relationship(relation)
+            actual.append(serialized_relation)
+            relation = self.table_lineage.create_next_relation()
+
+        self.assertEqual(actual, expected_relations)
+
+    def test_create_relation_neptune(self) -> None:
+        expected = [
+            [
+                {
+                    NEPTUNE_HEADER_ID: "{from_vertex_id}_{to_vertex_id}_{label}".format(
+                        from_vertex_id=self.start_key,
+                        to_vertex_id=self.end_key1,
+                        label=TableLineage.ORIGIN_DEPENDENCY_RELATION_TYPE,
+                    ),
+                    NEPTUNE_RELATIONSHIP_HEADER_FROM: self.start_key,
+                    NEPTUNE_RELATIONSHIP_HEADER_TO: self.end_key1,
+                    NEPTUNE_HEADER_LABEL: TableLineage.ORIGIN_DEPENDENCY_RELATION_TYPE,
+                    NEPTUNE_LAST_EXTRACTED_AT_RELATIONSHIP_PROPERTY_NAME_BULK_LOADER_FORMAT: ANY,
+                    NEPTUNE_CREATION_TYPE_RELATIONSHIP_PROPERTY_NAME_BULK_LOADER_FORMAT: NEPTUNE_CREATION_TYPE_JOB
+                },
+                {
+                    NEPTUNE_HEADER_ID: "{from_vertex_id}_{to_vertex_id}_{label}".format(
+                        from_vertex_id=self.end_key1,
+                        to_vertex_id=self.start_key,
+                        label=TableLineage.DEPENDENCY_ORIGIN_RELATION_TYPE
+                    ),
+                    NEPTUNE_RELATIONSHIP_HEADER_FROM: self.end_key1,
+                    NEPTUNE_RELATIONSHIP_HEADER_TO: self.start_key,
+                    NEPTUNE_HEADER_LABEL: TableLineage.DEPENDENCY_ORIGIN_RELATION_TYPE,
+                    NEPTUNE_LAST_EXTRACTED_AT_RELATIONSHIP_PROPERTY_NAME_BULK_LOADER_FORMAT: ANY,
+                    NEPTUNE_CREATION_TYPE_RELATIONSHIP_PROPERTY_NAME_BULK_LOADER_FORMAT: NEPTUNE_CREATION_TYPE_JOB
+                }
+            ],
+            [
+                {
+                    NEPTUNE_HEADER_ID: "{from_vertex_id}_{to_vertex_id}_{label}".format(
+                        from_vertex_id=self.start_key,
+                        to_vertex_id=self.end_key2,
+                        label=TableLineage.ORIGIN_DEPENDENCY_RELATION_TYPE,
+                    ),
+                    NEPTUNE_RELATIONSHIP_HEADER_FROM: self.start_key,
+                    NEPTUNE_RELATIONSHIP_HEADER_TO: self.end_key2,
+                    NEPTUNE_HEADER_LABEL: TableLineage.ORIGIN_DEPENDENCY_RELATION_TYPE,
+                    NEPTUNE_LAST_EXTRACTED_AT_RELATIONSHIP_PROPERTY_NAME_BULK_LOADER_FORMAT: ANY,
+                    NEPTUNE_CREATION_TYPE_RELATIONSHIP_PROPERTY_NAME_BULK_LOADER_FORMAT: NEPTUNE_CREATION_TYPE_JOB
+                },
+                {
+                    NEPTUNE_HEADER_ID: "{from_vertex_id}_{to_vertex_id}_{label}".format(
+                        from_vertex_id=self.end_key2,
+                        to_vertex_id=self.start_key,
+                        label=TableLineage.DEPENDENCY_ORIGIN_RELATION_TYPE
+                    ),
+                    NEPTUNE_RELATIONSHIP_HEADER_FROM: self.end_key2,
+                    NEPTUNE_RELATIONSHIP_HEADER_TO: self.start_key,
+                    NEPTUNE_HEADER_LABEL: TableLineage.DEPENDENCY_ORIGIN_RELATION_TYPE,
+                    NEPTUNE_LAST_EXTRACTED_AT_RELATIONSHIP_PROPERTY_NAME_BULK_LOADER_FORMAT: ANY,
+                    NEPTUNE_CREATION_TYPE_RELATIONSHIP_PROPERTY_NAME_BULK_LOADER_FORMAT: NEPTUNE_CREATION_TYPE_JOB
+                }
+            ]
         ]
-        self.assertTrue(expected in actual_relations)
+
+        actual = []
+        relation = self.table_lineage.create_next_relation()
+        while relation:
+            serialized_relation = neptune_serializer.convert_relationship(relation)
+            actual.append(serialized_relation)
+            relation = self.table_lineage.create_next_relation()
+
+        self.assertEqual(actual, expected)

--- a/tests/unit/models/test_table_owner.py
+++ b/tests/unit/models/test_table_owner.py
@@ -45,9 +45,6 @@ class TestTableOwner(unittest.TestCase):
         self.assertEqual(metadata, 'hive://DEFAULT.BASE/TEST')
 
     def test_create_nodes(self) -> None:
-        nodes = self.table_owner.create_nodes()
-        self.assertEqual(len(nodes), 2)
-
         expected_node1 = {
             NODE_KEY: User.USER_NODE_KEY_FORMAT.format(email=owner1),
             NODE_LABEL: User.USER_NODE_LABEL,
@@ -58,17 +55,18 @@ class TestTableOwner(unittest.TestCase):
             NODE_LABEL: User.USER_NODE_LABEL,
             User.USER_NODE_EMAIL: owner2
         }
-        actual_nodes = [
-            neo4_serializer.serialize_node(node)
-            for node in nodes
-        ]
+        expected = [expected_node1, expected_node2]
 
-        self.assertTrue(expected_node1 in actual_nodes)
-        self.assertTrue(expected_node2 in actual_nodes)
+        actual = []
+        node = self.table_owner.create_next_node()
+        while node:
+            serialized_node = neo4_serializer.serialize_node(node)
+            actual.append(serialized_node)
+            node = self.table_owner.create_next_node()
+
+        self.assertEqual(actual, expected)
 
     def test_create_nodes_neptune(self) -> None:
-        nodes = self.table_owner.create_nodes()
-
         expected_node1 = {
             NEPTUNE_HEADER_ID: User.USER_NODE_KEY_FORMAT.format(email=owner1),
             NEPTUNE_HEADER_LABEL: User.USER_NODE_LABEL,
@@ -83,19 +81,18 @@ class TestTableOwner(unittest.TestCase):
             NEPTUNE_CREATION_TYPE_NODE_PROPERTY_NAME_BULK_LOADER_FORMAT: NEPTUNE_CREATION_TYPE_JOB,
             User.USER_NODE_EMAIL + ":String(single)": owner2
         }
+        expected = [expected_node1, expected_node2]
 
-        actual_nodes = [
-            neptune_serializer.convert_node(node)
-            for node in nodes
-        ]
+        actual = []
+        node = self.table_owner.create_next_node()
+        while node:
+            serialized_node = neptune_serializer.convert_node(node)
+            actual.append(serialized_node)
+            node = self.table_owner.create_next_node()
 
-        self.assertTrue(expected_node1 in actual_nodes)
-        self.assertTrue(expected_node2 in actual_nodes)
+        self.assertEqual(actual, expected)
 
     def test_create_relation(self) -> None:
-        relations = self.table_owner.create_relation()
-        self.assertEqual(len(relations), 2)
-
         expected_relation1 = {
             RELATION_START_KEY: owner1,
             RELATION_START_LABEL: User.USER_NODE_LABEL,
@@ -112,49 +109,81 @@ class TestTableOwner(unittest.TestCase):
             RELATION_TYPE: TableOwner.OWNER_TABLE_RELATION_TYPE,
             RELATION_REVERSE_TYPE: TableOwner.TABLE_OWNER_RELATION_TYPE
         }
+        expected = [expected_relation1, expected_relation2]
 
-        actual_relations = [
-            neo4_serializer.serialize_relationship(relation)
-            for relation in relations
-        ]
+        actual = []
+        relation = self.table_owner.create_next_relation()
+        while relation:
+            serialized_relation = neo4_serializer.serialize_relationship(relation)
+            actual.append(serialized_relation)
+            relation = self.table_owner.create_next_relation()
 
-        self.assertTrue(expected_relation1 in actual_relations)
-        self.assertTrue(expected_relation2 in actual_relations)
+        self.assertEqual(actual, expected)
 
     def test_create_relation_neptune(self) -> None:
-        relations = self.table_owner.create_relation()
         expected = [
-            {
-                NEPTUNE_HEADER_ID: "{from_vertex_id}_{to_vertex_id}_{label}".format(
-                    from_vertex_id=owner1,
-                    to_vertex_id=self.table_owner.get_metadata_model_key(),
-                    label=TableOwner.OWNER_TABLE_RELATION_TYPE
-                ),
-                NEPTUNE_RELATIONSHIP_HEADER_FROM: owner1,
-                NEPTUNE_RELATIONSHIP_HEADER_TO: self.table_owner.get_metadata_model_key(),
-                NEPTUNE_HEADER_LABEL: TableOwner.OWNER_TABLE_RELATION_TYPE,
-                NEPTUNE_LAST_EXTRACTED_AT_RELATIONSHIP_PROPERTY_NAME_BULK_LOADER_FORMAT: ANY,
-                NEPTUNE_CREATION_TYPE_RELATIONSHIP_PROPERTY_NAME_BULK_LOADER_FORMAT: NEPTUNE_CREATION_TYPE_JOB
-            },
-            {
-                NEPTUNE_HEADER_ID: "{from_vertex_id}_{to_vertex_id}_{label}".format(
-                    from_vertex_id=self.table_owner.get_metadata_model_key(),
-                    to_vertex_id=owner1,
-                    label=TableOwner.TABLE_OWNER_RELATION_TYPE
-                ),
-                NEPTUNE_RELATIONSHIP_HEADER_FROM: self.table_owner.get_metadata_model_key(),
-                NEPTUNE_RELATIONSHIP_HEADER_TO: owner1,
-                NEPTUNE_HEADER_LABEL: TableOwner.TABLE_OWNER_RELATION_TYPE,
-                NEPTUNE_LAST_EXTRACTED_AT_RELATIONSHIP_PROPERTY_NAME_BULK_LOADER_FORMAT: ANY,
-                NEPTUNE_CREATION_TYPE_RELATIONSHIP_PROPERTY_NAME_BULK_LOADER_FORMAT: NEPTUNE_CREATION_TYPE_JOB
-            }
+            [
+                {
+                    NEPTUNE_HEADER_ID: "{from_vertex_id}_{to_vertex_id}_{label}".format(
+                        from_vertex_id=owner1,
+                        to_vertex_id=self.table_owner.get_metadata_model_key(),
+                        label=TableOwner.OWNER_TABLE_RELATION_TYPE
+                    ),
+                    NEPTUNE_RELATIONSHIP_HEADER_FROM: owner1,
+                    NEPTUNE_RELATIONSHIP_HEADER_TO: self.table_owner.get_metadata_model_key(),
+                    NEPTUNE_HEADER_LABEL: TableOwner.OWNER_TABLE_RELATION_TYPE,
+                    NEPTUNE_LAST_EXTRACTED_AT_RELATIONSHIP_PROPERTY_NAME_BULK_LOADER_FORMAT: ANY,
+                    NEPTUNE_CREATION_TYPE_RELATIONSHIP_PROPERTY_NAME_BULK_LOADER_FORMAT: NEPTUNE_CREATION_TYPE_JOB
+                },
+                {
+                    NEPTUNE_HEADER_ID: "{from_vertex_id}_{to_vertex_id}_{label}".format(
+                        from_vertex_id=self.table_owner.get_metadata_model_key(),
+                        to_vertex_id=owner1,
+                        label=TableOwner.TABLE_OWNER_RELATION_TYPE
+                    ),
+                    NEPTUNE_RELATIONSHIP_HEADER_FROM: self.table_owner.get_metadata_model_key(),
+                    NEPTUNE_RELATIONSHIP_HEADER_TO: owner1,
+                    NEPTUNE_HEADER_LABEL: TableOwner.TABLE_OWNER_RELATION_TYPE,
+                    NEPTUNE_LAST_EXTRACTED_AT_RELATIONSHIP_PROPERTY_NAME_BULK_LOADER_FORMAT: ANY,
+                    NEPTUNE_CREATION_TYPE_RELATIONSHIP_PROPERTY_NAME_BULK_LOADER_FORMAT: NEPTUNE_CREATION_TYPE_JOB
+                }
+            ],
+            [
+                {
+                    NEPTUNE_HEADER_ID: "{from_vertex_id}_{to_vertex_id}_{label}".format(
+                        from_vertex_id=owner2,
+                        to_vertex_id=self.table_owner.get_metadata_model_key(),
+                        label=TableOwner.OWNER_TABLE_RELATION_TYPE
+                    ),
+                    NEPTUNE_RELATIONSHIP_HEADER_FROM: owner2,
+                    NEPTUNE_RELATIONSHIP_HEADER_TO: self.table_owner.get_metadata_model_key(),
+                    NEPTUNE_HEADER_LABEL: TableOwner.OWNER_TABLE_RELATION_TYPE,
+                    NEPTUNE_LAST_EXTRACTED_AT_RELATIONSHIP_PROPERTY_NAME_BULK_LOADER_FORMAT: ANY,
+                    NEPTUNE_CREATION_TYPE_RELATIONSHIP_PROPERTY_NAME_BULK_LOADER_FORMAT: NEPTUNE_CREATION_TYPE_JOB
+                },
+                {
+                    NEPTUNE_HEADER_ID: "{from_vertex_id}_{to_vertex_id}_{label}".format(
+                        from_vertex_id=self.table_owner.get_metadata_model_key(),
+                        to_vertex_id=owner2,
+                        label=TableOwner.TABLE_OWNER_RELATION_TYPE
+                    ),
+                    NEPTUNE_RELATIONSHIP_HEADER_FROM: self.table_owner.get_metadata_model_key(),
+                    NEPTUNE_RELATIONSHIP_HEADER_TO: owner2,
+                    NEPTUNE_HEADER_LABEL: TableOwner.TABLE_OWNER_RELATION_TYPE,
+                    NEPTUNE_LAST_EXTRACTED_AT_RELATIONSHIP_PROPERTY_NAME_BULK_LOADER_FORMAT: ANY,
+                    NEPTUNE_CREATION_TYPE_RELATIONSHIP_PROPERTY_NAME_BULK_LOADER_FORMAT: NEPTUNE_CREATION_TYPE_JOB
+                }
+            ]
         ]
 
-        actual_relations = [
-            neptune_serializer.convert_relationship(relation)
-            for relation in relations
-        ]
-        self.assertTrue(expected in actual_relations)
+        actual = []
+        relation = self.table_owner.create_next_relation()
+        while relation:
+            serialized_relation = neptune_serializer.convert_relationship(relation)
+            actual.append(serialized_relation)
+            relation = self.table_owner.create_next_relation()
+
+        self.assertEqual(expected, actual)
 
     def test_create_nodes_with_owners_list(self) -> None:
         self.table_owner_list = TableOwner(db_name='hive',
@@ -162,9 +191,6 @@ class TestTableOwner(unittest.TestCase):
                                            table_name=TABLE,
                                            cluster=CLUSTER,
                                            owners=['user1@1', ' user2@2 '])
-        nodes = self.table_owner_list.create_nodes()
-        self.assertEqual(len(nodes), 2)
-
         expected_node1 = {
             NODE_KEY: User.USER_NODE_KEY_FORMAT.format(email=owner1),
             NODE_LABEL: User.USER_NODE_LABEL,
@@ -175,10 +201,13 @@ class TestTableOwner(unittest.TestCase):
             NODE_LABEL: User.USER_NODE_LABEL,
             User.USER_NODE_EMAIL: owner2
         }
-        actual_nodes = [
-            neo4_serializer.serialize_node(node)
-            for node in nodes
-        ]
+        expected = [expected_node1, expected_node2]
 
-        self.assertTrue(expected_node1 in actual_nodes)
-        self.assertTrue(expected_node2 in actual_nodes)
+        actual = []
+        node = self.table_owner_list.create_next_node()
+        while node:
+            serialized_node = neo4_serializer.serialize_node(node)
+            actual.append(serialized_node)
+            node = self.table_owner_list.create_next_node()
+
+        self.assertEqual(actual, expected)

--- a/tests/unit/models/test_table_source.py
+++ b/tests/unit/models/test_table_source.py
@@ -45,54 +45,76 @@ class TestTableSource(unittest.TestCase):
         self.assertEqual(metadata, 'hive://default.base/test')
 
     def test_create_nodes(self) -> None:
-        nodes = self.table_source.create_nodes()
-        self.assertEqual(len(nodes), 1)
+        expected_nodes = [{
+            'LABEL': 'Source',
+            'KEY': f'{DB}://{CLUSTER}.{SCHEMA}/{TABLE}/_source',
+            'source': SOURCE,
+            'source_type': 'github'
+        }]
+
+        actual = []
+        node = self.table_source.create_next_node()
+        while node:
+            serialized_node = neo4_serializer.serialize_node(node)
+            actual.append(serialized_node)
+            node = self.table_source.create_next_node()
+
+        self.assertEqual(expected_nodes, actual)
 
     def test_create_relation(self) -> None:
-        relations = self.table_source.create_relation()
-        self.assertEquals(len(relations), 1)
-        serialized_relation = neo4_serializer.serialize_relationship(relations[0])
-
-        expected_relation = {
+        expected_relations = [{
             RELATION_START_KEY: self.start_key,
             RELATION_START_LABEL: TableSource.LABEL,
             RELATION_END_KEY: self.end_key,
             RELATION_END_LABEL: 'Table',
             RELATION_TYPE: TableSource.SOURCE_TABLE_RELATION_TYPE,
             RELATION_REVERSE_TYPE: TableSource.TABLE_SOURCE_RELATION_TYPE
-        }
+        }]
 
-        self.assertDictEqual(expected_relation, serialized_relation)
+        actual = []
+        relation = self.table_source.create_next_relation()
+        while relation:
+            serialized_relation = neo4_serializer.serialize_relationship(relation)
+            actual.append(serialized_relation)
+            relation = self.table_source.create_next_relation()
+
+        self.assertEqual(expected_relations, actual)
 
     def test_create_relation_neptune(self) -> None:
-        relations = self.table_source.create_relation()
-        serialized_relations = neptune_serializer.convert_relationship(relations[0])
-
         expected = [
-            {
-                NEPTUNE_HEADER_ID: "{from_vertex_id}_{to_vertex_id}_{label}".format(
-                    from_vertex_id=self.start_key,
-                    to_vertex_id=self.end_key,
-                    label=TableSource.SOURCE_TABLE_RELATION_TYPE
-                ),
-                NEPTUNE_RELATIONSHIP_HEADER_FROM: self.start_key,
-                NEPTUNE_RELATIONSHIP_HEADER_TO: self.end_key,
-                NEPTUNE_HEADER_LABEL: TableSource.SOURCE_TABLE_RELATION_TYPE,
-                NEPTUNE_LAST_EXTRACTED_AT_RELATIONSHIP_PROPERTY_NAME_BULK_LOADER_FORMAT: ANY,
-                NEPTUNE_CREATION_TYPE_RELATIONSHIP_PROPERTY_NAME_BULK_LOADER_FORMAT: NEPTUNE_CREATION_TYPE_JOB
-            },
-            {
-                NEPTUNE_HEADER_ID: "{from_vertex_id}_{to_vertex_id}_{label}".format(
-                    from_vertex_id=self.end_key,
-                    to_vertex_id=self.start_key,
-                    label=TableSource.TABLE_SOURCE_RELATION_TYPE
-                ),
-                NEPTUNE_RELATIONSHIP_HEADER_FROM: self.end_key,
-                NEPTUNE_RELATIONSHIP_HEADER_TO: self.start_key,
-                NEPTUNE_HEADER_LABEL: TableSource.TABLE_SOURCE_RELATION_TYPE,
-                NEPTUNE_LAST_EXTRACTED_AT_RELATIONSHIP_PROPERTY_NAME_BULK_LOADER_FORMAT: ANY,
-                NEPTUNE_CREATION_TYPE_RELATIONSHIP_PROPERTY_NAME_BULK_LOADER_FORMAT: NEPTUNE_CREATION_TYPE_JOB
-            }
+            [
+                {
+                    NEPTUNE_HEADER_ID: "{from_vertex_id}_{to_vertex_id}_{label}".format(
+                        from_vertex_id=self.start_key,
+                        to_vertex_id=self.end_key,
+                        label=TableSource.SOURCE_TABLE_RELATION_TYPE
+                    ),
+                    NEPTUNE_RELATIONSHIP_HEADER_FROM: self.start_key,
+                    NEPTUNE_RELATIONSHIP_HEADER_TO: self.end_key,
+                    NEPTUNE_HEADER_LABEL: TableSource.SOURCE_TABLE_RELATION_TYPE,
+                    NEPTUNE_LAST_EXTRACTED_AT_RELATIONSHIP_PROPERTY_NAME_BULK_LOADER_FORMAT: ANY,
+                    NEPTUNE_CREATION_TYPE_RELATIONSHIP_PROPERTY_NAME_BULK_LOADER_FORMAT: NEPTUNE_CREATION_TYPE_JOB
+                },
+                {
+                    NEPTUNE_HEADER_ID: "{from_vertex_id}_{to_vertex_id}_{label}".format(
+                        from_vertex_id=self.end_key,
+                        to_vertex_id=self.start_key,
+                        label=TableSource.TABLE_SOURCE_RELATION_TYPE
+                    ),
+                    NEPTUNE_RELATIONSHIP_HEADER_FROM: self.end_key,
+                    NEPTUNE_RELATIONSHIP_HEADER_TO: self.start_key,
+                    NEPTUNE_HEADER_LABEL: TableSource.TABLE_SOURCE_RELATION_TYPE,
+                    NEPTUNE_LAST_EXTRACTED_AT_RELATIONSHIP_PROPERTY_NAME_BULK_LOADER_FORMAT: ANY,
+                    NEPTUNE_CREATION_TYPE_RELATIONSHIP_PROPERTY_NAME_BULK_LOADER_FORMAT: NEPTUNE_CREATION_TYPE_JOB
+                }
+            ]
         ]
 
-        self.assertListEqual(expected, serialized_relations)
+        actual = []
+        relation = self.table_source.create_next_relation()
+        while relation:
+            serialized_relation = neptune_serializer.convert_relationship(relation)
+            actual.append(serialized_relation)
+            relation = self.table_source.create_next_relation()
+
+        self.assertListEqual(expected, actual)

--- a/tests/unit/models/test_table_stats.py
+++ b/tests/unit/models/test_table_stats.py
@@ -29,23 +29,23 @@ class TestTableStats(unittest.TestCase):
                                             start_epoch='1',
                                             end_epoch='2',)
 
-        self.expected_node_result = {
+        self.expected_node_results = [{
             NODE_KEY: 'hive://gold.base/test/col/avg/',
             NODE_LABEL: 'Stat',
             'stat_val': '1',
             'stat_name': 'avg',
             'start_epoch': '1',
             'end_epoch': '2',
-        }
+        }]
 
-        self.expected_relation_result = {
+        self.expected_relation_results = [{
             RELATION_START_KEY: 'hive://gold.base/test/col/avg/',
             RELATION_START_LABEL: 'Stat',
             RELATION_END_KEY: 'hive://gold.base/test/col',
             RELATION_END_LABEL: 'Column',
             RELATION_TYPE: 'STAT_OF',
             RELATION_REVERSE_TYPE: 'STAT'
-        }
+        }]
 
     def test_get_table_stat_model_key(self) -> None:
         table_stats = self.table_stats.get_table_stat_model_key()
@@ -56,27 +56,27 @@ class TestTableStats(unittest.TestCase):
         self.assertEqual(metadata, 'hive://gold.base/test/col')
 
     def test_create_nodes(self) -> None:
-        nodes = self.table_stats.create_nodes()
-        self.assertEquals(len(nodes), 1)
-        serialized_node = neo4_serializer.serialize_node(nodes[0])
-        self.assertEquals(serialized_node, self.expected_node_result)
+        actual = []
+        node = self.table_stats.create_next_node()
+        while node:
+            serialized_node = neo4_serializer.serialize_node(node)
+            actual.append(serialized_node)
+            node = self.table_stats.create_next_node()
+
+        self.assertEquals(actual, self.expected_node_results)
 
     def test_create_relation(self) -> None:
-        relation = self.table_stats.create_relation()
+        actual = []
+        relation = self.table_stats.create_next_relation()
+        while relation:
+            serialized_relation = neo4_serializer.serialize_relationship(relation)
+            actual.append(serialized_relation)
+            relation = self.table_stats.create_next_relation()
 
-        self.assertEquals(len(relation), 1)
-        serialized_relation = neo4_serializer.serialize_relationship(relation[0])
-        self.assertEquals(serialized_relation, self.expected_relation_result)
+        self.assertEquals(actual, self.expected_relation_results)
 
-    def test_create_next_node(self) -> None:
-        next_node = self.table_stats.create_next_node()
-        serialized_node = neo4_serializer.serialize_node(next_node)
-        self.assertEquals(serialized_node, self.expected_node_result)
-
-    def test_create_next_node_neptune(self) -> None:
-        next_node = self.table_stats.create_next_node()
-        serialized_node = neptune_serializer.convert_node(next_node)
-        expected_neptune_node = {
+    def test_create_nodes_neptune(self) -> None:
+        expected_neptune_nodes = [{
             NEPTUNE_HEADER_ID: 'hive://gold.base/test/col/avg/',
             NEPTUNE_HEADER_LABEL: 'Stat',
             NEPTUNE_LAST_EXTRACTED_AT_RELATIONSHIP_PROPERTY_NAME_BULK_LOADER_FORMAT: ANY,
@@ -85,52 +85,52 @@ class TestTableStats(unittest.TestCase):
             'stat_name:String(single)': 'avg',
             'start_epoch:String(single)': '1',
             'end_epoch:String(single)': '2',
-        }
-        self.assertDictEqual(serialized_node, expected_neptune_node)
+        }]
 
-    def test_create_next_relation(self) -> None:
-        next_relation = self.table_stats.create_next_relation()
-        serialized_relation = neo4_serializer.serialize_relationship(next_relation)
-        self.assertEquals(serialized_relation, self.expected_relation_result)
+        actual = []
+        next_node = self.table_stats.create_next_node()
+        while next_node:
+            serialized_node = neptune_serializer.convert_node(next_node)
+            actual.append(serialized_node)
+            next_node = self.table_stats.create_next_node()
 
-    def test_create_next_relation_neptune(self) -> None:
-        next_relation = self.table_stats.create_next_relation()
+        self.assertEqual(actual, expected_neptune_nodes)
 
-        self.expected_relation_result = {
-            RELATION_START_KEY: 'hive://gold.base/test/col/avg/',
-            RELATION_START_LABEL: 'Stat',
-            RELATION_END_KEY: 'hive://gold.base/test/col',
-            RELATION_END_LABEL: 'Column',
-            RELATION_TYPE: 'STAT_OF',
-            RELATION_REVERSE_TYPE: 'STAT'
-        }
-
+    def test_create_relations_neptune(self) -> None:
         expected = [
-            {
-                NEPTUNE_HEADER_ID: "{from_vertex_id}_{to_vertex_id}_{label}".format(
-                    from_vertex_id='hive://gold.base/test/col/avg/',
-                    to_vertex_id='hive://gold.base/test/col',
-                    label='STAT_OF'
-                ),
-                NEPTUNE_RELATIONSHIP_HEADER_FROM: 'hive://gold.base/test/col/avg/',
-                NEPTUNE_RELATIONSHIP_HEADER_TO: 'hive://gold.base/test/col',
-                NEPTUNE_HEADER_LABEL: 'STAT_OF',
-                NEPTUNE_LAST_EXTRACTED_AT_RELATIONSHIP_PROPERTY_NAME_BULK_LOADER_FORMAT: ANY,
-                NEPTUNE_CREATION_TYPE_RELATIONSHIP_PROPERTY_NAME_BULK_LOADER_FORMAT: NEPTUNE_CREATION_TYPE_JOB
-            },
-            {
-                NEPTUNE_HEADER_ID: "{from_vertex_id}_{to_vertex_id}_{label}".format(
-                    from_vertex_id='hive://gold.base/test/col',
-                    to_vertex_id='hive://gold.base/test/col/avg/',
-                    label='STAT'
-                ),
-                NEPTUNE_RELATIONSHIP_HEADER_FROM: 'hive://gold.base/test/col',
-                NEPTUNE_RELATIONSHIP_HEADER_TO: 'hive://gold.base/test/col/avg/',
-                NEPTUNE_HEADER_LABEL: 'STAT',
-                NEPTUNE_LAST_EXTRACTED_AT_RELATIONSHIP_PROPERTY_NAME_BULK_LOADER_FORMAT: ANY,
-                NEPTUNE_CREATION_TYPE_RELATIONSHIP_PROPERTY_NAME_BULK_LOADER_FORMAT: NEPTUNE_CREATION_TYPE_JOB
-            }
+            [
+                {
+                    NEPTUNE_HEADER_ID: "{from_vertex_id}_{to_vertex_id}_{label}".format(
+                        from_vertex_id='hive://gold.base/test/col/avg/',
+                        to_vertex_id='hive://gold.base/test/col',
+                        label='STAT_OF'
+                    ),
+                    NEPTUNE_RELATIONSHIP_HEADER_FROM: 'hive://gold.base/test/col/avg/',
+                    NEPTUNE_RELATIONSHIP_HEADER_TO: 'hive://gold.base/test/col',
+                    NEPTUNE_HEADER_LABEL: 'STAT_OF',
+                    NEPTUNE_LAST_EXTRACTED_AT_RELATIONSHIP_PROPERTY_NAME_BULK_LOADER_FORMAT: ANY,
+                    NEPTUNE_CREATION_TYPE_RELATIONSHIP_PROPERTY_NAME_BULK_LOADER_FORMAT: NEPTUNE_CREATION_TYPE_JOB
+                },
+                {
+                    NEPTUNE_HEADER_ID: "{from_vertex_id}_{to_vertex_id}_{label}".format(
+                        from_vertex_id='hive://gold.base/test/col',
+                        to_vertex_id='hive://gold.base/test/col/avg/',
+                        label='STAT'
+                    ),
+                    NEPTUNE_RELATIONSHIP_HEADER_FROM: 'hive://gold.base/test/col',
+                    NEPTUNE_RELATIONSHIP_HEADER_TO: 'hive://gold.base/test/col/avg/',
+                    NEPTUNE_HEADER_LABEL: 'STAT',
+                    NEPTUNE_LAST_EXTRACTED_AT_RELATIONSHIP_PROPERTY_NAME_BULK_LOADER_FORMAT: ANY,
+                    NEPTUNE_CREATION_TYPE_RELATIONSHIP_PROPERTY_NAME_BULK_LOADER_FORMAT: NEPTUNE_CREATION_TYPE_JOB
+                }
+            ]
         ]
 
-        serialized_relation = neptune_serializer.convert_relationship(next_relation)
-        self.assertListEqual(serialized_relation, expected)
+        actual = []
+        next_relation = self.table_stats.create_next_relation()
+        while next_relation:
+            serialized_relation = neptune_serializer.convert_relationship(next_relation)
+            actual.append(serialized_relation)
+            next_relation = self.table_stats.create_next_relation()
+
+        self.assertListEqual(actual, expected)

--- a/tests/unit/models/test_user.py
+++ b/tests/unit/models/test_user.py
@@ -23,7 +23,7 @@ class TestUser(unittest.TestCase):
         super(TestUser, self).setUp()
         self.user = User(first_name='test_first',
                          last_name='test_last',
-                         name='test_first test_last',
+                         full_name='test_first test_last',
                          email='test@email.com',
                          github_username='github_test',
                          team_name='test_team',
@@ -39,13 +39,35 @@ class TestUser(unittest.TestCase):
         self.assertEqual(user_email, 'test@email.com')
 
     def test_create_nodes(self) -> None:
-        nodes = self.user.create_nodes()
-        self.assertEqual(len(nodes), 1)
+        expected_nodes = [{
+            'LABEL': 'User',
+            'KEY': 'test@email.com',
+            'email': 'test@email.com',
+            'is_active:UNQUOTED': True,
+            'first_name': 'test_first',
+            'last_name': 'test_last',
+            'full_name': 'test_first test_last',
+            'github_username': 'github_test',
+            'team_name': 'test_team',
+            'employee_type': 'FTE',
+            'slack_id': 'slack',
+            'role_name': 'swe',
+            'updated_at:UNQUOTED': 1
+        }]
+
+        actual = []
+        node = self.user.create_next_node()
+        while node:
+            serialized_node = neo4_serializer.serialize_node(node)
+            actual.append(serialized_node)
+            node = self.user.create_next_node()
+
+        self.assertEqual(actual, expected_nodes)
 
     def test_create_node_additional_attr(self) -> None:
         test_user = User(first_name='test_first',
                          last_name='test_last',
-                         name='test_first test_last',
+                         full_name='test_first test_last',
                          email='test@email.com',
                          github_username='github_test',
                          team_name='test_team',
@@ -56,8 +78,8 @@ class TestUser(unittest.TestCase):
                          updated_at=1,
                          role_name='swe',
                          enable_notify=True)
-        nodes = test_user.create_nodes()
-        serialized_node = neo4_serializer.serialize_node(nodes[0])
+        node = test_user.create_next_node()
+        serialized_node = neo4_serializer.serialize_node(node)
         self.assertEqual(serialized_node['email'], 'test@email.com')
         self.assertEqual(serialized_node['role_name'], 'swe')
         self.assertTrue(serialized_node['enable_notify:UNQUOTED'])
@@ -65,7 +87,7 @@ class TestUser(unittest.TestCase):
     def test_create_node_additional_attr_neptune(self) -> None:
         test_user = User(first_name='test_first',
                          last_name='test_last',
-                         name='test_first test_last',
+                         full_name='test_first test_last',
                          email='test@email.com',
                          github_username='github_test',
                          team_name='test_team',
@@ -76,66 +98,75 @@ class TestUser(unittest.TestCase):
                          updated_at=1,
                          role_name='swe',
                          enable_notify=True)
-        nodes = test_user.create_nodes()
-        serialized_node = neptune_serializer.convert_node(nodes[0])
+        node = test_user.create_next_node()
+        serialized_node = neptune_serializer.convert_node(node)
         self.assertEqual(serialized_node['email:String(single)'], 'test@email.com')
         self.assertEqual(serialized_node['role_name:String(single)'], 'swe')
         self.assertTrue(serialized_node['enable_notify:Bool(single)'])
 
     def test_create_relation(self) -> None:
-        relations = self.user.create_relation()
-        self.assertEqual(len(relations), 1)
-
         start_key = 'test@email.com'
         end_key = 'test_manager@email.com'
 
-        expected_relation = {
+        expected_relations = [{
             RELATION_START_KEY: start_key,
             RELATION_START_LABEL: User.USER_NODE_LABEL,
             RELATION_END_KEY: end_key,
             RELATION_END_LABEL: User.USER_NODE_LABEL,
             RELATION_TYPE: User.USER_MANAGER_RELATION_TYPE,
             RELATION_REVERSE_TYPE: User.MANAGER_USER_RELATION_TYPE
-        }
+        }]
 
-        self.assertTrue(expected_relation, neo4_serializer.serialize_relationship(relations[0]))
+        actual = []
+        relation = self.user.create_next_relation()
+        while relation:
+            serialized_relation = neo4_serializer.serialize_relationship(relation)
+            actual.append(serialized_relation)
+            relation = self.user.create_next_relation()
+
+        self.assertTrue(expected_relations, actual)
 
     def test_create_relation_neptune(self) -> None:
-        relations = self.user.create_relation()
-
-        serialized = neptune_serializer.convert_relationship(relations[0])
-
         start_key = '{email}'.format(email='test@email.com')
         end_key = '{email}'.format(email='test_manager@email.com')
 
         expected = [
-            {
-                NEPTUNE_HEADER_ID: "{from_vertex_id}_{to_vertex_id}_{label}".format(
-                    from_vertex_id=start_key,
-                    to_vertex_id=end_key,
-                    label=User.USER_MANAGER_RELATION_TYPE
-                ),
-                NEPTUNE_RELATIONSHIP_HEADER_FROM: start_key,
-                NEPTUNE_RELATIONSHIP_HEADER_TO: end_key,
-                NEPTUNE_HEADER_LABEL: User.USER_MANAGER_RELATION_TYPE,
-                NEPTUNE_LAST_EXTRACTED_AT_RELATIONSHIP_PROPERTY_NAME_BULK_LOADER_FORMAT: ANY,
-                NEPTUNE_CREATION_TYPE_RELATIONSHIP_PROPERTY_NAME_BULK_LOADER_FORMAT: NEPTUNE_CREATION_TYPE_JOB
-            },
-            {
-                NEPTUNE_HEADER_ID: "{from_vertex_id}_{to_vertex_id}_{label}".format(
-                    from_vertex_id=end_key,
-                    to_vertex_id=start_key,
-                    label=User.MANAGER_USER_RELATION_TYPE
-                ),
-                NEPTUNE_RELATIONSHIP_HEADER_FROM: end_key,
-                NEPTUNE_RELATIONSHIP_HEADER_TO: start_key,
-                NEPTUNE_HEADER_LABEL: User.MANAGER_USER_RELATION_TYPE,
-                NEPTUNE_LAST_EXTRACTED_AT_RELATIONSHIP_PROPERTY_NAME_BULK_LOADER_FORMAT: ANY,
-                NEPTUNE_CREATION_TYPE_RELATIONSHIP_PROPERTY_NAME_BULK_LOADER_FORMAT: NEPTUNE_CREATION_TYPE_JOB
-            }
+            [
+                {
+                    NEPTUNE_HEADER_ID: "{from_vertex_id}_{to_vertex_id}_{label}".format(
+                        from_vertex_id=start_key,
+                        to_vertex_id=end_key,
+                        label=User.USER_MANAGER_RELATION_TYPE
+                    ),
+                    NEPTUNE_RELATIONSHIP_HEADER_FROM: start_key,
+                    NEPTUNE_RELATIONSHIP_HEADER_TO: end_key,
+                    NEPTUNE_HEADER_LABEL: User.USER_MANAGER_RELATION_TYPE,
+                    NEPTUNE_LAST_EXTRACTED_AT_RELATIONSHIP_PROPERTY_NAME_BULK_LOADER_FORMAT: ANY,
+                    NEPTUNE_CREATION_TYPE_RELATIONSHIP_PROPERTY_NAME_BULK_LOADER_FORMAT: NEPTUNE_CREATION_TYPE_JOB
+                },
+                {
+                    NEPTUNE_HEADER_ID: "{from_vertex_id}_{to_vertex_id}_{label}".format(
+                        from_vertex_id=end_key,
+                        to_vertex_id=start_key,
+                        label=User.MANAGER_USER_RELATION_TYPE
+                    ),
+                    NEPTUNE_RELATIONSHIP_HEADER_FROM: end_key,
+                    NEPTUNE_RELATIONSHIP_HEADER_TO: start_key,
+                    NEPTUNE_HEADER_LABEL: User.MANAGER_USER_RELATION_TYPE,
+                    NEPTUNE_LAST_EXTRACTED_AT_RELATIONSHIP_PROPERTY_NAME_BULK_LOADER_FORMAT: ANY,
+                    NEPTUNE_CREATION_TYPE_RELATIONSHIP_PROPERTY_NAME_BULK_LOADER_FORMAT: NEPTUNE_CREATION_TYPE_JOB
+                }
+            ]
         ]
 
-        self.assertListEqual(serialized, expected)
+        actual = []
+        relation = self.user.create_next_relation()
+        while relation:
+            serialized = neptune_serializer.convert_relationship(relation)
+            actual.append(serialized)
+            relation = self.user.create_next_relation()
+
+        self.assertListEqual(actual, expected)
 
     def test_not_including_empty_attribute(self) -> None:
         test_user = User(email='test@email.com',

--- a/tests/unit/models/test_watermark.py
+++ b/tests/unit/models/test_watermark.py
@@ -4,8 +4,6 @@
 import unittest
 from unittest.mock import ANY
 
-from databuilder.models.graph_node import GraphNode
-from databuilder.models.graph_relationship import GraphRelationship
 from databuilder.models.graph_serializable import (
     NODE_KEY, NODE_LABEL, RELATION_END_KEY, RELATION_END_LABEL, RELATION_REVERSE_TYPE, RELATION_START_KEY,
     RELATION_START_LABEL, RELATION_TYPE,
@@ -43,42 +41,23 @@ class TestWatermark(unittest.TestCase):
         )
         self.start_key = f'{DATABASE}://{CLUSTER}.{SCHEMA}/{TABLE}/{PART_TYPE}/'
         self.end_key = f'{DATABASE}://{CLUSTER}.{SCHEMA}/{TABLE}'
-        self.expected_node_result = GraphNode(
-            key=self.start_key,
-            label='Watermark',
-            attributes={
-                'partition_key': 'ds',
-                'partition_value': '2017-09-18/feature_id=9',
-                'create_time': '2017-09-18T00:00:00'
-            }
-        )
 
-        self.expected_serialized_node_result = {
+        self.expected_serialized_node_results = [{
             NODE_KEY: self.start_key,
             NODE_LABEL: 'Watermark',
             'partition_key': 'ds',
             'partition_value': '2017-09-18/feature_id=9',
             'create_time': '2017-09-18T00:00:00'
-        }
+        }]
 
-        self.expected_relation_result = GraphRelationship(
-            start_label='Watermark',
-            end_label='Table',
-            start_key=self.start_key,
-            end_key=self.end_key,
-            type='BELONG_TO_TABLE',
-            reverse_type='WATERMARK',
-            attributes={}
-        )
-
-        self.expected_serialized_relation_result = {
+        self.expected_serialized_relation_results = [{
             RELATION_START_KEY: self.start_key,
             RELATION_START_LABEL: 'Watermark',
             RELATION_END_KEY: self.end_key,
             RELATION_END_LABEL: 'Table',
             RELATION_TYPE: 'BELONG_TO_TABLE',
             RELATION_REVERSE_TYPE: 'WATERMARK'
-        }
+        }]
 
     def test_get_watermark_model_key(self) -> None:
         watermark = self.watermark.get_watermark_model_key()
@@ -89,16 +68,17 @@ class TestWatermark(unittest.TestCase):
         self.assertEqual(metadata, f'{DATABASE}://{CLUSTER}.{SCHEMA}/{TABLE}')
 
     def test_create_nodes(self) -> None:
-        nodes = self.watermark.create_nodes()
-        self.assertEquals(len(nodes), 1)
+        actual = []
+        node = self.watermark.create_next_node()
+        while node:
+            serialized_node = neo4_serializer.serialize_node(node)
+            actual.append(serialized_node)
+            node = self.watermark.create_next_node()
 
-        self.assertEquals(nodes[0], self.expected_node_result)
-        self.assertEqual(neo4_serializer.serialize_node(nodes[0]), self.expected_serialized_node_result)
+        self.assertEqual(actual, self.expected_serialized_node_results)
 
     def test_create_nodes_neptune(self) -> None:
-        nodes = self.watermark.create_nodes()
-
-        expected_serialized_node_result = {
+        expected_serialized_node_results = [{
             NEPTUNE_HEADER_ID: self.start_key,
             NEPTUNE_HEADER_LABEL: 'Watermark',
             NEPTUNE_LAST_EXTRACTED_AT_RELATIONSHIP_PROPERTY_NAME_BULK_LOADER_FORMAT: ANY,
@@ -106,56 +86,62 @@ class TestWatermark(unittest.TestCase):
             'partition_key:String(single)': 'ds',
             'partition_value:String(single)': '2017-09-18/feature_id=9',
             'create_time:String(single)': '2017-09-18T00:00:00'
-        }
+        }]
 
-        serialized_node = neptune_serializer.convert_node(nodes[0])
-        self.assertDictEqual(expected_serialized_node_result, serialized_node)
+        actual = []
+        node = self.watermark.create_next_node()
+        while node:
+            serialized_node = neptune_serializer.convert_node(node)
+            actual.append(serialized_node)
+            node = self.watermark.create_next_node()
+
+        self.assertEqual(expected_serialized_node_results, actual)
 
     def test_create_relation(self) -> None:
-        relation = self.watermark.create_relation()
-        self.assertEquals(len(relation), 1)
-        self.assertEquals(relation[0], self.expected_relation_result)
-        self.assertEqual(neo4_serializer.serialize_relationship(relation[0]), self.expected_serialized_relation_result)
+        actual = []
+        relation = self.watermark.create_next_relation()
+        while relation:
+            serialized_relation = neo4_serializer.serialize_relationship(relation)
+            actual.append(serialized_relation)
+            relation = self.watermark.create_next_relation()
+
+        self.assertEqual(actual, self.expected_serialized_relation_results)
 
     def test_create_relation_neptune(self) -> None:
-        relation = self.watermark.create_relation()
-        serialized_relation = neptune_serializer.convert_relationship(relation[0])
         expected = [
-            {
-                NEPTUNE_HEADER_ID: "{from_vertex_id}_{to_vertex_id}_{label}".format(
-                    from_vertex_id=self.start_key,
-                    to_vertex_id=self.end_key,
-                    label='BELONG_TO_TABLE'
-                ),
-                NEPTUNE_RELATIONSHIP_HEADER_FROM: self.start_key,
-                NEPTUNE_RELATIONSHIP_HEADER_TO: self.end_key,
-                NEPTUNE_HEADER_LABEL: 'BELONG_TO_TABLE',
-                NEPTUNE_LAST_EXTRACTED_AT_RELATIONSHIP_PROPERTY_NAME_BULK_LOADER_FORMAT: ANY,
-                NEPTUNE_CREATION_TYPE_RELATIONSHIP_PROPERTY_NAME_BULK_LOADER_FORMAT: NEPTUNE_CREATION_TYPE_JOB
-            },
-            {
-                NEPTUNE_HEADER_ID: "{from_vertex_id}_{to_vertex_id}_{label}".format(
-                    from_vertex_id=self.end_key,
-                    to_vertex_id=self.start_key,
-                    label='WATERMARK'
-                ),
-                NEPTUNE_RELATIONSHIP_HEADER_FROM: self.end_key,
-                NEPTUNE_RELATIONSHIP_HEADER_TO: self.start_key,
-                NEPTUNE_HEADER_LABEL: 'WATERMARK',
-                NEPTUNE_LAST_EXTRACTED_AT_RELATIONSHIP_PROPERTY_NAME_BULK_LOADER_FORMAT: ANY,
-                NEPTUNE_CREATION_TYPE_RELATIONSHIP_PROPERTY_NAME_BULK_LOADER_FORMAT: NEPTUNE_CREATION_TYPE_JOB
-            }
+            [
+                {
+                    NEPTUNE_HEADER_ID: "{from_vertex_id}_{to_vertex_id}_{label}".format(
+                        from_vertex_id=self.start_key,
+                        to_vertex_id=self.end_key,
+                        label='BELONG_TO_TABLE'
+                    ),
+                    NEPTUNE_RELATIONSHIP_HEADER_FROM: self.start_key,
+                    NEPTUNE_RELATIONSHIP_HEADER_TO: self.end_key,
+                    NEPTUNE_HEADER_LABEL: 'BELONG_TO_TABLE',
+                    NEPTUNE_LAST_EXTRACTED_AT_RELATIONSHIP_PROPERTY_NAME_BULK_LOADER_FORMAT: ANY,
+                    NEPTUNE_CREATION_TYPE_RELATIONSHIP_PROPERTY_NAME_BULK_LOADER_FORMAT: NEPTUNE_CREATION_TYPE_JOB
+                },
+                {
+                    NEPTUNE_HEADER_ID: "{from_vertex_id}_{to_vertex_id}_{label}".format(
+                        from_vertex_id=self.end_key,
+                        to_vertex_id=self.start_key,
+                        label='WATERMARK'
+                    ),
+                    NEPTUNE_RELATIONSHIP_HEADER_FROM: self.end_key,
+                    NEPTUNE_RELATIONSHIP_HEADER_TO: self.start_key,
+                    NEPTUNE_HEADER_LABEL: 'WATERMARK',
+                    NEPTUNE_LAST_EXTRACTED_AT_RELATIONSHIP_PROPERTY_NAME_BULK_LOADER_FORMAT: ANY,
+                    NEPTUNE_CREATION_TYPE_RELATIONSHIP_PROPERTY_NAME_BULK_LOADER_FORMAT: NEPTUNE_CREATION_TYPE_JOB
+                }
+            ]
         ]
 
-        self.assertListEqual(serialized_relation, expected)
+        actual = []
+        relation = self.watermark.create_next_relation()
+        while relation:
+            serialized_relation = neptune_serializer.convert_relationship(relation)
+            actual.append(serialized_relation)
+            relation = self.watermark.create_next_relation()
 
-    def test_create_next_node(self) -> None:
-        next_node = self.watermark.create_next_node()
-        self.assertEquals(neo4_serializer.serialize_node(next_node), self.expected_serialized_node_result)
-
-    def test_create_next_relation(self) -> None:
-        next_relation = self.watermark.create_next_relation()
-        self.assertEquals(
-            neo4_serializer.serialize_relationship(next_relation),
-            self.expected_serialized_relation_result
-        )
+        self.assertListEqual(actual, expected)


### PR DESCRIPTION

<!---
Provide a general summary of your changes in the Title above
Include one of these prefixes:
  fix – Fixes an unexpected problem or unintended behavior
  feat – Adds a new feature
  docs – A documentation improvement task
  build – A task related to our build system
  ci – A task related to our ci system
  perf – A performance improvement
  refactor – A code refactor PR
  style – A task about styling
  test – A PR that improve test coverage
  chore – A regular maintenance chore or task
  other – Any other kind of PR
-->

### Summary of Changes

Use yield instead of return for all node/relation iterators in databuilder.
Issue: https://github.com/amundsen-io/amundsen/issues/924

### Tests

Refactored model unit tests as well and made the model instance call iterator to get yielded node/relation instead of accepting a returned list.

### Documentation
N/A

### CheckList

Make sure you have checked **all** steps below to ensure a timely review.

- [x] PR title addresses the issue accurately and concisely. Example: "Updates the version of Flask to v1.0.2"
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
- [x] PR includes a summary of changes.
- [x] PR adds unit tests, updates existing unit tests, **OR** documents why no test additions or modifications are needed.
- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
- [x] PR passes `make test`