### PR TITLE
fix: Add missing amundsen-rds package

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@
 
 from setuptools import find_packages, setup
 
-__version__ = '4.2.1'
+__version__ = '4.2.2'
 
 
 requirements = [
@@ -17,7 +17,8 @@ requirements = [
     "pyhocon>=0.3.42",
     "unidecode",
     "Jinja2>=2.10.0,<2.12",
-    "pandas>=0.21.0,<1.2.0"
+    "pandas>=0.21.0,<1.2.0",
+    "amundsen-rds"
 ]
 
 kafka = ['confluent-kafka==1.0.0']


### PR DESCRIPTION
Signed-off-by: hhobson <hugo.hobson@dazn.com>

### Summary of Changes

`databuilder` version 4.2.1 is missing `amundsen-rds` package. Have added package and with no version pinning as presume will always want to use latest.

### Tests

No test added as only changed setup.py

### CheckList

Make sure you have checked **all** steps below to ensure a timely review.

- [x] PR title addresses the issue accurately and concisely. Example: "Updates the version of Flask to v1.0.2"
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
- [x] PR includes a summary of changes.
- [ ] PR adds unit tests, updates existing unit tests, **OR** documents why no test additions or modifications are needed.
- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
- [ ] PR passes `make test`
