### PR TITLE
feat: take GCP quota project as parameter

### DIFF
--- a/databuilder/extractor/bigquery_watermark_extractor.py
+++ b/databuilder/extractor/bigquery_watermark_extractor.py
@@ -20,9 +20,12 @@ LOGGER = logging.getLogger(__name__)
 
 
 class BigQueryWatermarkExtractor(BaseBigQueryExtractor):
+    
+    GCP_BILLING_PROJECT = 'billing_project'
 
     def init(self, conf: ConfigTree) -> None:
         BaseBigQueryExtractor.init(self, conf)
+        self.gcp_billing_project = conf.get_string(BaseBigQueryExtractor.GCP_BILLING_PROJECT, None)
         self.iter: Iterator[Watermark] = iter(self._iterate_over_tables())
 
     def get_scope(self) -> str:
@@ -107,7 +110,7 @@ class BigQueryWatermarkExtractor(BaseBigQueryExtractor):
                 table=tableRef['tableId']),
             'useLegacySql': True
         }
-        result = self.bigquery_service.jobs().query(projectId=self.project_id, body=body).execute()
+        result = self.bigquery_service.jobs().query(projectId=self.gcp_billing_project or self.project_id, body=body).execute()
 
         if 'rows' not in result:
             return []


### PR DESCRIPTION
In GCP world, there is a concept of a billing/quota project. 

You might use a table from project A but may want the query to be subject to quotas and appear in logs of project B. 

An absolute must for us.

<!---
Provide a general summary of your changes in the Title above
Include one of these prefixes:
  fix – Fixes an unexpected problem or unintended behavior
  feat – Adds a new feature
  docs – A documentation improvement task
  build – A task related to our build system
  ci – A task related to our ci system
  perf – A performance improvement
  refactor – A code refactor PR
  style – A task about styling
  test – A PR that improve test coverage
  chore – A regular maintenance chore or task
  other – Any other kind of PR
-->

### Summary of Changes

_Include a summary of changes then remove this line_

### Tests

_What tests did you add or modify and why? If no tests were added or modified, explain why. Remove this line_

### Documentation

_What documentation did you add or modify and why? Add any relevant links then remove this line_

### CheckList

Make sure you have checked **all** steps below to ensure a timely review.

- [ ] PR title addresses the issue accurately and concisely. Example: "Updates the version of Flask to v1.0.2"
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
- [ ] PR includes a summary of changes.
- [ ] PR adds unit tests, updates existing unit tests, **OR** documents why no test additions or modifications are needed.
- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
- [ ] PR passes `make test`
