### PR TITLE
ci: Use GITHUB_OUTPUT envvar instead of set-output command

### DIFF
--- a/.github/workflows/monthly_release.yml
+++ b/.github/workflows/monthly_release.yml
@@ -29,7 +29,7 @@ jobs:
           git config user.name github-actions
           git config user.email github-actions@github.com
           semantic-release version
-          echo "version=$(semantic-release print-version --current)" >> $GITHUB_OUTPUT
+          echo "version=$(semantic-release print-version --current)" >> "$GITHUB_OUTPUT"
           semantic-release changelog > './CHANGELOG.md'
       - name: Create release pull request
         uses: peter-evans/create-pull-request@v3

--- a/.github/workflows/monthly_release.yml
+++ b/.github/workflows/monthly_release.yml
@@ -29,7 +29,7 @@ jobs:
           git config user.name github-actions
           git config user.email github-actions@github.com
           semantic-release version
-          echo ::set-output name=version::$(semantic-release print-version --current)
+          echo "version=$(semantic-release print-version --current)" >> $GITHUB_OUTPUT
           semantic-release changelog > './CHANGELOG.md'
       - name: Create release pull request
         uses: peter-evans/create-pull-request@v3

--- a/.github/workflows/publish_release.yml
+++ b/.github/workflows/publish_release.yml
@@ -22,7 +22,7 @@ jobs:
         id: vers
         run: |
           pip install python-semantic-release
-          echo ::set-output name=version::$(semantic-release print-version --current)
+          echo "version=$(semantic-release print-version --current)" >> $GITHUB_OUTPUT
       - name: Create release
         id: create_release
         uses: actions/create-release@v1

--- a/.github/workflows/publish_release.yml
+++ b/.github/workflows/publish_release.yml
@@ -22,7 +22,7 @@ jobs:
         id: vers
         run: |
           pip install python-semantic-release
-          echo "version=$(semantic-release print-version --current)" >> $GITHUB_OUTPUT
+          echo "version=$(semantic-release print-version --current)" >> "$GITHUB_OUTPUT"
       - name: Create release
         id: create_release
         uses: actions/create-release@v1


### PR DESCRIPTION
`save-state` and `set-output` commands used in GitHub Actions are deprecated and [GitHub recommends using environment files](https://github.blog/changelog/2023-07-24-github-actions-update-on-save-state-and-set-output-commands/).

This PR updates the usage of `set-output` to `$GITHUB_OUTPUT`

Instructions for envvar usage from GitHub docs:

https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-output-parameter


