### PR TITLE
fix: Close SQL Alchemy connections.

### DIFF
--- a/databuilder/extractor/athena_metadata_extractor.py
+++ b/databuilder/extractor/athena_metadata_extractor.py
@@ -63,6 +63,9 @@ class AthenaMetadataExtractor(Extractor):
         self._alchemy_extractor.init(sql_alch_conf)
         self._extract_iter: Union[None, Iterator] = None
 
+    def close(self) -> None:
+        self._alchemy_extractor.close()
+
     def extract(self) -> Union[TableMetadata, None]:
         if not self._extract_iter:
             self._extract_iter = self._get_extract_iter()

--- a/databuilder/extractor/druid_metadata_extractor.py
+++ b/databuilder/extractor/druid_metadata_extractor.py
@@ -59,6 +59,9 @@ class DruidMetadataExtractor(Extractor):
         self._alchemy_extractor.init(sql_alch_conf)
         self._extract_iter: Union[None, Iterator] = None
 
+    def close(self) -> None:
+        self._alchemy_extractor.close()
+
     def extract(self) -> Union[TableMetadata, None]:
         if not self._extract_iter:
             self._extract_iter = self._get_extract_iter()

--- a/databuilder/extractor/mssql_metadata_extractor.py
+++ b/databuilder/extractor/mssql_metadata_extractor.py
@@ -116,6 +116,9 @@ class MSSQLMetadataExtractor(Extractor):
         self._alchemy_extractor.init(sql_alch_conf)
         self._extract_iter: Union[None, Iterator] = None
 
+    def close(self) -> None:
+        self._alchemy_extractor.close()
+
     def extract(self) -> Union[TableMetadata, None]:
         if not self._extract_iter:
             self._extract_iter = self._get_extract_iter()

--- a/databuilder/extractor/presto_view_metadata_extractor.py
+++ b/databuilder/extractor/presto_view_metadata_extractor.py
@@ -62,6 +62,9 @@ class PrestoViewMetadataExtractor(Extractor):
         self._alchemy_extractor.init(sql_alch_conf)
         self._extract_iter: Union[None, Iterator] = None
 
+    def close(self) -> None:
+        self._alchemy_extractor.close()
+
     def extract(self) -> Union[TableMetadata, None]:
         if not self._extract_iter:
             self._extract_iter = self._get_extract_iter()

--- a/databuilder/extractor/snowflake_metadata_extractor.py
+++ b/databuilder/extractor/snowflake_metadata_extractor.py
@@ -106,6 +106,9 @@ class SnowflakeMetadataExtractor(Extractor):
         self._alchemy_extractor.init(sql_alch_conf)
         self._extract_iter: Union[None, Iterator] = None
 
+    def close(self) -> None:
+        self._alchemy_extractor.close()
+
     def extract(self) -> Union[TableMetadata, None]:
         if not self._extract_iter:
             self._extract_iter = self._get_extract_iter()

--- a/databuilder/extractor/snowflake_table_last_updated_extractor.py
+++ b/databuilder/extractor/snowflake_table_last_updated_extractor.py
@@ -83,6 +83,9 @@ class SnowflakeTableLastUpdatedExtractor(Extractor):
         self._alchemy_extractor.init(sql_alch_conf)
         self._extract_iter: Union[None, Iterator] = None
 
+    def close(self) -> None:
+        self._alchemy_extractor.close()
+
     def extract(self) -> Union[TableLastUpdated, None]:
         if not self._extract_iter:
             self._extract_iter = self._get_extract_iter()

--- a/databuilder/extractor/sql_alchemy_extractor.py
+++ b/databuilder/extractor/sql_alchemy_extractor.py
@@ -38,6 +38,9 @@ class SQLAlchemyExtractor(Extractor):
             self.model_class = getattr(mod, class_name)
         self._execute_query()
 
+    def close(self) -> None:
+        self.connection.close()
+
     def _get_connection(self) -> Any:
         """
         Create a SQLAlchemy connection to Database


### PR DESCRIPTION
### Summary of Changes

This addresses #868, where extractions using the Snowflake extractor would
hand until the connection was closed. I've added close() calls to the other
SQL Alchemy based extractors since it is a general expectation of SQL Alchemy
and most of the infrastructure existed to do it already.

### Tests

Is there a good way of testing these extractor classes without requiring the appropriate DB to be available?

Test coverage in this project is already significantly below the goal of 70%, so `make test` is failing for me. This happens regardless of these changes.

### Documentation

Closing connections is an expected behavior, so I did not add specific documentation.

### CheckList

Make sure you have checked **all** steps below to ensure a timely review.

- [ ] PR title addresses the issue accurately and concisely. Example: "Updates the version of Flask to v1.0.2"
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
- [ ] PR includes a summary of changes.
- [ ] PR adds unit tests, updates existing unit tests, **OR** documents why no test additions or modifications are needed.
- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
- [ ] PR passes `make test`
