### PR TITLE
feat: Add mysql as backend store

### DIFF
--- a/databuilder/extractor/mysql_search_data_extractor.py
+++ b/databuilder/extractor/mysql_search_data_extractor.py
@@ -1,0 +1,538 @@
+# Copyright Contributors to the Amundsen project.
+# SPDX-License-Identifier: Apache-2.0
+
+import importlib
+import logging
+from typing import (
+    Any, Callable, Dict, Iterator, List, Optional,
+)
+
+from amundsen_rds.models.badge import Badge
+from amundsen_rds.models.cluster import Cluster
+from amundsen_rds.models.column import ColumnDescription, TableColumn
+from amundsen_rds.models.dashboard import (
+    Dashboard, DashboardChart, DashboardCluster, DashboardDescription, DashboardExecution, DashboardFollower,
+    DashboardGroup, DashboardGroupDescription, DashboardOwner, DashboardQuery, DashboardUsage,
+)
+from amundsen_rds.models.database import Database
+from amundsen_rds.models.schema import Schema, SchemaDescription
+from amundsen_rds.models.table import (
+    Table, TableDescription, TableFollower, TableOwner, TableProgrammaticDescription, TableTimestamp, TableUsage,
+)
+from amundsen_rds.models.tag import Tag
+from amundsen_rds.models.user import User
+from pyhocon import ConfigTree
+from sqlalchemy import create_engine, func
+from sqlalchemy.orm import (
+    Session, load_only, sessionmaker, subqueryload,
+)
+
+from databuilder.extractor.base_extractor import Extractor
+
+LOGGER = logging.getLogger(__name__)
+
+
+def _table_search_query(session: Session, table_filter: List, offset: int, limit: int) -> List:
+    """
+    Table query
+    :param session:
+    :param table_filter:
+    :param offset:
+    :param limit:
+    :return:
+    """
+    # table
+    query = session.query(Table).filter(*table_filter).options(
+        load_only(Table.rk, Table.name, Table.schema_rk)
+    )
+
+    # description
+    query = query.options(
+        subqueryload(Table.description).options(
+            load_only(TableDescription.description)
+        )
+    ).options(
+        subqueryload(Table.programmatic_descriptions).options(
+            load_only(TableProgrammaticDescription.description)
+        )
+    )
+
+    # schema, cluster, database
+    query = query.options(
+        subqueryload(Table.schema).options(
+            load_only(Schema.name, Schema.cluster_rk),
+            subqueryload(Schema.description).options(
+                load_only(SchemaDescription.description)
+            ),
+            subqueryload(Schema.cluster).options(
+                load_only(Cluster.name, Cluster.database_rk),
+                subqueryload(Cluster.database).options(
+                    load_only(Database.name)
+                )
+            )
+        )
+    )
+
+    # column
+    query = query.options(
+        subqueryload(Table.columns).options(
+            load_only(TableColumn.rk, TableColumn.name),
+            subqueryload(TableColumn.description).options(
+                load_only(ColumnDescription.description)
+            )
+        )
+    )
+
+    # tag, badge
+    query = query.options(
+        subqueryload(Table.tags).options(
+            load_only(Tag.rk, Tag.tag_type)
+        )
+    ).options(
+        subqueryload(Table.badges).options(
+            load_only(Badge.rk)
+        )
+    )
+
+    # usage
+    query = query.options(
+        subqueryload(Table.usage).options(
+            load_only(TableUsage.read_count)
+        )
+    )
+
+    # timestamp
+    query = query.options(
+        subqueryload(Table.timestamp).options(
+            load_only(TableTimestamp.last_updated_timestamp)
+        )
+    )
+
+    query = query.order_by(Table.rk).offset(offset).limit(limit)
+
+    return query.all()
+
+
+def _table_search(session: Session, published_tag: str, limit: int) -> List[Dict]:
+    """
+    Query table metadata.
+    :param session:
+    :param published_tag:
+    :param limit:
+    :return:
+    """
+    LOGGER.info('Querying table metadata.')
+
+    table_filter = []
+    if published_tag:
+        table_filter.append(Table.published_tag == published_tag)
+
+    table_results = []
+
+    offset = 0
+    tables = _table_search_query(session, table_filter, offset, limit)
+    while tables:
+        for table in tables:
+            schema = table.schema
+            schema_description = schema.description.description if schema.description else None
+            cluster = schema.cluster
+            database = cluster.database
+            description = table.description.description if table.description else ''
+            programmatic_descriptions = [description.description
+                                         for description in table.programmatic_descriptions]
+
+            columns = table.columns
+            column_names = [column.name for column in columns]
+            column_descriptions = [column.description.description if column.description else ''
+                                   for column in columns]
+
+            total_usage = sum(usage.read_count for usage in table.usage)
+            unique_usage = len(table.usage)
+
+            tags = [tag.rk for tag in table.tags if tag.tag_type == 'default']
+            badges = [badge.rk for badge in table.badges]
+            last_updated_timestamp = table.timestamp.last_updated_timestamp if table.timestamp else None
+
+            table_result = dict(database=database.name,
+                                cluster=cluster.name,
+                                schema=schema.name,
+                                name=table.name,
+                                key=table.rk,
+                                description=description,
+                                last_updated_timestamp=last_updated_timestamp,
+                                column_names=column_names,
+                                column_descriptions=column_descriptions,
+                                total_usage=total_usage,
+                                unique_usage=unique_usage,
+                                tags=tags,
+                                badges=badges,
+                                schema_description=schema_description,
+                                programmatic_descriptions=programmatic_descriptions)
+            table_results.append(table_result)
+
+        offset += limit
+        tables = _table_search_query(session, table_filter, offset, limit)
+
+    return table_results
+
+
+def _dashboard_search_query(session: Session, dashboard_filter: List, offset: int, limit: int) -> List:
+    """
+    Dashboard query
+    :param session:
+    :param dashboard_filter:
+    :param offset:
+    :param limit:
+    :return:
+    """
+    # dashboard
+    query = session.query(Dashboard).filter(*dashboard_filter).options(
+        load_only(Dashboard.rk,
+                  Dashboard.name,
+                  Dashboard.dashboard_url,
+                  Dashboard.dashboard_group_rk)
+    )
+
+    # group, cluster
+    query = query.options(
+        subqueryload(Dashboard.group).options(
+            load_only(DashboardGroup.rk,
+                      DashboardGroup.name,
+                      DashboardGroup.dashboard_group_url,
+                      DashboardGroup.cluster_rk),
+            subqueryload(DashboardGroup.description).options(
+                load_only(DashboardGroupDescription.description)
+            ),
+            subqueryload(DashboardGroup.cluster).options(
+                load_only(DashboardCluster.name)
+            )
+        )
+    )
+
+    # description
+    query = query.options(
+        subqueryload(Dashboard.description).options(
+            load_only(DashboardDescription.description)
+        )
+    )
+
+    # execution
+    query = query.options(
+        subqueryload(Dashboard.execution).options(
+            load_only(DashboardExecution.rk)
+        )
+    )
+    # usage
+    query = query.options(
+        subqueryload(Dashboard.usage).options(
+            load_only(DashboardUsage.read_count)
+        )
+    )
+
+    # query, chart
+    query = query.options(
+        subqueryload(Dashboard.queries).options(
+            load_only(DashboardQuery.name),
+            subqueryload(DashboardQuery.charts).options(
+                load_only(DashboardChart.name)
+            )
+        )
+    )
+
+    # tag, badge
+    query = query.options(
+        subqueryload(Dashboard.tags).options(
+            load_only(Tag.rk, Tag.tag_type)
+        )
+    ).options(
+        subqueryload(Dashboard.badges).options(
+            load_only(Badge.rk)
+        )
+    )
+
+    query = query.order_by(Dashboard.rk).offset(offset).limit(limit)
+
+    return query.all()
+
+
+def _dashboard_search(session: Session, published_tag: str, limit: int) -> List[Dict]:
+    """
+    Query dashboard metadata.
+    :param session:
+    :param published_tag:
+    :param limit:
+    :return:
+    """
+    LOGGER.info('Querying dashboard metadata.')
+
+    dashboard_filter = []
+    if published_tag:
+        dashboard_filter.append(Dashboard.published_tag == published_tag)
+
+    dashboard_results = []
+
+    offset = 0
+    dashboards = _dashboard_search_query(session, dashboard_filter, offset, limit)
+    while dashboards:
+        for dashboard in dashboards:
+            group = dashboard.group
+            description = dashboard.description.description if dashboard.description else None
+            group_description = group.description.description if group.description else None
+            cluster = group.cluster
+            product = dashboard.rk.split('_')[0]
+            last_exec = next((execution for execution in dashboard.execution
+                              if execution.rk.endswith('_last_successful_execution')), None)
+            last_successful_run_timestamp = last_exec.timestamp if last_exec else None
+            total_usage = sum(usage.read_count for usage in dashboard.usage)
+
+            queries = dashboard.queries
+            query_names = [query.name for query in queries]
+            chart_names = [chart.name for query in queries for chart in query.charts]
+
+            tags = [tag.rk for tag in dashboard.tags if tag.tag_type == 'default']
+            badges = [badge.rk for badge in dashboard.badges]
+
+            dashboard_result = dict(group_name=group.name,
+                                    name=dashboard.name,
+                                    description=description,
+                                    total_usage=total_usage,
+                                    product=product,
+                                    cluster=cluster.name,
+                                    group_description=group_description,
+                                    query_names=query_names,
+                                    chart_names=chart_names,
+                                    group_url=group.dashboard_group_url,
+                                    url=dashboard.dashboard_url,
+                                    uri=dashboard.rk,
+                                    last_successful_run_timestamp=last_successful_run_timestamp,
+                                    tags=tags,
+                                    badges=badges)
+
+            dashboard_results.append(dashboard_result)
+
+        offset += limit
+        dashboards = _dashboard_search_query(session, dashboard_filter, offset, limit)
+
+    return dashboard_results
+
+
+def _user_search_query(session: Session, user_filter: List, offset: int, limit: int) -> List:
+    """
+    User query
+    :param session:
+    :param user_filter:
+    :param offset:
+    :param limit:
+    :return:
+    """
+    # read
+    table_usage_subquery = session \
+        .query(User.rk, func.sum(TableUsage.read_count).label('table_read_count')) \
+        .outerjoin(TableUsage) \
+        .filter(*user_filter) \
+        .group_by(User.rk).order_by(User.rk).offset(offset).limit(limit).subquery()
+
+    dashboard_usage_subquery = session \
+        .query(User.rk, func.sum(DashboardUsage.read_count).label('dashboard_read_count')) \
+        .outerjoin(DashboardUsage) \
+        .filter(*user_filter) \
+        .group_by(User.rk).order_by(User.rk).offset(offset).limit(limit).subquery()
+
+    # own
+    table_owner_subquery = session \
+        .query(User.rk, func.count(TableOwner.table_rk).label('table_own_count')) \
+        .outerjoin(TableOwner) \
+        .filter(*user_filter) \
+        .group_by(User.rk).order_by(User.rk).offset(offset).limit(limit).subquery()
+
+    dashboard_owner_subquery = session \
+        .query(User.rk, func.count(DashboardOwner.dashboard_rk).label('dashboard_own_count')) \
+        .outerjoin(DashboardOwner) \
+        .filter(*user_filter) \
+        .group_by(User.rk).order_by(User.rk).offset(offset).limit(limit).subquery()
+
+    # follow
+    table_follower_subquery = session \
+        .query(User.rk, func.count(TableFollower.table_rk).label('table_follow_count')) \
+        .outerjoin(TableFollower) \
+        .filter(*user_filter) \
+        .group_by(User.rk).order_by(User.rk).offset(offset).limit(limit).subquery()
+
+    dashboard_follower_subquery = session \
+        .query(User.rk, func.count(DashboardFollower.dashboard_rk).label('dashboard_follow_count')) \
+        .outerjoin(DashboardFollower) \
+        .filter(*user_filter) \
+        .group_by(User.rk).order_by(User.rk).offset(offset).limit(limit).subquery()
+
+    # user
+    query = session \
+        .query(User,
+               table_usage_subquery.c.table_read_count,
+               dashboard_usage_subquery.c.dashboard_read_count,
+               table_owner_subquery.c.table_own_count,
+               dashboard_owner_subquery.c.dashboard_own_count,
+               table_follower_subquery.c.table_follow_count,
+               dashboard_follower_subquery.c.dashboard_follow_count) \
+        .join(table_usage_subquery, table_usage_subquery.c.rk == User.rk) \
+        .join(dashboard_usage_subquery, dashboard_usage_subquery.c.rk == User.rk) \
+        .join(table_owner_subquery, table_owner_subquery.c.rk == User.rk) \
+        .join(dashboard_owner_subquery, dashboard_owner_subquery.c.rk == User.rk) \
+        .join(table_follower_subquery, table_follower_subquery.c.rk == User.rk) \
+        .join(dashboard_follower_subquery, dashboard_follower_subquery.c.rk == User.rk)
+
+    # manager
+    query = query.options(
+        subqueryload(User.manager).options(
+            load_only(User.email)
+        )
+    )
+
+    return query.all()
+
+
+def _user_search(session: Session, published_tag: str, limit: int) -> List[Dict]:
+    """
+    Query user metadata.
+    :param session:
+    :param published_tag:
+    :param limit:
+    :return:
+    """
+    LOGGER.info('Querying user metadata.')
+
+    user_filter = [User.full_name.isnot(None)]
+    if published_tag:
+        user_filter.append(User.published_tag == published_tag)
+
+    user_results = []
+
+    offset = 0
+    query_results = _user_search_query(session, user_filter, offset, limit)
+    while query_results:
+        for query_result in query_results:
+            user = query_result.User
+            table_read_count = int(query_result.table_read_count) if query_result.table_read_count else 0
+            dashboard_read_count = int(query_result.dashboard_read_count) if query_result.dashboard_read_count else 0
+            total_read_count = table_read_count + dashboard_read_count
+
+            table_own_count = query_result.table_own_count
+            dashboard_own_count = query_result.dashboard_own_count
+            total_own_count = table_own_count + dashboard_own_count
+
+            table_follow_count = query_result.table_follow_count
+            dashboard_follow_count = query_result.dashboard_follow_count
+            total_follow_count = table_follow_count + dashboard_follow_count
+
+            manager_email = user.manager.email if user.manager else ''
+            user_result = dict(email=user.email,
+                               first_name=user.first_name,
+                               last_name=user.last_name,
+                               full_name=user.full_name,
+                               github_username=user.github_username,
+                               team_name=user.team_name,
+                               employee_type=user.employee_type,
+                               manager_email=manager_email,
+                               slack_id=user.slack_id,
+                               role_name=user.role_name,
+                               is_active=user.is_active,
+                               total_read=total_read_count,
+                               total_own=total_own_count,
+                               total_follow=total_follow_count)
+
+            user_results.append(user_result)
+
+        offset += limit
+        query_results = _user_search_query(session, user_filter, offset, limit)
+
+    return user_results
+
+
+class MySQLSearchDataExtractor(Extractor):
+    """
+    Extractor to fetch data required to support search from MySQL.
+    """
+    ENTITY_TYPE = 'entity_type'
+    MODEL_CLASS = 'model_class'
+    JOB_PUBLISH_TAG = 'job_publish_tag'
+    SEARCH_FUNCTION = 'search_function'
+
+    CONN_STRING = 'conn_string'
+    ENGINE_ECHO = 'engine_echo'
+    CONNECT_ARGS = 'connect_args'
+    QUERY_LIMIT = 'query_limit'
+
+    _DEFAULT_QUERY_LIMIT = 500
+    _DEFAULT_SEARCH_BY_ENTITY: Dict[str, Callable] = {
+        'table': _table_search,
+        'user': _user_search,
+        'dashboard': _dashboard_search
+    }
+
+    def init(self, conf: ConfigTree) -> None:
+        self.conf = conf
+        self.entity = conf.get_string(MySQLSearchDataExtractor.ENTITY_TYPE, default='table').lower()
+        if MySQLSearchDataExtractor.SEARCH_FUNCTION in conf:
+            self.search_function = conf.get(MySQLSearchDataExtractor.SEARCH_FUNCTION)
+        else:
+            self.search_function = MySQLSearchDataExtractor._DEFAULT_SEARCH_BY_ENTITY[self.entity]
+        self.published_tag = conf.get_string(MySQLSearchDataExtractor.JOB_PUBLISH_TAG, '')
+        self.query_limit = conf.get_int(MySQLSearchDataExtractor.QUERY_LIMIT, self._DEFAULT_QUERY_LIMIT)
+
+        connect_args = {k: v for k, v in self.conf.get_config(MySQLSearchDataExtractor.CONNECT_ARGS,
+                                                              default=ConfigTree()).items()}
+        self._engine = create_engine(conf.get_string(MySQLSearchDataExtractor.CONN_STRING),
+                                     echo=conf.get_bool(MySQLSearchDataExtractor.ENGINE_ECHO, False),
+                                     connect_args=connect_args)
+        self._session_factory = sessionmaker(bind=self._engine)
+
+        model_class = conf.get(MySQLSearchDataExtractor.MODEL_CLASS, None)
+        if model_class:
+            module_name, class_name = model_class.rsplit(".", 1)
+            mod = importlib.import_module(module_name)
+            self.model_class = getattr(mod, class_name)
+
+        self._extract_iter: Optional[Iterator] = None
+
+    def close(self) -> None:
+        """
+        Close connection to mysql.
+        """
+        try:
+            self._engine.dispose()
+        except Exception as e:
+            LOGGER.error(f'Exception encountered while closing engine: {e}')
+
+    def extract(self) -> Optional[Any]:
+        """
+        Return an object or a raw query result.
+        """
+        if not self._extract_iter:
+            self._extract_iter = self._get_extract_iter()
+
+        try:
+            return next(self._extract_iter)
+        except StopIteration:
+            return None
+
+    def _get_extract_iter(self) -> Iterator[Any]:
+        if not hasattr(self, 'results'):
+            session = self._session_factory()
+            try:
+                self.results = self.search_function(session=session,
+                                                    published_tag=self.published_tag,
+                                                    limit=self.query_limit)
+            except Exception as e:
+                LOGGER.exception('Exception encountered while executing the search function.')
+                raise e
+            finally:
+                session.close()
+
+        for result in self.results:
+            if hasattr(self, 'model_class'):
+                obj = self.model_class(**result)
+                yield obj
+            else:
+                yield result
+
+    def get_scope(self) -> str:
+        return 'extractor.mysql_search_data'

--- a/databuilder/extractor/mysql_search_data_extractor.py
+++ b/databuilder/extractor/mysql_search_data_extractor.py
@@ -219,9 +219,10 @@ def _dashboard_search_query(session: Session, dashboard_filter: List, offset: in
     # execution
     query = query.options(
         subqueryload(Dashboard.execution).options(
-            load_only(DashboardExecution.rk)
+            load_only(DashboardExecution.rk, DashboardExecution.timestamp)
         )
     )
+
     # usage
     query = query.options(
         subqueryload(Dashboard.usage).options(

--- a/databuilder/loader/file_system_mysql_csv_loader.py
+++ b/databuilder/loader/file_system_mysql_csv_loader.py
@@ -1,0 +1,163 @@
+# Copyright Contributors to the Amundsen project.
+# SPDX-License-Identifier: Apache-2.0
+
+import csv
+import logging
+import os
+import shutil
+from csv import DictWriter
+from typing import (
+    Any, Dict, FrozenSet,
+)
+
+from pyhocon import ConfigFactory, ConfigTree
+
+from databuilder.job.base_job import Job
+from databuilder.loader.base_loader import Loader
+from databuilder.models.table_serializable import TableSerializable
+from databuilder.serializers import mysql_serializer
+from databuilder.utils.closer import Closer
+
+LOGGER = logging.getLogger(__name__)
+
+
+class FSMySQLCSVLoader(Loader):
+    """
+    Write table record CSV file(s) that can be consumed by MySQLCsvPublisher.
+    It assumes that the record it consumes is instance of TableSerializable.
+    """
+    # Config keys
+    RECORD_DIR_PATH = 'record_dir_path'
+    FORCE_CREATE_DIR = 'force_create_directory'
+    SHOULD_DELETE_CREATED_DIR = 'delete_created_directories'
+
+    _DEFAULT_CONFIG = ConfigFactory.from_dict({
+        SHOULD_DELETE_CREATED_DIR: True,
+        FORCE_CREATE_DIR: False
+    })
+
+    def __init__(self) -> None:
+        self._record_file_mapping: Dict[Any, DictWriter] = {}
+        self._keys: Dict[FrozenSet[str], int] = {}
+        self._closer = Closer()
+
+    def init(self, conf: ConfigTree) -> None:
+        """
+        Initializing FsMySQLCSVLoader by creating directory for record files.
+        Note that the directory defined in configuration should not exist.
+        :param conf:
+        :return:
+        """
+        conf = conf.with_fallback(FSMySQLCSVLoader._DEFAULT_CONFIG)
+
+        self._record_dir = conf.get_string(FSMySQLCSVLoader.RECORD_DIR_PATH)
+        self._delete_created_dir = conf.get_bool(FSMySQLCSVLoader.SHOULD_DELETE_CREATED_DIR)
+        self._force_create_dir = conf.get_bool(FSMySQLCSVLoader.FORCE_CREATE_DIR)
+        self._create_directory(self._record_dir)
+
+    def _create_directory(self, path: str) -> None:
+        """
+        Validate directory does not exist, creates it, register deletion of
+        created directory function to Job.closer.
+        :param path:
+        :return:
+        """
+        if os.path.exists(path):
+            if self._force_create_dir:
+                LOGGER.info(f'Directory exist. Deleting directory {path}')
+                shutil.rmtree(path)
+            else:
+                raise RuntimeError(f'Directory should not exist: {path}')
+
+        os.makedirs(path)
+
+        def _delete_dir() -> None:
+            if not self._delete_created_dir:
+                LOGGER.warning(f'Skip Deleting directory {path}')
+                return
+
+            LOGGER.info(f'Deleting directory {path}')
+            shutil.rmtree(path)
+
+        # Directory should be deleted after publish is finished
+        Job.closer.register(_delete_dir)
+
+    def load(self, csv_serializable: TableSerializable) -> None:
+        """
+        Writes TableSerializable records into CSV files.
+        There are multiple CSV files meaning different tables that this method writes.
+
+        Common pattern for table records:
+         1. retrieve csv row (a dict where keys represent a header,
+         values represent a row)
+         2. using this dict to get a appropriate csv writer and write to it.
+         3. repeat 1 and 2
+
+        :param csv_serializable:
+        :return:
+        """
+        record = csv_serializable.next_record()
+        while record:
+            record_dict = mysql_serializer.serialize_record(record)
+            table_name = record.__tablename__
+            key = (table_name, self._make_key(record_dict))
+            file_suffix = '{}_{}'.format(*key)
+            record_writer = self._get_writer(record_dict,
+                                             self._record_file_mapping,
+                                             key,
+                                             self._record_dir,
+                                             file_suffix)
+            record_writer.writerow(record_dict)
+            record = csv_serializable.next_record()
+
+    def _get_writer(self,
+                    csv_record_dict: Dict[str, Any],
+                    file_mapping: Dict[Any, DictWriter],
+                    key: Any,
+                    dir_path: str,
+                    file_suffix: str
+                    ) -> DictWriter:
+        """
+        Finds a writer based on csv record, key.
+        If writer does not exist, it's creates a csv writer and update the mapping.
+
+        :param csv_record_dict:
+        :param file_mapping:
+        :param key:
+        :param dir_path:
+        :param file_suffix:
+        :return:
+        """
+        writer = file_mapping.get(key)
+        if writer:
+            return writer
+
+        LOGGER.info(f'Creating file for {key}')
+
+        file_out = open(f'{dir_path}/{file_suffix}.csv', 'w', encoding='utf8')
+        writer = csv.DictWriter(file_out, fieldnames=csv_record_dict.keys(),
+                                quoting=csv.QUOTE_NONNUMERIC)
+
+        def file_out_close() -> None:
+            LOGGER.info(f'Closing file IO {file_out}')
+            file_out.close()
+        self._closer.register(file_out_close)
+
+        writer.writeheader()
+        file_mapping[key] = writer
+
+        return writer
+
+    def close(self) -> None:
+        """
+        Any closeable callable registered in _closer, it will close.
+        :return:
+        """
+        self._closer.close()
+
+    def get_scope(self) -> str:
+        return "loader.mysql_filesystem_csv"
+
+    def _make_key(self, record_dict: Dict[str, Any]) -> int:
+        """ Each unique set of record keys is assigned an increasing numeric key """
+        return self._keys.setdefault(frozenset(record_dict.keys()), len(self._keys))

--- a/databuilder/publisher/mysql_csv_publisher.py
+++ b/databuilder/publisher/mysql_csv_publisher.py
@@ -1,0 +1,207 @@
+# Copyright Contributors to the Amundsen project.
+# SPDX-License-Identifier: Apache-2.0
+
+import logging
+import time
+from os import listdir
+from os.path import (
+    basename, isfile, join, splitext,
+)
+from typing import (
+    Dict, List, Optional, Type,
+)
+
+import pandas
+from amundsen_rds.models import RDSModel
+from amundsen_rds.models.base import Base
+from pyhocon import ConfigFactory, ConfigTree
+from sqlalchemy import create_engine
+from sqlalchemy.orm import Session, sessionmaker
+
+from databuilder.publisher.base_publisher import Publisher
+
+LOGGER = logging.getLogger(__name__)
+
+
+class MySQLCSVPublisher(Publisher):
+    """
+    A Publisher takes the table record folder as input and publishes csv to MySQL.
+    The folder contains CSV file(s) for table records.
+
+    The publish job works with rds models and SQLAlchemy ORM for data ingestion into MySQL.
+    For more information:
+    rds models: https://github.com/amundsen-io/amundsenrds
+    SQLAlchemy ORM: https://docs.sqlalchemy.org/en/13/orm/
+    """
+    # Config keys
+    # A directory that contains CSV files for records
+    RECORD_FILES_DIR = 'record_files_directory'
+    # It is used to provide unique tag to each record
+    JOB_PUBLISH_TAG = 'job_publish_tag'
+
+    # Connection string
+    CONN_STRING = 'conn_string'
+    # If its value is true, SQLAlchemy engine will log all statements
+    ENGINE_ECHO = 'engine_echo'
+    # Additional arguments used for engine
+    CONNECT_ARGS = 'connect_args'
+    # A transaction size that determines how often it commits.
+    TRANSACTION_SIZE = 'transaction_size'
+    # A progress report frequency that determines how often it report the progress.
+    PROGRESS_REPORT_FREQUENCY = 'progress_report_frequency'
+
+    _DEFAULT_CONFIG = ConfigFactory.from_dict({TRANSACTION_SIZE: 500,
+                                               PROGRESS_REPORT_FREQUENCY: 500,
+                                               ENGINE_ECHO: False})
+
+    def __init__(self) -> None:
+        super(MySQLCSVPublisher, self).__init__()
+
+    def init(self, conf: ConfigTree) -> None:
+        conf = conf.with_fallback(MySQLCSVPublisher._DEFAULT_CONFIG)
+
+        self._count: int = 0
+        self._progress_report_frequency = conf.get_int(MySQLCSVPublisher.PROGRESS_REPORT_FREQUENCY)
+        self._record_files = self._list_files(conf, MySQLCSVPublisher.RECORD_FILES_DIR)
+        self._sorted_record_files = self._sort_record_files(self._record_files)
+        self._record_files_iter = iter(self._sorted_record_files)
+
+        connect_args = {k: v for k, v in conf.get_config(MySQLCSVPublisher.CONNECT_ARGS,
+                                                         default=ConfigTree()).items()}
+        self._engine = create_engine(conf.get_string(MySQLCSVPublisher.CONN_STRING),
+                                     echo=conf.get_bool(MySQLCSVPublisher.ENGINE_ECHO),
+                                     connect_args=connect_args)
+        self._session_factory = sessionmaker(bind=self._engine)
+        self._transaction_size = conf.get_int(MySQLCSVPublisher.TRANSACTION_SIZE)
+
+        self._publish_tag: str = conf.get_string(MySQLCSVPublisher.JOB_PUBLISH_TAG)
+        if not self._publish_tag:
+            raise Exception(f'{MySQLCSVPublisher.JOB_PUBLISH_TAG} should not be empty')
+
+    def _list_files(self, conf: ConfigTree, path_key: str) -> List[str]:
+        """
+        List files from directory
+        :param conf:
+        :param path_key:
+        :return: List of file paths
+        """
+        if path_key not in conf:
+            return []
+
+        path = conf.get_string(path_key)
+        return [join(path, f) for f in listdir(path) if isfile(join(path, f))]
+
+    def _sort_record_files(self, files: List[str]) -> List[str]:
+        """
+        Sort record files in the order of table dependencies
+        :param files:
+        :return:
+        """
+        sorted_table_names = [table.name for table in Base.metadata.sorted_tables]
+        return sorted(files, key=lambda file: sorted_table_names.index(self._get_table_name_from_file(file)))
+
+    def _get_table_name_from_file(self, file: str) -> str:
+        """
+        Get table name from file path
+        :param file:
+        :return:
+        """
+        try:
+            filename = splitext(basename(file))[0]
+            table_name, _ = filename.rsplit('_', 1)
+            return table_name
+        except Exception as e:
+            LOGGER.exception(f'Error encountered while getting table name from file: {file}')
+            raise e
+
+    def publish_impl(self) -> None:
+        """
+        Publish records
+        :return:
+        """
+        start = time.time()
+
+        LOGGER.info(f'Publishing record files: {self._sorted_record_files}')
+        session = self._session_factory()
+        try:
+            while True:
+                try:
+                    record_file = next(self._record_files_iter)
+                    self._publish(record_file=record_file, session=session)
+                except StopIteration:
+                    break
+
+            LOGGER.info(f'Committed total {self._count} statements')
+            LOGGER.info(f'Successfully published. Elapsed: {time.time() - start} seconds')
+        except Exception as e:
+            LOGGER.exception('Failed to publish. Rolling back.')
+            session.rollback()
+            raise e
+        finally:
+            session.close()
+
+    def _publish(self, record_file: str, session: Session) -> None:
+        """
+        Iterate over each row of the given csv file and convert each record to a rds model instance.
+        Then the model instance will be inserted/updated in mysql.
+        :param record_file:
+        :param session:
+        :return:
+        """
+        with open(record_file, 'r', encoding='utf8') as record_csv:
+            table_name = self._get_table_name_from_file(record_file)
+            table_model = self._get_model_from_table_name(table_name)
+            if not table_model:
+                raise RuntimeError(f'Failed to get model for table: {table_name}')
+
+            for record_dict in pandas.read_csv(record_csv, na_filter=False).to_dict(orient='records'):
+                record = self._create_record(model=table_model, record_dict=record_dict)
+                session.merge(record)
+                self._execute(session)
+            session.commit()
+
+    def _get_model_from_table_name(self, table_name: str) -> Optional[Type[RDSModel]]:
+        """
+        Get rds model for the given table name
+        :param table_name:
+        :return:
+        """
+        for model in Base._decl_class_registry.values():
+            if hasattr(model, '__tablename__') and model.__tablename__ == table_name:
+                return model
+        return None
+
+    def _create_record(self, model: Type[RDSModel], record_dict: Dict) -> RDSModel:
+        """
+        Convert the record dict to an instance of the given rds model
+        and set additional attributes for the record instance
+        :param model:
+        :param record_dict:
+        :return:
+        """
+        record = model(**record_dict)
+        record.published_tag = self._publish_tag
+        record.publisher_last_updated_epoch_ms = int(time.time() * 1000)
+        return record
+
+    def _execute(self, session: Session) -> None:
+        """
+        Commit pending record changes
+        :param session:
+        :return:
+        """
+        try:
+            self._count += 1
+            if self._count > 1 and self._count % self._transaction_size == 0:
+                session.commit()
+                LOGGER.info(f'Committed {self._count} records so far')
+
+            if self._count > 1 and self._count % self._progress_report_frequency == 0:
+                LOGGER.info(f'Processed {self._count} records so far')
+
+        except Exception as e:
+            LOGGER.exception('Failed to commit changes')
+            raise e
+
+    def get_scope(self) -> str:
+        return 'publisher.mysql'

--- a/example/scripts/sample_data_loader_mysql.py
+++ b/example/scripts/sample_data_loader_mysql.py
@@ -1,0 +1,303 @@
+# Copyright Contributors to the Amundsen project.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+TODO: it needs db init(in dev) first in metadata service
+This is a example script demonstrating how to load data into MySQL and
+Elasticsearch without using an Airflow DAG.
+
+It contains several jobs:
+- `run_csv_job`: runs a job that extracts table data from a CSV, loads (writes)
+  this into a different local directory as a csv, then publishes this data to
+  mysql.
+- `run_table_column_job`: does the same thing as `run_csv_job`, but with a csv
+  containing column data.
+- `create_last_updated_job`: creates a job that gets the current time, dumps it
+  into a predefined model schema, and publishes this to mysql.
+- `create_es_publisher_sample_job`: creates a job that extracts data from mysql
+  and publishes it into elasticsearch.
+
+For other available extractors, please take a look at
+https://github.com/amundsen-io/amundsendatabuilder#list-of-extractors
+"""
+
+import logging
+import os
+import sys
+import uuid
+
+from elasticsearch import Elasticsearch
+from pyhocon import ConfigFactory
+
+from databuilder.extractor.csv_extractor import CsvExtractor, CsvTableColumnExtractor
+from databuilder.extractor.es_last_updated_extractor import EsLastUpdatedExtractor
+from databuilder.extractor.mysql_search_data_extractor import MySQLSearchDataExtractor
+from databuilder.job.job import DefaultJob
+from databuilder.loader.file_system_elasticsearch_json_loader import FSElasticsearchJSONLoader
+from databuilder.loader.file_system_mysql_csv_loader import FSMySQLCSVLoader
+from databuilder.publisher.elasticsearch_constants import (
+    DASHBOARD_ELASTICSEARCH_INDEX_MAPPING, USER_ELASTICSEARCH_INDEX_MAPPING,
+)
+from databuilder.publisher.elasticsearch_publisher import ElasticsearchPublisher
+from databuilder.publisher.mysql_csv_publisher import MySQLCSVPublisher
+from databuilder.task.task import DefaultTask
+from databuilder.transformer.base_transformer import ChainedTransformer, NoopTransformer
+from databuilder.transformer.dict_to_model import DictToModel
+from databuilder.transformer.generic_transformer import GenericTransformer
+
+es_host = os.getenv('CREDENTIALS_ELASTICSEARCH_PROXY_HOST', 'localhost')
+es_port = os.getenv('CREDENTIALS_ELASTICSEARCH_PROXY_PORT', 9200)
+
+mysql_host = os.getenv('CREDENTIALS_MYSQL_PROXY_HOST', 'localhost')
+mysql_port = os.getenv('CREDENTIALS_MYSQL_PROXY_PORT', 3306)
+mysql_db = os.getenv('CREDENTIALS_MYSQL_PROXY_DATABASE', 'test')
+
+if len(sys.argv) > 1:
+    es_host = sys.argv[1]
+if len(sys.argv) > 2:
+    mysql_host = sys.argv[2]
+
+es = Elasticsearch([
+    {'host': es_host, 'port': es_port},
+])
+
+mysql_user = 'root'
+mysql_password = 'password'
+
+mysql_conn_string = f'mysql://{mysql_user}:{mysql_password}@{mysql_host}:{mysql_port}/{mysql_db}'
+
+
+LOGGER = logging.getLogger(__name__)
+
+
+def run_csv_job(file_loc, job_name, model):
+    tmp_folder = f'/var/tmp/amundsen/{job_name}'
+    record_files_folder = f'{tmp_folder}/records'
+
+    csv_extractor = CsvExtractor()
+    csv_loader = FSMySQLCSVLoader()
+
+    task = DefaultTask(extractor=csv_extractor,
+                       loader=csv_loader,
+                       transformer=NoopTransformer())
+
+    job_config = ConfigFactory.from_dict({
+        'extractor.csv.file_location': file_loc,
+        'extractor.csv.model_class': model,
+        'loader.mysql_filesystem_csv.record_dir_path': record_files_folder,
+        'loader.mysql_filesystem_csv.delete_created_directories': True,
+        'publisher.mysql.record_files_directory': record_files_folder,
+        'publisher.mysql.conn_string': mysql_conn_string,
+        'publisher.mysql.job_publish_tag': 'unique_tag',
+    })
+
+    DefaultJob(conf=job_config,
+               task=task,
+               publisher=MySQLCSVPublisher()).launch()
+
+
+def run_table_column_job(table_path, column_path):
+    tmp_folder = '/var/tmp/amundsen/table_column'
+    record_files_folder = f'{tmp_folder}/records'
+
+    extractor = CsvTableColumnExtractor()
+    csv_loader = FSMySQLCSVLoader()
+    task = DefaultTask(extractor,
+                       loader=csv_loader,
+                       transformer=NoopTransformer())
+    job_config = ConfigFactory.from_dict({
+        'extractor.csvtablecolumn.table_file_location': table_path,
+        'extractor.csvtablecolumn.column_file_location': column_path,
+        'loader.mysql_filesystem_csv.record_dir_path': record_files_folder,
+        'loader.mysql_filesystem_csv.delete_created_directories': True,
+        'publisher.mysql.record_files_directory': record_files_folder,
+        'publisher.mysql.conn_string': mysql_conn_string,
+        'publisher.mysql.job_publish_tag': 'unique_tag'
+    })
+    job = DefaultJob(conf=job_config,
+                     task=task,
+                     publisher=MySQLCSVPublisher())
+    job.launch()
+
+
+def create_last_updated_job():
+    # loader saves data to these folders and publisher reads it from here
+    tmp_folder = '/var/tmp/amundsen/last_updated_data'
+    record_files_folder = f'{tmp_folder}/records'
+
+    task = DefaultTask(extractor=EsLastUpdatedExtractor(),
+                       loader=FSMySQLCSVLoader())
+
+    job_config = ConfigFactory.from_dict({
+        'extractor.es_last_updated.model_class': 'databuilder.models.es_last_updated.ESLastUpdated',
+        'loader.mysql_filesystem_csv.record_dir_path': record_files_folder,
+        'loader.mysql_filesystem_csv.delete_created_directories': True,
+        'publisher.mysql.record_files_directory': record_files_folder,
+        'publisher.mysql.conn_string': mysql_conn_string,
+        'publisher.mysql.job_publish_tag': 'unique_tag'
+    })
+
+    return DefaultJob(conf=job_config,
+                      task=task,
+                      publisher=MySQLCSVPublisher())
+
+
+def _str_to_list(str_val):
+    return str_val.split(',')
+
+
+def create_dashboard_tables_job():
+    # loader saves data to these folders and publisher reads it from here
+    tmp_folder = '/var/tmp/amundsen/dashboard_table'
+    record_files_folder = f'{tmp_folder}/records'
+    model_class = 'databuilder.models.dashboard.dashboard_table.DashboardTable'
+
+    csv_extractor = CsvExtractor()
+    csv_loader = FSMySQLCSVLoader()
+
+    generic_transformer = GenericTransformer()
+    dict_to_model_transformer = DictToModel()
+    transformer = ChainedTransformer(transformers=[generic_transformer, dict_to_model_transformer],
+                                     is_init_transformers=True)
+
+    task = DefaultTask(extractor=csv_extractor,
+                       loader=csv_loader,
+                       transformer=transformer)
+    publisher = MySQLCSVPublisher()
+
+    job_config = ConfigFactory.from_dict({
+        'extractor.csv.file_location': 'example/sample_data/sample_dashboard_table.csv',
+        'transformer.chained.transformer.generic.field_name': 'table_ids',
+        'transformer.chained.transformer.generic.callback_function': _str_to_list,
+        'transformer.chained.transformer.dict_to_model.model_class': model_class,
+        'loader.mysql_filesystem_csv.record_dir_path': record_files_folder,
+        'loader.mysql_filesystem_csv.delete_created_directories': True,
+        'publisher.mysql.record_files_directory': record_files_folder,
+        'publisher.mysql.conn_string': mysql_conn_string,
+        'publisher.mysql.job_publish_tag': 'unique_tag',
+    })
+
+    return DefaultJob(conf=job_config,
+                      task=task,
+                      publisher=publisher)
+
+
+def create_es_publisher_sample_job(elasticsearch_index_alias='table_search_index',
+                                   elasticsearch_doc_type_key='table',
+                                   model_name='databuilder.models.table_elasticsearch_document.TableESDocument',
+                                   entity_type='table',
+                                   elasticsearch_mapping=None):
+    """
+    :param elasticsearch_index_alias:  alias for Elasticsearch used in
+                                       amundsensearchlibrary/search_service/config.py as an index
+    :param elasticsearch_doc_type_key: name the ElasticSearch index is prepended with. Defaults to `table` resulting in
+                                       `table_{uuid}`
+    :param model_name:                 the Databuilder model class used in transporting between Extractor and Loader
+    :param entity_type:                Entity type handed to the `MySQLSearchDataExtractor` class, used to determine
+                                       search function to extract data from MySQL. Defaults to `table`.
+    :param elasticsearch_mapping:      Elasticsearch field mapping "DDL" handed to the `ElasticsearchPublisher` class,
+                                       if None is given (default) it uses the `Table` query baked into the Publisher
+    """
+    # loader saves data to this location and publisher reads it from here
+    extracted_search_data_path = '/var/tmp/amundsen/search_data.json'
+
+    task = DefaultTask(loader=FSElasticsearchJSONLoader(),
+                       extractor=MySQLSearchDataExtractor(),
+                       transformer=NoopTransformer())
+
+    # elastic search client instance
+    elasticsearch_client = es
+    # unique name of new index in Elasticsearch
+    elasticsearch_new_index_key = f'{elasticsearch_doc_type_key}_{uuid.uuid4()}'
+
+    job_config = ConfigFactory.from_dict({
+        'extractor.mysql_search_data.conn_string': mysql_conn_string,
+        'extractor.mysql_search_data.entity_type': entity_type,
+        'extractor.mysql_search_data.model_class': model_name,
+        'loader.filesystem.elasticsearch.file_path': extracted_search_data_path,
+        'loader.filesystem.elasticsearch.mode': 'w',
+        'publisher.elasticsearch.file_path': extracted_search_data_path,
+        'publisher.elasticsearch.mode': 'r',
+        'publisher.elasticsearch.client': elasticsearch_client,
+        'publisher.elasticsearch.new_index': elasticsearch_new_index_key,
+        'publisher.elasticsearch.doc_type': elasticsearch_doc_type_key,
+        'publisher.elasticsearch.alias': elasticsearch_index_alias,
+    })
+
+    # only optionally add these keys, so need to dynamically `put` them
+    if elasticsearch_mapping:
+        job_config.put(f'publisher.elasticsearch.{ElasticsearchPublisher.ELASTICSEARCH_MAPPING_CONFIG_KEY}',
+                       elasticsearch_mapping)
+
+    job = DefaultJob(conf=job_config,
+                     task=task,
+                     publisher=ElasticsearchPublisher())
+    return job
+
+
+if __name__ == "__main__":
+    # Uncomment next line to get INFO level logging
+    # logging.basicConfig(level=logging.INFO)
+
+    run_table_column_job('example/sample_data/sample_table.csv', 'example/sample_data/sample_col.csv')
+    run_csv_job('example/sample_data/sample_table_column_stats.csv', 'test_table_column_stats',
+                'databuilder.models.table_stats.TableColumnStats')
+    run_csv_job('example/sample_data/sample_table_programmatic_source.csv', 'test_programmatic_source',
+                'databuilder.models.table_metadata.TableMetadata')
+    run_csv_job('example/sample_data/sample_watermark.csv', 'test_watermark_metadata',
+                'databuilder.models.watermark.Watermark')
+    run_csv_job('example/sample_data/sample_user.csv', 'test_user_metadata',
+                'databuilder.models.user.User')
+    run_csv_job('example/sample_data/sample_table_owner.csv', 'test_table_owner_metadata',
+                'databuilder.models.table_owner.TableOwner')
+    run_csv_job('example/sample_data/sample_column_usage.csv', 'test_usage_metadata',
+                'databuilder.models.column_usage_model.ColumnUsageModel')
+    run_csv_job('example/sample_data/sample_application.csv', 'test_application_metadata',
+                'databuilder.models.application.Application')
+    run_csv_job('example/sample_data/sample_source.csv', 'test_source_metadata',
+                'databuilder.models.table_source.TableSource')
+    run_csv_job('example/sample_data/sample_tags.csv', 'test_tag_metadata',
+                'databuilder.models.table_metadata.TagMetadata')
+    run_csv_job('example/sample_data/sample_table_last_updated.csv', 'test_table_last_updated_metadata',
+                'databuilder.models.table_last_updated.TableLastUpdated')
+    run_csv_job('example/sample_data/sample_schema_description.csv', 'test_schema_description',
+                'databuilder.models.schema.schema.SchemaModel')
+    run_csv_job('example/sample_data/sample_dashboard_base.csv', 'test_dashboard_base',
+                'databuilder.models.dashboard.dashboard_metadata.DashboardMetadata')
+    run_csv_job('example/sample_data/sample_dashboard_usage.csv', 'test_dashboard_usage',
+                'databuilder.models.dashboard.dashboard_usage.DashboardUsage')
+    run_csv_job('example/sample_data/sample_dashboard_owner.csv', 'test_dashboard_owner',
+                'databuilder.models.dashboard.dashboard_owner.DashboardOwner')
+    run_csv_job('example/sample_data/sample_dashboard_query.csv', 'test_dashboard_query',
+                'databuilder.models.dashboard.dashboard_query.DashboardQuery')
+    run_csv_job('example/sample_data/sample_dashboard_last_execution.csv', 'test_dashboard_last_execution',
+                'databuilder.models.dashboard.dashboard_execution.DashboardExecution')
+    run_csv_job('example/sample_data/sample_dashboard_last_modified.csv', 'test_dashboard_last_modified',
+                'databuilder.models.dashboard.dashboard_last_modified.DashboardLastModifiedTimestamp')
+
+    create_dashboard_tables_job().launch()
+
+    create_last_updated_job().launch()
+
+    job_es_table = create_es_publisher_sample_job(
+        elasticsearch_index_alias='table_search_index',
+        elasticsearch_doc_type_key='table',
+        entity_type='table',
+        model_name='databuilder.models.table_elasticsearch_document.TableESDocument')
+    job_es_table.launch()
+
+    job_es_user = create_es_publisher_sample_job(
+        elasticsearch_index_alias='user_search_index',
+        elasticsearch_doc_type_key='user',
+        model_name='databuilder.models.user_elasticsearch_document.UserESDocument',
+        entity_type='user',
+        elasticsearch_mapping=USER_ELASTICSEARCH_INDEX_MAPPING)
+    job_es_user.launch()
+
+    job_es_dashboard = create_es_publisher_sample_job(
+        elasticsearch_index_alias='dashboard_search_index',
+        elasticsearch_doc_type_key='dashboard',
+        model_name='databuilder.models.dashboard_elasticsearch_document.DashboardESDocument',
+        entity_type='dashboard',
+        elasticsearch_mapping=DASHBOARD_ELASTICSEARCH_INDEX_MAPPING)
+    job_es_dashboard.launch()

--- a/requirements.txt
+++ b/requirements.txt
@@ -45,7 +45,7 @@ pluggy>=0.6.0
 py==1.5.3
 pyhocon==0.3.42
 pyparsing==2.2.0
-sqlalchemy>=1.3.0,<2.0
+sqlalchemy>=1.3.6,<1.4
 wheel==0.31.1
 neo4j-driver==1.7.2
 neotime==1.7.1
@@ -65,4 +65,4 @@ responses==0.10.6
 
 pyatlasclient==1.1.2
 
-amundsen-rds>=0.0.3
+amundsen-rds>=0.0.4

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ requirements = [
     "unidecode",
     "Jinja2>=2.10.0,<2.12",
     "pandas>=0.21.0,<1.2.0",
-    "amundsen-rds"
+    "amundsen-rds>=0.0.4"
 ]
 
 kafka = ['confluent-kafka==1.0.0']
@@ -80,8 +80,13 @@ atlas = [
     'pyatlasclient==1.1.2'
 ]
 
+rds = [
+    'sqlalchemy>=1.3.6,<1.4'
+    'mysqlclient>=1.3.6,<3'
+]
+
 all_deps = requirements + kafka + cassandra + glue + snowflake + athena + \
-    bigquery + jsonpath + db2 + dremio + druid + spark + feast + neptune
+    bigquery + jsonpath + db2 + dremio + druid + spark + feast + neptune + rds
 
 setup(
     name='amundsen-databuilder',
@@ -109,7 +114,8 @@ setup(
         'neptune': neptune,
         'delta': spark,
         'feast': feast,
-        'atlas': atlas
+        'atlas': atlas,
+        'rds': rds
     },
     classifiers=[
         'Programming Language :: Python :: 3.6',

--- a/tests/unit/extractor/test_mysql_search_data_extractor.py
+++ b/tests/unit/extractor/test_mysql_search_data_extractor.py
@@ -1,0 +1,257 @@
+# Copyright Contributors to the Amundsen project.
+# SPDX-License-Identifier: Apache-2.0
+
+import unittest
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+from amundsen_rds.models.badge import Badge
+from amundsen_rds.models.cluster import Cluster
+from amundsen_rds.models.column import ColumnDescription, TableColumn
+from amundsen_rds.models.dashboard import (
+    Dashboard, DashboardChart, DashboardCluster, DashboardDescription, DashboardExecution, DashboardGroup,
+    DashboardGroupDescription, DashboardQuery, DashboardUsage,
+)
+from amundsen_rds.models.database import Database
+from amundsen_rds.models.schema import Schema, SchemaDescription
+from amundsen_rds.models.table import (
+    Table, TableDescription, TableProgrammaticDescription, TableTimestamp, TableUsage,
+)
+from amundsen_rds.models.tag import Tag
+from amundsen_rds.models.user import User
+from pyhocon import ConfigFactory
+
+from databuilder import Scoped
+from databuilder.extractor import mysql_search_data_extractor
+from databuilder.extractor.mysql_search_data_extractor import MySQLSearchDataExtractor
+from databuilder.models.dashboard_elasticsearch_document import DashboardESDocument
+from databuilder.models.table_elasticsearch_document import TableESDocument
+from databuilder.models.user_elasticsearch_document import UserESDocument
+
+
+class MyTestCase(unittest.TestCase):
+    def setUp(self) -> None:
+        self.maxDiff = None
+
+    @patch.object(mysql_search_data_extractor, '_table_search_query')
+    @patch.object(mysql_search_data_extractor, 'sessionmaker')
+    @patch.object(mysql_search_data_extractor, 'create_engine')
+    def test_table_search(self,
+                          mock_create_engine: Any,
+                          mock_session_maker: Any,
+                          mock_table_search_query: Any) -> None:
+        database = Database(rk='test_database_key', name='test_database')
+        cluster = Cluster(rk='test_cluster_key', name='test_cluster')
+        cluster.database = database
+
+        schema = Schema(rk='test_schema_key', name='test_schema')
+        schema.description = SchemaDescription(rk='test_schema_description_key', description='test_schema_description')
+        schema.cluster = cluster
+
+        table = Table(rk='test_table_key', name='test_table')
+        table.schema = schema
+
+        table.description = TableDescription(rk='test_table_description_key', description='test_table_description')
+        table.programmatic_descriptions = [TableProgrammaticDescription(rk='test_table_prog_description_key',
+                                                                        description='test_table_prog_description')]
+
+        table.timestamp = TableTimestamp(rk='test_table_timestamp_key', last_updated_timestamp=123456789)
+
+        column1 = TableColumn(rk='test_col1_key', name='test_col1')
+        column2 = TableColumn(rk='test_col2_key', name='test_col2')
+        column3 = TableColumn(rk='test_col3_key', name='test_col3')
+        column1.description = ColumnDescription(rk='test_col1_description_key',
+                                                description='test_col1_description')
+        column2.description = ColumnDescription(rk='test_col2_description_key',
+                                                description='test_col2_description')
+        table.columns = [column1, column2, column3]
+
+        usage1 = TableUsage(user_rk='test_user1_key', table_rk='test_table_key', read_count=5)
+        usage2 = TableUsage(user_rk='test_user2_key', table_rk='test_table_key', read_count=10)
+        table.usage = [usage1, usage2]
+
+        tags = [Tag(rk='test_tag', tag_type='default')]
+        table.tags = tags
+
+        badges = [Badge(rk='test_badge')]
+        table.badges = badges
+
+        tables = [table]
+
+        expected_dict = dict(database='test_database',
+                             cluster='test_cluster',
+                             schema='test_schema',
+                             name='test_table',
+                             display_name='test_schema.test_table',
+                             key='test_table_key',
+                             description='test_table_description',
+                             last_updated_timestamp=123456789,
+                             column_names=['test_col1', 'test_col2', 'test_col3'],
+                             column_descriptions=['test_col1_description', 'test_col2_description', ''],
+                             total_usage=15,
+                             unique_usage=2,
+                             tags=['test_tag'],
+                             badges=['test_badge'],
+                             schema_description='test_schema_description',
+                             programmatic_descriptions=['test_table_prog_description'])
+
+        config_dict = {
+            f'extractor.mysql_search_data.{MySQLSearchDataExtractor.CONN_STRING}': 'test_conn_string',
+            f'extractor.mysql_search_data.{MySQLSearchDataExtractor.ENTITY_TYPE}': 'table',
+            f'extractor.mysql_search_data.{MySQLSearchDataExtractor.JOB_PUBLISH_TAG}': 'test_tag',
+            f'extractor.mysql_search_data.{MySQLSearchDataExtractor.MODEL_CLASS}':
+                'databuilder.models.table_elasticsearch_document.TableESDocument'
+        }
+        self.conf = ConfigFactory.from_dict(config_dict)
+
+        extractor = MySQLSearchDataExtractor()
+        extractor.init(Scoped.get_scoped_conf(conf=self.conf,
+                                              scope=extractor.get_scope()))
+
+        mock_table_search_query.side_effect = [tables, None]
+
+        actual_obj = extractor.extract()
+
+        self.assertIsInstance(actual_obj, TableESDocument)
+        self.assertDictEqual(vars(actual_obj), expected_dict)
+
+    @patch.object(mysql_search_data_extractor, '_user_search_query')
+    @patch.object(mysql_search_data_extractor, 'sessionmaker')
+    @patch.object(mysql_search_data_extractor, 'create_engine')
+    def test_user_search(self,
+                         mock_create_engine: Any,
+                         mock_session_maker: Any,
+                         mock_user_search_query: Any) -> None:
+        user = User(rk='test_user_key',
+                    email='test_user@email.com',
+                    first_name='test_first_name',
+                    last_name='test_last_name',
+                    full_name='test_full_name',
+                    github_username='test_github_username',
+                    team_name='test_team_name',
+                    employee_type='test_employee_type',
+                    slack_id='test_slack_id',
+                    role_name='test_role_name',
+                    is_active=True)
+        manager = User(rk='test_manager_key', email='test_manager@email.com')
+        user.manager = manager
+
+        expected_dict = dict(email='test_user@email.com',
+                             first_name='test_first_name',
+                             last_name='test_last_name',
+                             full_name='test_full_name',
+                             github_username='test_github_username',
+                             team_name='test_team_name',
+                             employee_type='test_employee_type',
+                             manager_email='test_manager@email.com',
+                             slack_id='test_slack_id',
+                             role_name='test_role_name',
+                             is_active=True,
+                             total_read=30,
+                             total_own=2,
+                             total_follow=2)
+
+        config_dict = {
+            f'extractor.mysql_search_data.{MySQLSearchDataExtractor.CONN_STRING}': 'test_conn_string',
+            f'extractor.mysql_search_data.{MySQLSearchDataExtractor.ENTITY_TYPE}': 'user',
+            f'extractor.mysql_search_data.{MySQLSearchDataExtractor.JOB_PUBLISH_TAG}': 'test_tag',
+            f'extractor.mysql_search_data.{MySQLSearchDataExtractor.MODEL_CLASS}':
+                'databuilder.models.user_elasticsearch_document.UserESDocument'
+        }
+        self.conf = ConfigFactory.from_dict(config_dict)
+
+        extractor = MySQLSearchDataExtractor()
+        extractor.init(Scoped.get_scoped_conf(conf=self.conf,
+                                              scope=extractor.get_scope()))
+
+        query_results = [MagicMock(User=user,
+                                   table_read_count=10,
+                                   dashboard_read_count=20,
+                                   table_own_count=1,
+                                   dashboard_own_count=1,
+                                   table_follow_count=1,
+                                   dashboard_follow_count=1)]
+        mock_user_search_query.side_effect = [query_results, None]
+
+        actual_obj = extractor.extract()
+
+        self.assertIsInstance(actual_obj, UserESDocument)
+        self.assertDictEqual(vars(actual_obj), expected_dict)
+
+    @patch.object(mysql_search_data_extractor, '_dashboard_search_query')
+    @patch.object(mysql_search_data_extractor, 'sessionmaker')
+    @patch.object(mysql_search_data_extractor, 'create_engine')
+    def test_dashboard_search(self,
+                              mock_create_engine: Any,
+                              mock_session_maker: Any,
+                              mock_dashboard_search_query: Any) -> None:
+        dashboard = Dashboard(rk='test_dashboard//key', name='test_dashboard', dashboard_url='test://dashboard_url')
+        dashboard.description = DashboardDescription(rk='test_dashboard_description_key',
+                                                     description='test_dashboard_description')
+
+        group = DashboardGroup(rk='test_group_key', name='test_group', dashboard_group_url='test://group_url')
+        group.description = DashboardGroupDescription(rk='test_group_description_key',
+                                                      description='test_group_description')
+        dashboard.group = group
+
+        cluster = DashboardCluster(rk='test_cluster_key', name='test_cluster')
+        group.cluster = cluster
+
+        last_exec = DashboardExecution(rk='test_dashboard_exec_key/_last_successful_execution', timestamp=123456789)
+        dashboard.execution = [last_exec]
+
+        usage1 = DashboardUsage(user_rk='test_user1_key', dashboard_rk='test_dashboard_key', read_count=10)
+        usage2 = DashboardUsage(user_rk='test_user2_key', dashboard_rk='test_dashboard_key', read_count=5)
+        dashboard.usage = [usage1, usage2]
+
+        query = DashboardQuery(rk='test_query_key', name='test_query')
+        query.charts = [DashboardChart(rk='test_chart_key', name='test_chart')]
+        dashboard.queries = [query]
+
+        tags = [Tag(rk='test_tag', tag_type='default')]
+        dashboard.tags = tags
+
+        badges = [Badge(rk='test_badge')]
+        dashboard.badges = badges
+
+        dashboards = [dashboard]
+
+        expected_dict = dict(group_name='test_group',
+                             name='test_dashboard',
+                             description='test_dashboard_description',
+                             product='test',
+                             cluster='test_cluster',
+                             group_description='test_group_description',
+                             query_names=['test_query'],
+                             chart_names=['test_chart'],
+                             group_url='test://group_url',
+                             url='test://dashboard_url',
+                             uri='test_dashboard//key',
+                             last_successful_run_timestamp=123456789,
+                             total_usage=15,
+                             tags=['test_tag'],
+                             badges=['test_badge'])
+
+        config_dict = {
+            f'extractor.mysql_search_data.{MySQLSearchDataExtractor.CONN_STRING}': 'test_conn_string',
+            f'extractor.mysql_search_data.{MySQLSearchDataExtractor.ENTITY_TYPE}': 'dashboard',
+            f'extractor.mysql_search_data.{MySQLSearchDataExtractor.JOB_PUBLISH_TAG}': 'test_tag',
+            f'extractor.mysql_search_data.{MySQLSearchDataExtractor.MODEL_CLASS}':
+                'databuilder.models.dashboard_elasticsearch_document.DashboardESDocument'
+        }
+        self.conf = ConfigFactory.from_dict(config_dict)
+
+        extractor = MySQLSearchDataExtractor()
+        extractor.init(Scoped.get_scoped_conf(conf=self.conf,
+                                              scope=extractor.get_scope()))
+
+        mock_dashboard_search_query.side_effect = [dashboards, None]
+
+        actual_obj = extractor.extract()
+
+        self.assertIsInstance(actual_obj, DashboardESDocument)
+        self.assertDictEqual(vars(actual_obj), expected_dict)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/unit/loader/test_file_system_mysql_csv_loader.py
+++ b/tests/unit/loader/test_file_system_mysql_csv_loader.py
@@ -1,0 +1,70 @@
+# Copyright Contributors to the Amundsen project.
+# SPDX-License-Identifier: Apache-2.0
+
+import os
+import unittest
+from collections import OrderedDict
+from csv import DictReader
+from os import listdir
+from os.path import (
+    basename, isfile, join, splitext,
+)
+from typing import Any, Dict
+
+from pyhocon import ConfigFactory
+
+from databuilder.job.base_job import Job
+from databuilder.loader.file_system_mysql_csv_loader import FSMySQLCSVLoader
+from tests.unit.models.test_table_serializable import Actor, Movie
+
+
+class TestFileSystemMySQLCSVLoader(unittest.TestCase):
+    def setUp(self) -> None:
+        directory = '/var/tmp/TestFileSystemMySQLCSVLoader'
+        self._conf = ConfigFactory.from_dict(
+            {
+                FSMySQLCSVLoader.RECORD_DIR_PATH: '{}/{}'.format(directory, 'records'),
+                FSMySQLCSVLoader.SHOULD_DELETE_CREATED_DIR: True,
+                FSMySQLCSVLoader.FORCE_CREATE_DIR: True,
+            }
+        )
+
+    def tearDown(self) -> None:
+        Job.closer.close()
+
+    def test_load(self) -> None:
+        actors = [Actor('Tom Cruise'), Actor('Meg Ryan')]
+        movie = Movie('Top Gun', actors)
+
+        loader = FSMySQLCSVLoader()
+        loader.init(self._conf)
+        loader.load(movie)
+
+        loader.close()
+
+        expected_record_path = '{}/../resources/fs_mysql_csv_loader/records'.format(
+            os.path.join(os.path.dirname(__file__))
+        )
+        expected_records = self._get_csv_rows(expected_record_path)
+        actual_records = self._get_csv_rows(self._conf.get_string(FSMySQLCSVLoader.RECORD_DIR_PATH))
+
+        self.maxDiff = None
+        self.assertDictEqual(expected_records, actual_records)
+
+    def _get_csv_rows(self, path: str) -> Dict[str, Any]:
+        files = [join(path, f) for f in listdir(path) if isfile(join(path, f))]
+
+        result: Dict[str, Any] = {}
+        for f in files:
+            filename = splitext(basename(f))[0]
+            result[filename] = []
+            with open(f, 'r') as f_input:
+                reader = DictReader(f_input)
+                for row in reader:
+                    result[filename].append(OrderedDict(sorted(row.items())))
+
+        return result
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/unit/models/test_table_serializable.py
+++ b/tests/unit/models/test_table_serializable.py
@@ -8,7 +8,7 @@ from typing import (
 
 from amundsen_rds.models import RDSModel
 from sqlalchemy import (
-    Column, ForeignKey, String,
+    BigInteger, Column, ForeignKey, String,
 )
 from sqlalchemy.ext.declarative import declarative_base
 
@@ -61,6 +61,8 @@ class RDSMovie(Base):  # type: ignore
 
     rk = Column(String(128), primary_key=True)
     name = Column(String(128))
+    published_tag = Column(String(128), nullable=False)
+    publisher_last_updated_epoch_ms = Column(BigInteger, nullable=False)
 
 
 class RDSActor(Base):  # type: ignore
@@ -68,6 +70,8 @@ class RDSActor(Base):  # type: ignore
 
     rk = Column(String(128), primary_key=True)
     name = Column(String(128))
+    published_tag = Column(String(128), nullable=False)
+    publisher_last_updated_epoch_ms = Column(BigInteger, nullable=False)
 
 
 class RDSMovieActor(Base):  # type: ignore
@@ -75,6 +79,8 @@ class RDSMovieActor(Base):  # type: ignore
 
     movie_rk = Column(String(128), ForeignKey('movie.rk'), primary_key=True)
     actor_rk = Column(String(128), ForeignKey('actor.rk'), primary_key=True)
+    published_tag = Column(String(128), nullable=False)
+    publisher_last_updated_epoch_ms = Column(BigInteger, nullable=False)
 
 
 class Actor(object):

--- a/tests/unit/publisher/test_mysql_csv_publisher.py
+++ b/tests/unit/publisher/test_mysql_csv_publisher.py
@@ -1,0 +1,63 @@
+# Copyright Contributors to the Amundsen project.
+# SPDX-License-Identifier: Apache-2.0
+
+import os
+import unittest
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+from freezegun import freeze_time
+from pyhocon import ConfigFactory
+
+from databuilder.publisher import mysql_csv_publisher
+from databuilder.publisher.mysql_csv_publisher import MySQLCSVPublisher
+from tests.unit.models.test_table_serializable import Base
+
+here = os.path.dirname(__file__)
+
+
+class TestMySQLPublish(unittest.TestCase):
+
+    def setUp(self) -> None:
+        resource_path = os.path.join(here, f'../resources/mysql_csv_publisher')
+        self.conf = ConfigFactory.from_dict(
+            {
+                MySQLCSVPublisher.CONN_STRING: 'test_connection',
+                MySQLCSVPublisher.RECORD_FILES_DIR: f'{resource_path}/records',
+                MySQLCSVPublisher.JOB_PUBLISH_TAG: 'test'
+            }
+        )
+
+    @freeze_time("2021-01-01 01:01:00")
+    @patch.object(mysql_csv_publisher, 'sessionmaker')
+    @patch.object(mysql_csv_publisher, 'create_engine')
+    def test_publisher_old(self, mock_create_engine: Any, mock_session_maker: Any) -> None:
+        mock_engine = MagicMock()
+        mock_create_engine.return_value = mock_engine
+
+        mock_session_factory = MagicMock()
+        mock_session_maker.return_value = mock_session_factory
+
+        mock_session = MagicMock()
+        mock_session_factory.return_value = mock_session
+
+        mock_merge = MagicMock()
+        mock_session.merge = mock_merge
+
+        mock_commit = MagicMock()
+        mock_session.commit = mock_commit
+
+        mysql_csv_publisher.Base = Base
+
+        publisher = MySQLCSVPublisher()
+        publisher.init(self.conf)
+        publisher.publish()
+
+        # 5 records
+        self.assertEqual(5, mock_merge.call_count)
+        # 3 record files
+        self.assertEqual(3, mock_commit.call_count)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/unit/resources/fs_mysql_csv_loader/records/actor_0.csv
+++ b/tests/unit/resources/fs_mysql_csv_loader/records/actor_0.csv
@@ -1,0 +1,3 @@
+"rk","name"
+"actor://Tom Cruise","Tom Cruise"
+"actor://Meg Ryan","Meg Ryan"

--- a/tests/unit/resources/fs_mysql_csv_loader/records/movie_0.csv
+++ b/tests/unit/resources/fs_mysql_csv_loader/records/movie_0.csv
@@ -1,0 +1,2 @@
+"rk","name"
+"movie://Top Gun","Top Gun"

--- a/tests/unit/resources/fs_mysql_csv_loader/records/movie_actor_1.csv
+++ b/tests/unit/resources/fs_mysql_csv_loader/records/movie_actor_1.csv
@@ -1,0 +1,3 @@
+"movie_rk","actor_rk"
+"movie://Top Gun","actor://Tom Cruise"
+"movie://Top Gun","actor://Meg Ryan"

--- a/tests/unit/resources/mysql_csv_publisher/records/actor_0.csv
+++ b/tests/unit/resources/mysql_csv_publisher/records/actor_0.csv
@@ -1,0 +1,3 @@
+"rk","name"
+"actor://Tom Cruise","Tom Cruise"
+"actor://Meg Ryan","Meg Ryan"

--- a/tests/unit/resources/mysql_csv_publisher/records/movie_0.csv
+++ b/tests/unit/resources/mysql_csv_publisher/records/movie_0.csv
@@ -1,0 +1,2 @@
+"rk","name"
+"movie://Top Gun","Top Gun"

--- a/tests/unit/resources/mysql_csv_publisher/records/movie_actor_1.csv
+++ b/tests/unit/resources/mysql_csv_publisher/records/movie_actor_1.csv
@@ -1,0 +1,3 @@
+"movie_rk","actor_rk"
+"movie://Top Gun","actor://Tom Cruise"
+"movie://Top Gun","actor://Meg Ryan"


### PR DESCRIPTION
<!---
Provide a general summary of your changes in the Title above
Include one of these prefixes:
  fix – Fixes an unexpected problem or unintended behavior
  feat – Adds a new feature
  docs – A documentation improvement task
  build – A task related to our build system
  ci – A task related to our ci system
  perf – A performance improvement
  refactor – A code refactor PR
  style – A task about styling
  test – A PR that improve test coverage
  chore – A regular maintenance chore or task
  other – Any other kind of PR
-->

### Summary of Changes

A feature supporting [RFC:support-mysql-as-backend-store](https://github.com/amundsen-io/rfcs/blob/master/rfcs/023-support-mysql-as-backend-store.md)

Main changes:
- fs\_mysql\_csv\_loader
Read data from record_iterator and the output are csv files, {tablename}\_{key}.csv

- mysql\_csv\_publisher
Read csv files and publish records to mysql with rds orm models.

- mysql\_search\_extractor
Retrieve metadata stored in mysql and outputs instances of the given model or raw results.

- sample_data_loader_mysql
Sample script for publishing metadata into mysql. The script can not work until db init(in dev) is finished and for now, is mainly used to show how ETL works for mysql in the databuilder. (This note was also marked as TODO in the script)

- Pinned sqlalchemy >=1.3.6, < 1.4 to support Load.options() and avoid backward incompatibiliy issue of the latest sqlalchemy version.
### Tests

Units test are added for fs_mysql\_csv\_loader/mysql\_csv\_publisher/mysql\_search\_extractor

### Documentation
N/A

### CheckList

Make sure you have checked **all** steps below to ensure a timely review.

- [x] PR title addresses the issue accurately and concisely. Example: "Updates the version of Flask to v1.0.2"
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
- [x] PR includes a summary of changes.
- [x] PR adds unit tests, updates existing unit tests, **OR** documents why no test additions or modifications are needed.
- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
- [x] PR passes `make test`
