### PR TITLE
fix: Avoid error by checking for existence before close.

### DIFF
--- a/databuilder/extractor/athena_metadata_extractor.py
+++ b/databuilder/extractor/athena_metadata_extractor.py
@@ -59,7 +59,8 @@ class AthenaMetadataExtractor(Extractor):
         self._extract_iter: Union[None, Iterator] = None
 
     def close(self) -> None:
-        self._alchemy_extractor.close()
+        if getattr(self, '_alchemy_extractor', None) is not None:
+            self._alchemy_extractor.close()
 
     def extract(self) -> Union[TableMetadata, None]:
         if not self._extract_iter:

--- a/databuilder/extractor/athena_metadata_extractor.py
+++ b/databuilder/extractor/athena_metadata_extractor.py
@@ -10,9 +10,8 @@ from typing import (
 
 from pyhocon import ConfigFactory, ConfigTree
 
-from databuilder import Scoped
+from databuilder.extractor import sql_alchemy_extractor
 from databuilder.extractor.base_extractor import Extractor
-from databuilder.extractor.sql_alchemy_extractor import SQLAlchemyExtractor
 from databuilder.models.table_metadata import ColumnMetadata, TableMetadata
 
 TableKey = namedtuple('TableKey', ['schema', 'table_name'])
@@ -56,11 +55,7 @@ class AthenaMetadataExtractor(Extractor):
 
         LOGGER.info('SQL for Athena metadata: %s', self.sql_stmt)
 
-        self._alchemy_extractor = SQLAlchemyExtractor()
-        sql_alch_conf = Scoped.get_scoped_conf(conf, self._alchemy_extractor.get_scope())\
-            .with_fallback(ConfigFactory.from_dict({SQLAlchemyExtractor.EXTRACT_SQL: self.sql_stmt}))
-
-        self._alchemy_extractor.init(sql_alch_conf)
+        self._alchemy_extractor = sql_alchemy_extractor.from_surrounding_config(conf, self.sql_stmt)
         self._extract_iter: Union[None, Iterator] = None
 
     def close(self) -> None:

--- a/databuilder/extractor/druid_metadata_extractor.py
+++ b/databuilder/extractor/druid_metadata_extractor.py
@@ -11,9 +11,8 @@ from typing import (
 
 from pyhocon import ConfigFactory, ConfigTree
 
-from databuilder import Scoped
+from databuilder.extractor import sql_alchemy_extractor
 from databuilder.extractor.base_extractor import Extractor
-from databuilder.extractor.sql_alchemy_extractor import SQLAlchemyExtractor
 from databuilder.models.table_metadata import ColumnMetadata, TableMetadata
 
 TableKey = namedtuple('TableKey', ['schema', 'table_name'])
@@ -52,11 +51,7 @@ class DruidMetadataExtractor(Extractor):
             where_clause_suffix=conf.get_string(DruidMetadataExtractor.WHERE_CLAUSE_SUFFIX_KEY,
                                                 default=''))
 
-        self._alchemy_extractor = SQLAlchemyExtractor()
-        sql_alch_conf = Scoped.get_scoped_conf(conf, self._alchemy_extractor.get_scope())\
-            .with_fallback(ConfigFactory.from_dict({SQLAlchemyExtractor.EXTRACT_SQL: self.sql_stmt}))
-
-        self._alchemy_extractor.init(sql_alch_conf)
+        self._alchemy_extractor = sql_alchemy_extractor.from_surrounding_config(conf, self.sql_stmt)
         self._extract_iter: Union[None, Iterator] = None
 
     def close(self) -> None:

--- a/databuilder/extractor/druid_metadata_extractor.py
+++ b/databuilder/extractor/druid_metadata_extractor.py
@@ -55,7 +55,8 @@ class DruidMetadataExtractor(Extractor):
         self._extract_iter: Union[None, Iterator] = None
 
     def close(self) -> None:
-        self._alchemy_extractor.close()
+        if getattr(self, '_alchemy_extractor', None) is not None:
+            self._alchemy_extractor.close()
 
     def extract(self) -> Union[TableMetadata, None]:
         if not self._extract_iter:

--- a/databuilder/extractor/mssql_metadata_extractor.py
+++ b/databuilder/extractor/mssql_metadata_extractor.py
@@ -111,7 +111,8 @@ class MSSQLMetadataExtractor(Extractor):
         self._extract_iter: Union[None, Iterator] = None
 
     def close(self) -> None:
-        self._alchemy_extractor.close()
+        if getattr(self, '_alchemy_extractor', None) is not None:
+            self._alchemy_extractor.close()
 
     def extract(self) -> Union[TableMetadata, None]:
         if not self._extract_iter:

--- a/databuilder/extractor/mssql_metadata_extractor.py
+++ b/databuilder/extractor/mssql_metadata_extractor.py
@@ -10,9 +10,8 @@ from typing import (
 
 from pyhocon import ConfigFactory, ConfigTree
 
-from databuilder import Scoped
+from databuilder.extractor import sql_alchemy_extractor
 from databuilder.extractor.base_extractor import Extractor
-from databuilder.extractor.sql_alchemy_extractor import SQLAlchemyExtractor
 from databuilder.models.table_metadata import ColumnMetadata, TableMetadata
 
 TableKey = namedtuple('TableKey', ['schema_name', 'table_name'])
@@ -108,12 +107,7 @@ class MSSQLMetadataExtractor(Extractor):
 
         LOGGER.info('SQL for MS SQL Metadata: %s', self.sql_stmt)
 
-        self._alchemy_extractor = SQLAlchemyExtractor()
-        sql_alch_conf = Scoped \
-            .get_scoped_conf(conf, self._alchemy_extractor.get_scope()) \
-            .with_fallback(ConfigFactory.from_dict({SQLAlchemyExtractor.EXTRACT_SQL: self.sql_stmt}))
-
-        self._alchemy_extractor.init(sql_alch_conf)
+        self._alchemy_extractor = sql_alchemy_extractor.from_surrounding_config(conf, self.sql_stmt)
         self._extract_iter: Union[None, Iterator] = None
 
     def close(self) -> None:

--- a/databuilder/extractor/presto_view_metadata_extractor.py
+++ b/databuilder/extractor/presto_view_metadata_extractor.py
@@ -10,9 +10,8 @@ from typing import (
 
 from pyhocon import ConfigFactory, ConfigTree
 
-from databuilder import Scoped
+from databuilder.extractor import sql_alchemy_extractor
 from databuilder.extractor.base_extractor import Extractor
-from databuilder.extractor.sql_alchemy_extractor import SQLAlchemyExtractor
 from databuilder.models.table_metadata import ColumnMetadata, TableMetadata
 
 LOGGER = logging.getLogger(__name__)
@@ -55,11 +54,7 @@ class PrestoViewMetadataExtractor(Extractor):
 
         LOGGER.info('SQL for hive metastore: %s', self.sql_stmt)
 
-        self._alchemy_extractor = SQLAlchemyExtractor()
-        sql_alch_conf = Scoped.get_scoped_conf(conf, self._alchemy_extractor.get_scope())\
-            .with_fallback(ConfigFactory.from_dict({SQLAlchemyExtractor.EXTRACT_SQL: self.sql_stmt}))
-
-        self._alchemy_extractor.init(sql_alch_conf)
+        self._alchemy_extractor = sql_alchemy_extractor.from_surrounding_config(conf, self.sql_stmt)
         self._extract_iter: Union[None, Iterator] = None
 
     def close(self) -> None:

--- a/databuilder/extractor/presto_view_metadata_extractor.py
+++ b/databuilder/extractor/presto_view_metadata_extractor.py
@@ -58,7 +58,8 @@ class PrestoViewMetadataExtractor(Extractor):
         self._extract_iter: Union[None, Iterator] = None
 
     def close(self) -> None:
-        self._alchemy_extractor.close()
+        if getattr(self, '_alchemy_extractor', None) is not None:
+            self._alchemy_extractor.close()
 
     def extract(self) -> Union[TableMetadata, None]:
         if not self._extract_iter:

--- a/databuilder/extractor/snowflake_metadata_extractor.py
+++ b/databuilder/extractor/snowflake_metadata_extractor.py
@@ -102,7 +102,8 @@ class SnowflakeMetadataExtractor(Extractor):
         self._extract_iter: Union[None, Iterator] = None
 
     def close(self) -> None:
-        self._alchemy_extractor.close()
+        if getattr(self, '_alchemy_extractor', None) is not None:
+            self._alchemy_extractor.close()
 
     def extract(self) -> Union[TableMetadata, None]:
         if not self._extract_iter:

--- a/databuilder/extractor/snowflake_metadata_extractor.py
+++ b/databuilder/extractor/snowflake_metadata_extractor.py
@@ -12,9 +12,8 @@ from typing import (
 from pyhocon import ConfigFactory, ConfigTree
 from unidecode import unidecode
 
-from databuilder import Scoped
+from databuilder.extractor import sql_alchemy_extractor
 from databuilder.extractor.base_extractor import Extractor
-from databuilder.extractor.sql_alchemy_extractor import SQLAlchemyExtractor
 from databuilder.models.table_metadata import ColumnMetadata, TableMetadata
 
 TableKey = namedtuple('TableKey', ['schema', 'table_name'])
@@ -99,11 +98,7 @@ class SnowflakeMetadataExtractor(Extractor):
 
         LOGGER.info('SQL for snowflake metadata: %s', self.sql_stmt)
 
-        self._alchemy_extractor = SQLAlchemyExtractor()
-        sql_alch_conf = Scoped.get_scoped_conf(conf, self._alchemy_extractor.get_scope()) \
-            .with_fallback(ConfigFactory.from_dict({SQLAlchemyExtractor.EXTRACT_SQL: self.sql_stmt}))
-
-        self._alchemy_extractor.init(sql_alch_conf)
+        self._alchemy_extractor = sql_alchemy_extractor.from_surrounding_config(conf, self.sql_stmt)
         self._extract_iter: Union[None, Iterator] = None
 
     def close(self) -> None:

--- a/databuilder/extractor/snowflake_table_last_updated_extractor.py
+++ b/databuilder/extractor/snowflake_table_last_updated_extractor.py
@@ -79,7 +79,8 @@ class SnowflakeTableLastUpdatedExtractor(Extractor):
         self._extract_iter: Union[None, Iterator] = None
 
     def close(self) -> None:
-        self._alchemy_extractor.close()
+        if getattr(self, '_alchemy_extractor', None) is not None:
+            self._alchemy_extractor.close()
 
     def extract(self) -> Union[TableLastUpdated, None]:
         if not self._extract_iter:

--- a/databuilder/extractor/snowflake_table_last_updated_extractor.py
+++ b/databuilder/extractor/snowflake_table_last_updated_extractor.py
@@ -6,9 +6,8 @@ from typing import Iterator, Union
 
 from pyhocon import ConfigFactory, ConfigTree
 
-from databuilder import Scoped
+from databuilder.extractor import sql_alchemy_extractor
 from databuilder.extractor.base_extractor import Extractor
-from databuilder.extractor.sql_alchemy_extractor import SQLAlchemyExtractor
 from databuilder.models.table_last_updated import TableLastUpdated
 
 LOGGER = logging.getLogger(__name__)
@@ -76,11 +75,7 @@ class SnowflakeTableLastUpdatedExtractor(Extractor):
         LOGGER.info('SQL for snowflake table last updated timestamp: %s', self.sql_stmt)
 
         # use an sql_alchemy_extractor to execute sql
-        self._alchemy_extractor = SQLAlchemyExtractor()
-        sql_alch_conf = Scoped.get_scoped_conf(conf, self._alchemy_extractor.get_scope()) \
-            .with_fallback(ConfigFactory.from_dict({SQLAlchemyExtractor.EXTRACT_SQL: self.sql_stmt}))
-
-        self._alchemy_extractor.init(sql_alch_conf)
+        self._alchemy_extractor = sql_alchemy_extractor.from_surrounding_config(conf, self.sql_stmt)
         self._extract_iter: Union[None, Iterator] = None
 
     def close(self) -> None:

--- a/databuilder/extractor/sql_alchemy_extractor.py
+++ b/databuilder/extractor/sql_alchemy_extractor.py
@@ -40,7 +40,8 @@ class SQLAlchemyExtractor(Extractor):
         self._execute_query()
 
     def close(self) -> None:
-        self.connection.close()
+        if self.connection is not None:
+            self.connection.close()
 
     def _get_connection(self) -> Any:
         """

--- a/databuilder/extractor/sql_alchemy_extractor.py
+++ b/databuilder/extractor/sql_alchemy_extractor.py
@@ -4,9 +4,10 @@
 import importlib
 from typing import Any
 
-from pyhocon import ConfigTree
+from pyhocon import ConfigFactory, ConfigTree
 from sqlalchemy import create_engine
 
+from databuilder import Scoped
 from databuilder.extractor.base_extractor import Extractor
 
 
@@ -83,3 +84,19 @@ class SQLAlchemyExtractor(Extractor):
 
     def get_scope(self) -> str:
         return 'extractor.sqlalchemy'
+
+
+def from_surrounding_config(conf: ConfigTree, sql_stmt: str) -> SQLAlchemyExtractor:
+    """
+    A factory to create SQLAlchemyExtractors that are wrapped by another, specialized
+    extractor. This function pulls the config from the wrapping extractor's config, and
+    returns a newly configured SQLAlchemyExtractor.
+    :param conf: A config tree from which the sqlalchemy config still needs to be taken.
+    :param conf: The SQL statement to use for extraction. Expected to be set by the
+        wrapping extractor implementation, and not by the config.
+    """
+    ae = SQLAlchemyExtractor()
+    c = Scoped.get_scoped_conf(conf, ae.get_scope()) \
+        .with_fallback(ConfigFactory.from_dict({SQLAlchemyExtractor.EXTRACT_SQL: sql_stmt}))
+    ae.init(c)
+    return ae


### PR DESCRIPTION
### Summary of Changes

Without checking the existence of the `_alchemy_extractor` attribute, and that
the value is not None, an AttributeError can be raised when close() is called
if the init method didn't complete. Tasks still call close to clean up, so
this code should check if there is anything to clean up first.

### Tests

No tests were added. I am not familiar enough with mocking to set up effective tests.

### Documentation

No documentation was added.

### CheckList

Make sure you have checked **all** steps below to ensure a timely review.

- [x] PR title addresses the issue accurately and concisely. Example: "Updates the version of Flask to v1.0.2"
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
- [x] PR includes a summary of changes.
- [x] PR adds unit tests, updates existing unit tests, **OR** documents why no test additions or modifications are needed.
- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
- [x] PR passes `make test`
