### PR TITLE
fix: Add default empty list when parse tableau_excluded_projects from config

### DIFF
--- a/databuilder/extractor/dashboard/tableau/tableau_dashboard_extractor.py
+++ b/databuilder/extractor/dashboard/tableau/tableau_dashboard_extractor.py
@@ -37,7 +37,7 @@ class TableauGraphQLApiMetadataExtractor(TableauGraphQLApiExtractor):
 
         workbooks_data = [workbook for workbook in response['workbooks']
                           if workbook['projectName'] not in
-                          self._conf.get_list(TableauGraphQLApiMetadataExtractor.EXCLUDED_PROJECTS)]
+                          self._conf.get_list(TableauGraphQLApiMetadataExtractor.EXCLUDED_PROJECTS, [])]
         base_url = self._conf.get(TableauGraphQLApiMetadataExtractor.TABLEAU_BASE_URL)
         for workbook in workbooks_data:
             if None in (workbook['projectName'], workbook['name']):

--- a/databuilder/extractor/dashboard/tableau/tableau_dashboard_last_modified_extractor.py
+++ b/databuilder/extractor/dashboard/tableau/tableau_dashboard_last_modified_extractor.py
@@ -36,7 +36,7 @@ class TableauGraphQLApiLastModifiedExtractor(TableauGraphQLApiExtractor):
 
         workbooks_data = [workbook for workbook in response['workbooks']
                           if workbook['projectName'] not in
-                          self._conf.get_list(TableauGraphQLApiLastModifiedExtractor.EXCLUDED_PROJECTS)]
+                          self._conf.get_list(TableauGraphQLApiLastModifiedExtractor.EXCLUDED_PROJECTS, [])]
 
         for workbook in workbooks_data:
             if None in (workbook['projectName'], workbook['name']):

--- a/databuilder/extractor/dashboard/tableau/tableau_dashboard_query_extractor.py
+++ b/databuilder/extractor/dashboard/tableau/tableau_dashboard_query_extractor.py
@@ -36,7 +36,7 @@ class TableauGraphQLApiQueryExtractor(TableauGraphQLApiExtractor):
         for query in response['customSQLTables']:
             for workbook in query['downstreamWorkbooks']:
                 if workbook['projectName'] not in \
-                        self._conf.get_list(TableauGraphQLApiQueryExtractor.EXCLUDED_PROJECTS):
+                        self._conf.get_list(TableauGraphQLApiQueryExtractor.EXCLUDED_PROJECTS, []):
                     data = {
                         'dashboard_group_id': workbook['projectName'],
                         'dashboard_id': TableauDashboardUtils.sanitize_workbook_name(workbook['name']),

--- a/databuilder/extractor/dashboard/tableau/tableau_dashboard_table_extractor.py
+++ b/databuilder/extractor/dashboard/tableau/tableau_dashboard_table_extractor.py
@@ -38,7 +38,7 @@ class TableauGraphQLDashboardTableExtractor(TableauGraphQLApiExtractor):
 
         workbooks_data = [workbook for workbook in response['workbooks']
                           if workbook['projectName'] not in
-                          self._conf.get_list(TableauGraphQLDashboardTableExtractor.EXCLUDED_PROJECTS)]
+                          self._conf.get_list(TableauGraphQLDashboardTableExtractor.EXCLUDED_PROJECTS, [])]
 
         for workbook in workbooks_data:
             data = {


### PR DESCRIPTION
### Summary of Changes

If I don't give any value to job config's `EXCLUDED_PROJECTS` key, `get_list` method of config_tree gives a following exception.

> pyhocon.exceptions.ConfigMissingException: 'No configuration setting found for key excluded_projects'

Therefore, we can cope with this situation by giving a default value.

### Tests

I don't think there is a need for testing because the situation that I'm trying to prevent is not what you normally want. Nevertheless, when giving an empty list to config, I think it's good to make it work well even if you don't give any value.

### Documentation

N/A

### CheckList

Make sure you have checked **all** steps below to ensure a timely review.

- [x] PR title addresses the issue accurately and concisely. Example: "Updates the version of Flask to v1.0.2"
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
- [x] PR includes a summary of changes.
- [x] PR adds unit tests, updates existing unit tests, **OR** documents why no test additions or modifications are needed.
- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
- [x] PR passes `make test`
