### PR TITLE
fix: Add comma between bigquery requirements listings

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ athena = ['PyAthena[SQLAlchemy]>=1.0.0, <2.0.0']
 # Upstream url: https://github.com/googleapis/google-api-python-client
 bigquery = [
     'google-api-python-client>=1.6.0, <2.0.0dev',
-    'google-auth-httplib2>=0.0.1'
+    'google-auth-httplib2>=0.0.1',
     'google-auth>=1.0.0, <2.0.0dev'
 ]
 


### PR DESCRIPTION
### Summary of Changes

This PR fixes an issue wherein this package could not be installed with the `bigquery` extra because a comma was missing between two package specifications. Python allows this as a multi-line string, so both requirements are concatenated and neither can be found.

Resolves amundsen-io/amundsen#938

### Tests

No tests were modified

### Documentation

No documentation needed to be changed, this was a change to align with expected behavior.

### CheckList

Make sure you have checked **all** steps below to ensure a timely review.

- [x] PR title addresses the issue accurately and concisely. Example: "Updates the version of Flask to v1.0.2"
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
- [x] PR includes a summary of changes.
- [x] PR adds unit tests, updates existing unit tests, **OR** documents why no test additions or modifications are needed.
- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
- [ ] PR passes `make test`
