### PR TITLE
fix: add support for Tableau multi-site deployment

### DIFF
--- a/databuilder/extractor/dashboard/tableau/tableau_dashboard_extractor.py
+++ b/databuilder/extractor/dashboard/tableau/tableau_dashboard_extractor.py
@@ -40,9 +40,9 @@ class TableauGraphQLApiMetadataExtractor(TableauGraphQLApiExtractor):
                           if workbook['projectName'] not in
                           self._conf.get_list(TableauGraphQLApiMetadataExtractor.EXCLUDED_PROJECTS, [])]
         base_url = self._conf.get(TableauGraphQLApiMetadataExtractor.TABLEAU_BASE_URL)
-        site_name = self._conf.get_string(TableauGraphQLApiMetadataExtractor.SITE_NAME)
-        site_url_path = ""
-        if site_name != "":
+        site_name = self._conf.get_string(TableauGraphQLApiMetadataExtractor.SITE_NAME, '')
+        site_url_path = ''
+        if site_name != '':
             site_url_path = f'/site/{site_name}'
         for workbook in workbooks_data:
             if None in (workbook['projectName'], workbook['name']):

--- a/databuilder/extractor/dashboard/tableau/tableau_dashboard_extractor.py
+++ b/databuilder/extractor/dashboard/tableau/tableau_dashboard_extractor.py
@@ -30,6 +30,7 @@ class TableauGraphQLApiMetadataExtractor(TableauGraphQLApiExtractor):
 
     CLUSTER = const.CLUSTER
     EXCLUDED_PROJECTS = const.EXCLUDED_PROJECTS
+    SITE_NAME = const.SITE_NAME
     TABLEAU_BASE_URL = const.TABLEAU_BASE_URL
 
     def execute(self) -> Iterator[Dict[str, Any]]:
@@ -39,6 +40,10 @@ class TableauGraphQLApiMetadataExtractor(TableauGraphQLApiExtractor):
                           if workbook['projectName'] not in
                           self._conf.get_list(TableauGraphQLApiMetadataExtractor.EXCLUDED_PROJECTS, [])]
         base_url = self._conf.get(TableauGraphQLApiMetadataExtractor.TABLEAU_BASE_URL)
+        site_name = self._conf.get_string(TableauGraphQLApiMetadataExtractor.SITE_NAME)
+        site_url_path = ""
+        if site_name != "":
+            site_url_path = f'/site/{site_name}'
         for workbook in workbooks_data:
             if None in (workbook['projectName'], workbook['name']):
                 LOGGER.warning(f'Ignoring workbook (ID:{workbook["vizportalUrlId"]}) ' +
@@ -49,8 +54,8 @@ class TableauGraphQLApiMetadataExtractor(TableauGraphQLApiExtractor):
                 'dashboard_name': TableauDashboardUtils.sanitize_workbook_name(workbook['name']),
                 'description': workbook.get('description', ''),
                 'created_timestamp': workbook['createdAt'],
-                'dashboard_group_url': f'{base_url}/#/projects/{workbook["projectVizportalUrlId"]}',
-                'dashboard_url': f'{base_url}/#/workbooks/{workbook["vizportalUrlId"]}/views',
+                'dashboard_group_url': f'{base_url}/#{site_url_path}/projects/{workbook["projectVizportalUrlId"]}',
+                'dashboard_url': f'{base_url}/#{site_url_path}/workbooks/{workbook["vizportalUrlId"]}/views',
                 'cluster': self._conf.get_string(TableauGraphQLApiMetadataExtractor.CLUSTER)
             }
             yield data

--- a/databuilder/extractor/dashboard/tableau/tableau_dashboard_utils.py
+++ b/databuilder/extractor/dashboard/tableau/tableau_dashboard_utils.py
@@ -154,7 +154,7 @@ class TableauDashboardAuth:
         self._access_token_name = self._conf.get_string(TableauDashboardAuth.TABLEAU_ACCESS_TOKEN_NAME)
         self._access_token_secret = self._conf.get_string(TableauDashboardAuth.TABLEAU_ACCESS_TOKEN_SECRET)
         self._api_version = self._conf.get_string(TableauDashboardAuth.API_VERSION)
-        self._site_name = self._conf.get_string(TableauDashboardAuth.SITE_NAME)
+        self._site_name = self._conf.get_string(TableauDashboardAuth.SITE_NAME, '')
         self._api_base_url = self._conf.get_string(TableauDashboardAuth.API_BASE_URL)
         self._verify_request = self._conf.get(TableauDashboardAuth.VERIFY_REQUEST, None)
 


### PR DESCRIPTION
### Summary of Changes

Tableau supports multi-tenancy as a "site", but the current databuilder implementation does not support the feature.
Now, dashboard_url and dashboard_group_url contain site name (e.g. https://tableau-server/#/site/my-site/...).

### Tests

Add some test cases to check dashboard_url and dashboard_group_url

### Documentation

### CheckList

Make sure you have checked **all** steps below to ensure a timely review.

- [x] PR title addresses the issue accurately and concisely. Example: "Updates the version of Flask to v1.0.2"
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
- [x] PR includes a summary of changes.
- [x] PR adds unit tests, updates existing unit tests, **OR** documents why no test additions or modifications are needed.
- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
- [x] PR passes `make test`
